### PR TITLE
fix: Remove ExperimentalSparkApi & InternalSparkApi from plugin compiler args

### DIFF
--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidComposePlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidComposePlugin.kt
@@ -27,9 +27,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal class SparkAndroidComposePlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -41,16 +38,6 @@ internal class SparkAndroidComposePlugin : Plugin<Project> {
                 composeOptions {
                     kotlinCompilerExtensionVersion = spark().versions.`androidx-compose-compiler`.toString()
                 }
-            }
-
-            // Ignore [KaptGenerateStubsTask] types as they inherit arguments from standard tasks via
-            // [KaptGenerateStubsTask.compileKotlinArgumentsContributor] and applying arguments to them could result in duplicates.
-            target.tasks.withType<KotlinCompile>().matching { it !is KaptGenerateStubsTask }.configureEach {
-                compilerOptions.freeCompilerArgs.addAll(
-                    "-opt-in=com.adevinta.spark.InternalSparkApi",
-                    "-opt-in=com.adevinta.spark.ExperimentalSparkApi",
-                    "-opt-in=kotlin.RequiresOptIn",
-                )
             }
 
             dependencies {

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -32,6 +32,13 @@ plugins {
 android {
     namespace = "com.adevinta.spark"
     resourcePrefix = "spark_"
+
+    kotlinOptions {
+        freeCompilerArgs += listOf(
+            "-opt-in=com.adevinta.spark.InternalSparkApi",
+            "-opt-in=com.adevinta.spark.ExperimentalSparkApi",
+        )
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## 🧑‍ Changes description
<!--- Describe your changes in detail -->
Remove ExperimentalSparkApi & InternalSparkApi from plugin compiler args to move them on modules that use them

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
We get a warning when adding them on modules that don't use them which makes the build fail as we consider warnings as errors

