### PR TITLE
docs: Add code of conduct to the projct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,70 @@
+# Code of Conduct
+
+The [Adevinta](https://www.adevinta.com/) Code of Ethical Conduct serves as a roadmap for business decisions, together with our Key Behaviours. They both guide the actions of Adevinta employees to ensure we are always consistent with our Purpose and Missions, and we work towards our vision of sustainable commerce shaping a healthy planet and society.
+
+Adevinta’s purpose is to make a positive change in the world by helping everyone and everything find new purpose. We do this through our mission, creating perfect matches on the world’s most trusted marketplaces.
+
+Adevinta’s success depends on earning the trust and confidence of our employees, customers and shareholders. We gain credibility each time we live by our Key Behaviours:
+
+- Experiment bravely.
+- Act for max impact.
+- Use your voice.
+- Grow through different perspectives.
+- Win together, lose together.
+
+We look to build trust and confidence from our customers and shareholders by upholding the highest standards of ethical business conduct, displaying honesty and integrity and reaching company goals by acting with integrity and unity.
+
+## [Our Standards](https://zeroheight.com/2c2e9ba82/p/4614f7-code-of-conduct)
+
+- Foster open, respectful, and inclusive discussions
+- Use respectful language
+- Respect the opinions and points of view of others, even if you disagree with them
+- Avoid any topic that may offend, upset, or raise confrontation (religious, political, etc)
+- Avoid sharing opinions, articles or material of any kind if you are not sure about the reliability of the source
+- Prevent any action that may lead to misinformation
+- Protect your privacy and the privacy of your company
+- Never share confidential information. If you are not sure about this one, check with your manager first
+- Be inclusive, and never share any material that discriminates against anyone because of their sex, race, color, creed, religion, nationality, sexual orientation, age, or any kind of disability.
+- Never share someone else's private information without asking for permission explicitly
+- Never share insulting or defamatory content, regardless of how much or less it might affect other users
+- Never share any pornographic content
+- Never share any content that might infringe protection of minors
+- Avoid bothering others (including spamming)
+- Don't use or share any private content if you don't have permission from the author (intellectual property, brand, etc)
+
+### [Communication](https://zeroheight.com/2c2e9ba82/p/77af7e-comunication)
+
+We value every effort to bring designers and developers closer together. The language you use should always be correct but not at the expense of providing clarity.
+
+- Use vocabulary with clear meaning for both designers and engineers
+- Choose words that provide mutual understanding over specificity
+- Communicate what you are trying to achieve, and also what you are not trying to achieve as well
+- Give examples and descriptions for new words
+- Force yourself to be consistent with the vocabulary when writing and talking
+
+### [Judgment and Decision-making](https://zeroheight.com/2c2e9ba82/p/177da9-judgment-and-decision-making)
+
+There are many correct ways to do things and solve problems. Many times we have to make decisions without the help of best-practice examples to follow and move forward. To deal with uncertainty and still move forward we foster having strong opinions, weakly held
+
+- If you are at risk of getting stuck due to the ambiguity or difference of opinions, make decisions that will help us moving forward
+- Make short-term decisions based on long-term goals
+- Evaluate tools and integrations by the risk they present, not just the solution they offer. If the risk is high pay special attention.
+- Prioritize solutions for people who use spark-android and how it serves the customers who use products built with spark-android
+- Seek feedback on code review often, and more often when a solution takes you down a new path
+- Take time to provide good code review, encompassing the above values when providing feedback.
+
+### [Innovation](https://zeroheight.com/2c2e9ba82/p/255e7f-innovation)
+
+- Avoid big bangs: Make small experiments that provide data
+- Ship your ideas
+- Ship often
+- Work on reducing complexity and simplifying solutions to enable us to innovate faster
+
+### [Implementation](https://zeroheight.com/2c2e9ba82/p/85d5e7-implementation)
+
+- Develop just enough of a solution
+- Value declarative over abstraction
+- A little verbosity is better than clever code. Avoid implementations that reduce the ability of people to contribute
+- Decrease repetition with abstraction and automation
+- Provide flexibility, but within the boundaries of our agreements
+- Assume that people will break the rules, and provide safe ways for them to do so.


### PR DESCRIPTION
Close #21 

This is shared [with the web](https://github.com/adevinta/spark/tree/main/documentation/contributing/code-of-conduct)