### PR TITLE
chore: add `gradle-home-cache-cleanup: true` to first invocation of `gradle/gradle-build-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # v2.3.3
         with:
           arguments: dependencyGuard --quiet
+          gradle-home-cache-cleanup: true
 
   build-test-lint:
     needs: validation
@@ -43,6 +44,8 @@ jobs:
 
       - name: '🐘 Setup Gradle'
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # v2.3.3
+        with:
+          gradle-home-cache-cleanup: true
 
       - name: '👷 Build'
         id: build

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           # https://github.com/Kotlin/dokka/issues/1217
           arguments: dokkaHtml --no-configuration-cache
+          gradle-home-cache-cleanup: true
       - uses: actions/configure-pages@v3.0.4
       - uses: actions/upload-pages-artifact@v1.0.7
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,3 +22,4 @@ jobs:
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # v2.3.3
         with:
           arguments: ${{ inputs.arguments }}
+          gradle-home-cache-cleanup: true


### PR DESCRIPTION
To reduce the total cache upload.