### PR TITLE
Add Slack compose lint

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlinx-coroutines = "1.6.4"
 ksp = "1.8.10-1.0.9"
 lint = "31.1.0-alpha05"
 showkase = "1.0.0-beta17"
+slackLint = "1.0.0"
 
 [libraries]
 
@@ -56,6 +57,8 @@ lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "lint" }
 lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
+
+slack-lint-compose = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "slackLint" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradlePlugin" }

--- a/lint/lint-config.xml
+++ b/lint/lint-config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="ComposeCompositionLocalUsage" severity="warning">
+        <option name="allowed-composition-locals"
+            value="LocalSparkColors,LocalSparkShapes,LocalSparkTypography,LocalHighlightToken,LocalHighlightComponents,LocalIsUserPro" />
+    </issue>
+</lint>

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -138,6 +138,7 @@ publishing {
 
 dependencies {
     lintPublish(projects.sparkLint)
+    lintChecks(libs.slack.lint.compose)
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)


### PR DESCRIPTION
## 🧑‍ Changes description
<!--- Describe your changes in detail -->
Add the slack compose lint and the configuration to allow our CompositionLocals

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
This will ensure that the quality stay at least equal than what we used in the Adevinta Platform

## 👋 Other info
<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->
Close #114 
