### PR TITLE
fix: Update rating private const and Surfer90 color palette

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
@@ -46,9 +46,6 @@ import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
  * @param modifier to be applied
  * @param enabled whether the star should be colored
  */
-
-private const val BRIKKE_RATING_STAR_SIZE = 12
-
 @Composable
 @InternalSparkApi
 internal fun SparkRatingStar(
@@ -64,12 +61,14 @@ internal fun SparkRatingStar(
 
     CompositionLocalProvider(LocalContentColor provides color) {
         Icon(
-            modifier = modifier.size(BRIKKE_RATING_STAR_SIZE.dp),
+            modifier = modifier.size(StarSize),
             sparkIcon = SparkIcon.Options.Star.Default,
             contentDescription = null,
         )
     }
 }
+
+private val StarSize = 12.dp
 
 @Composable
 @Preview

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/PaletteTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/PaletteTokens.kt
@@ -177,7 +177,7 @@ internal object PaletteTokens {
     internal val Surfer60 = Color(0xFF9C9BA4)
     internal val Surfer70 = Color(0xFFB6B5BC)
     internal val Surfer80 = Color(0xFFD1D0D5)
-    internal val Surfer90 = Color(0xFF7B7986)
+    internal val Surfer90 = Color(0xFFEBEBED)
     internal val Surfer95 = Color(0xFFF8F8F9)
 
     internal val Kiwi10 = Color(0xFF353710)


### PR DESCRIPTION
## 🧑‍ Changes description
<!--- Describe your changes in detail -->
Change Surfer90 color from `#7B7986` to `#EBEBED`

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
`#7B7986` is the color to Surfer50 and was wrongly used here

## 📸 Screenshots
<!--- Put your phone screenshots here -->

<table>
<tr>
	<td> Before
	<td> After
<tr>
	<td><img  src="https://user-images.githubusercontent.com/11772084/222092170-e92dee0a-7613-4fe5-b732-6bf18b270774.png">
	<td> <img  src="https://user-images.githubusercontent.com/11772084/222092420-3d1d9933-bef1-4ccb-bee5-cf8e5ec35153.png">

</table>
