### PR TITLE
fix: remove zip extension from archive name

### DIFF
--- a/.github/actions/archive-junit-reports/action.yml
+++ b/.github/actions/archive-junit-reports/action.yml
@@ -12,11 +12,11 @@ runs:
       if: inputs.html != ''
       uses: actions/upload-artifact@v3
       with:
-        name: junit-html.zip
+        name: junit-html
         path: ${{ inputs.html }}
     - name: 'Archive JUnit XML report'
       if: inputs.xml != ''
       uses: actions/upload-artifact@v3
       with:
-        name: junit-xml.zip
+        name: junit-xml
         path: ${{ inputs.xml }}

--- a/.github/actions/archive-lint-reports/action.yml
+++ b/.github/actions/archive-lint-reports/action.yml
@@ -16,19 +16,19 @@ runs:
       if: inputs.html != ''
       uses: actions/upload-artifact@v3
       with:
-        name: lint-html.zip
+        name: lint-html
         path: ${{ inputs.html }}
     - name: 'Archive Lint SARIF report'
       if: inputs.sarif != ''
       uses: actions/upload-artifact@v3
       with:
-        name: lint-sarif.zip
+        name: lint-sarif
         path: ${{ inputs.sarif }}
     - name: 'Archive Lint XML report'
       if: inputs.xml != ''
       uses: actions/upload-artifact@v3
       with:
-        name: lint-xml.zip
+        name: lint-xml
         path: ${{ inputs.xml }}
     - name: 'Analyse Lint SARIF report'
       if: inputs.analysis != ''


### PR DESCRIPTION
This is already handled by `actions/upload-artifact@v3`, and providing a `.zip` extension will lead to a `.zip` in the un-zipped file.