### PR TITLE
chore: Add Material components wrapped by a spark one

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-activity = "1.6.1"
 androidx-appCompat = "1.5.1"
 androidx-compose-bom = "2023.01.00"
 androidx-compose-compiler = "1.4.3"
+coil = "2.2.2"
 compileSdk = "33"
 dependencyGuard = "0.4.1"
 dokka = "1.7.20"
@@ -52,6 +53,10 @@ androidx-compose-ui-testManifest = { module = "androidx.compose.ui:ui-test-manif
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util" }
+
+# https://coil-kt.github.io/coil/
+coil = { module = "io.coil-kt:coil", version.ref = "coil" }
+coilCompose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 gradlePlugins-android = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
 gradlePlugins-dependencyGuard = { module = "com.dropbox.dependency-guard:com.dropbox.dependency-guard.gradle.plugin", version.ref = "dependencyGuard" }

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_part_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_part_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6a2c005db8db00bf9e6380b1fa223d787097cf8d8e0b51157301d8309a17095
+size 13768

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_part_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_part_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd4b2917fe06507bb46d8195b312b6172eef076158149d8fb9641676ca316e02
+size 13803

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_pro_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_pro_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5414c8d5dcbb5dba04b5864195f9fc92898533004ac0e45081c92f72a7c392a8
+size 13675

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_pro_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_assistchip_pro_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f165dd0bb82e88a7cb7b63b58417fcf1a31e4a03de81d7cb0971d17659d7f48d
+size 13919

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_part_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_part_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:339cbe314b153e58d6b381e61c458c6e7fc5d3e7c382949132154503c853bf2c
+size 11056

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_part_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_part_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:029ecc0d98f0c50dfa84ab2aa205da54828dbeb1c7633f92c68eb1f34bcd2aa3
+size 11122

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_pro_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_pro_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c597761b0b690c9ce72e7465f749c27324a6e144424d3d60b96603226093c0e0
+size 11032

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_pro_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_filterchip_pro_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c21e14c39841c5c7c724b30b8f1b07dd3483a394bfc50d0bce5f3be7939c0c1
+size 11146

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_part_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_part_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a80c01d6ad878ed7371bef5a6755dce2b1e137252370eded6b7f3af9adfb0a5
+size 34043

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_part_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_part_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19dddfe6744adfca2944e76da9880522303b1c95dff92215d27350c2588621f0
+size 33696

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_pro_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_pro_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a80c01d6ad878ed7371bef5a6755dce2b1e137252370eded6b7f3af9adfb0a5
+size 34043

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_pro_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_inputchip_pro_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19dddfe6744adfca2944e76da9880522303b1c95dff92215d27350c2588621f0
+size 33696

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_part_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_part_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:622587ffc11bbdc0093d28db8fe53e645fb3cb0138b2d6268b496fa4ee226213
+size 6962

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_part_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_part_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccd8558b119f8ec5edb9d65999179aac1e1467a7377a943bb05b5cff0eda7ef6
+size 6911

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_pro_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_pro_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:622587ffc11bbdc0093d28db8fe53e645fb3cb0138b2d6268b496fa4ee226213
+size 6962

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_pro_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_suggestionchip_pro_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccd8558b119f8ec5edb9d65999179aac1e1467a7377a943bb05b5cff0eda7ef6
+size 6911

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_defaultgroup_previewdraghandle_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_defaultgroup_previewdraghandle_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35ed4740f2bcc61db82839806fcaa0c850bad8fe17dba78ccee3dbf7eda9b104
+size 607

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_defaultgroup_previewdraghandle_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_defaultgroup_previewdraghandle_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c673d81528cdf0a9b086e03db0946428fb8b76de419d8b7f150f974f8ec201be
+size 612

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_dialog_alertdialog_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_dialog_alertdialog_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8803588f0b1fa2c1c146445129568680830ecec2a05ef492f1ee1eab174fc3b5
+size 1305

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_dialog_alertdialog_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_dialog_alertdialog_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5830dbcd1aa928756622bbb2ba56f5fc3e4c16ecb7fe3a7f97b75cb3bc98fc3
+size 1177

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissibledrawersheet_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissibledrawersheet_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c0baed24d37752e2cac958f03150746b9b34e7014d812fba2a021f2075fe33d
+size 12029

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissibledrawersheet_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissibledrawersheet_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b9c235936c91a6e4be512a8ba97661b8208740fbcdbb273eca6b10417fff324
+size 11898

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissiblenavigationdrawer_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissiblenavigationdrawer_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1f56f6e972dc66b12cd6e3d0a6c8a768f9bbb2e1699a0347b1011beca74f0a1
+size 9544

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissiblenavigationdrawer_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_dismissiblenavigationdrawer_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3a3ab90941bde436f6801c12dc102c7a4f4d7c87523c756989473de9414ad44
+size 9549

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modaldrawersheet_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modaldrawersheet_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4e756bb162f18d5d89b89193c875eaf55c501938fc84b4c037a265aab448c32
+size 12466

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modaldrawersheet_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modaldrawersheet_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53fce00c4caaefd597c1bdf0e4f0ec069de57c00747cb6c758c6cfc53df18fa3
+size 12313

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modalnavigationdrawer_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modalnavigationdrawer_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1f56f6e972dc66b12cd6e3d0a6c8a768f9bbb2e1699a0347b1011beca74f0a1
+size 9544

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modalnavigationdrawer_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_drawer_modalnavigationdrawer_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3a3ab90941bde436f6801c12dc102c7a4f4d7c87523c756989473de9414ad44
+size 9549

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:186abbb7c9bc428cd8aa2969adb5f791a3ef78e92d1fc8f699a50b576607270d
+size 9513

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3873c3f1eea064e5ec067b82dd077484e03d29dcbfeae86ec975d3e14a715e78
+size 7694

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_image_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_image_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e3d8e349648a49278e231b1d2bdbf68dd78194f1826dca5134c005c2f2f9f15
+size 22351

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_image_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_image_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4c1699a847acf1a391f14702a66dd9e8001556c7de5fab946486ae362bb39d7
+size 21355

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff2fd7224b499213abe34a0f3fbe211cd594370c046446debcccc1c117fbbd61
+size 14332

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:762c8bc67bdc49767ca6626157a4d2adf4bce632ec5954ba2b2f1edd252d8756
+size 12309

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_list_listitem_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_list_listitem_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b842b9c14f8607029057144580547daeca847f5ad8c19076d6341d6d6ceb407e
+size 7309

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_list_listitem_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_list_listitem_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:249e1f75885934c033eedb168f84ba3eefcf8c6147cef1f80a1799c45ccae946
+size 7792

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_part_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_part_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25663d078bec156ec5245db97133804de792e1249f98964ec2cf01340e5e81b5
+size 4117

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_part_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_part_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67cb4bbca2c6627e24c0664a2200340978bcbe8cc7285925ce6a0226a436909a
+size 4143

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_pro_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_pro_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25663d078bec156ec5245db97133804de792e1249f98964ec2cf01340e5e81b5
+size 4117

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_pro_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_pro_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67cb4bbca2c6627e24c0664a2200340978bcbe8cc7285925ce6a0226a436909a
+size 4143

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationdraweritem_navigationdraweritem_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationdraweritem_navigationdraweritem_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf708d9177e94bca62943ef98db61ee0bb2d8422100bd3265592f49bf587d56e
+size 25320

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationdraweritem_navigationdraweritem_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationdraweritem_navigationdraweritem_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34eb86c177b95b01e76c110941c2065d16a0f833034d83ceb7cfa4898d4bcac2
+size 25710

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrail_navigationrail_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrail_navigationrail_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c9537c2536233da509875e30f00416a0c60124828d40661e09c586aafae6605
+size 7807

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrail_navigationrail_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrail_navigationrail_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:159c882cd1b16b3c127f823dcf4d07265ad8e3bee99107b5511aa42789ada7c6
+size 7504

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrailitem_navigationrailitem_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrailitem_navigationrailitem_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d32bb56aebcf50ceb8ecc4e5ebbf00767a55ae77c90d5479bb5987bb40bd7821
+size 24850

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrailitem_navigationrailitem_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationrailitem_navigationrailitem_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aa0c6fde76c8c1d2f7925986edaf549d28d50291c6f480ac7c8ec7a675c43ef
+size 23644

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentdrawersheet_permanentdrawersheet_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentdrawersheet_permanentdrawersheet_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aa5b99f17e364958d9958b1cdd497cff6194882272cf53550f10ea080a81dd1
+size 7235

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentdrawersheet_permanentdrawersheet_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentdrawersheet_permanentdrawersheet_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5f6d056d38daea5149486b772af8f463fc7c90a0481f007876b12f3d10ecf18
+size 7085

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentnavigationdrawer_permanentnavigationdrawer_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentnavigationdrawer_permanentnavigationdrawer_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:621ea43da3a2498c64603e04b97ca6cc90cfe2b8f1ebef2d1a3437bb590f30dd
+size 13736

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentnavigationdrawer_permanentnavigationdrawer_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_permanentnavigationdrawer_permanentnavigationdrawer_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45c42702281f69dfb7b19c6b269020e9c3d3f4d9154b23fd5233fe2581b17dbe
+size 14284

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_rangeslider_rangeslider_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_rangeslider_rangeslider_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23d6ec4a1dabe5dbbdf3810e53f9ffb4b2e8b06f106edea6af95b15649e9dc9
+size 8840

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_rangeslider_rangeslider_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_rangeslider_rangeslider_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a9ab0368f3be02cd2301e865a4c953b0feba46fe5e9f0b3656a36412c1c2d2c
+size 8770

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_slider_slider_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_slider_slider_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d3d9b1df59e2898de6d05b7456e580170e85df389b6928d2ba36771f18cf2e0
+size 6273

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_slider_slider_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_slider_slider_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d99144839be71ad09ac1a256c5cdf13cf6f18226bfd9066b7e61bb9b2dffb87
+size 6304

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_leadingicontab_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_leadingicontab_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c666547997bab9d4f496c88dcce207676452ee7fbe3db60b1e030a6f65464f59
+size 12438

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_leadingicontab_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_leadingicontab_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ea3e740e4bd80000e53f1b60c57ad4d96b224b996c43586aa994925acbdc101
+size 11466

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tab_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tab_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d53f75d883e2a94e8dfc186ebf89da4c6110ad976ddbb5053604ccda13aa3ae
+size 27126

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tab_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tab_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbf082452bf616a7acc6f033e209ba9b97e9d1cdd576450399f58d20e467aece
+size 28009

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tabrow_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tabrow_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcfd752c81ff4f3793e560eed84433ba318019bb913a8d782480d9ccc890822a
+size 14387

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tabrow_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_tabs_tabrow_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af2440f4ff03b0daa5ee55e5d9e5ff03186cf1186f95298f230c2755fdd54b1a
+size 13156

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling)
 
+    implementation(libs.coilCompose)
+
     compileOnly(libs.airbnb.showkase)
     ksp(libs.airbnb.showkase.processor)
 

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material3.windowSizeClass)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.util)
     implementation(libs.androidx.compose.ui.tooling)
 
     implementation(libs.coilCompose)

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -57,8 +57,8 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material3.windowSizeClass)
     implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.util)
     implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.util)
 
     implementation(libs.coilCompose)
 

--- a/spark/dependencies/releaseRuntimeClasspath.txt
+++ b/spark/dependencies/releaseRuntimeClasspath.txt
@@ -7,7 +7,7 @@ androidx.appcompat:appcompat-resources:1.5.1
 androidx.arch.core:core-common:2.1.0
 androidx.arch.core:core-runtime:2.1.0
 androidx.autofill:autofill:1.0.0
-androidx.collection:collection:1.1.0
+androidx.collection:collection:1.2.0
 androidx.compose.animation:animation-core:1.3.3
 androidx.compose.animation:animation:1.3.3
 androidx.compose.foundation:foundation-layout:1.3.1
@@ -30,9 +30,10 @@ androidx.compose.ui:ui-util:1.3.3
 androidx.compose.ui:ui:1.3.3
 androidx.compose:compose-bom:2023.01.00
 androidx.concurrent:concurrent-futures:1.0.0
-androidx.core:core-ktx:1.5.0
+androidx.core:core-ktx:1.8.0
 androidx.core:core:1.8.0
 androidx.customview:customview-poolingcontainer:1.0.0
+androidx.exifinterface:exifinterface:1.3.3
 androidx.interpolator:interpolator:1.0.0
 androidx.lifecycle:lifecycle-common-java8:2.5.1
 androidx.lifecycle:lifecycle-common:2.5.1
@@ -55,6 +56,13 @@ com.google.accompanist:accompanist-drawablepainter:0.28.0
 com.google.accompanist:accompanist-placeholder-material:0.28.0
 com.google.accompanist:accompanist-placeholder:0.28.0
 com.google.guava:listenablefuture:1.0
+com.squareup.okhttp3:okhttp:4.10.0
+com.squareup.okio:okio-jvm:3.2.0
+com.squareup.okio:okio:3.2.0
+io.coil-kt:coil-base:2.2.2
+io.coil-kt:coil-compose-base:2.2.2
+io.coil-kt:coil-compose:2.2.2
+io.coil-kt:coil:2.2.2
 io.github.aakira:napier-android:1.4.1
 io.github.aakira:napier:1.4.1
 org.jetbrains.kotlin:kotlin-bom:1.8.10

--- a/spark/lint.xml
+++ b/spark/lint.xml
@@ -34,4 +34,7 @@
         <ignore path="src/main/kotlin/com/adevinta/spark/components/spacer/Spacers.kt" />
         <ignore path="src/main/kotlin/com/adevinta/spark/SparkTheme.kt" />
     </issue>
+    <issue id="ComposeUnstableCollections">
+        <ignore path="src/main/kotlin/com/adevinta/spark/components/text/Text.kt" />
+    </issue>
 </lint>

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
@@ -43,9 +43,9 @@ internal fun rememberSparkTopAppBarState(
 
 /**
  * Creates a TopAppBarState that is remembered across compositions.
-@param initialHeightOffsetLimit - the initial value for TopAppBarState.heightOffsetLimit, which represents the pixel limit that a top app bar is allowed to collapse when the scrollable content is scrolled
-@param initialHeightOffset - the initial value for TopAppBarState.heightOffset. The initial offset height offset should be between zero and initialHeightOffsetLimit.
-@param initialContentOffset - the initial value for TopAppBarState.contentOffset
+@param initialHeightOffsetLimit the initial value for TopAppBarState.heightOffsetLimit, which represents the pixel limit that a top app bar is allowed to collapse when the scrollable content is scrolled
+@param initialHeightOffset the initial value for TopAppBarState.heightOffset. The initial offset height offset should be between zero and initialHeightOffsetLimit.
+@param initialContentOffset the initial value for TopAppBarState.contentOffset
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
@@ -43,9 +43,9 @@ internal fun rememberSparkTopAppBarState(
 
 /**
  * Creates a TopAppBarState that is remembered across compositions.
-@param initialHeightOffsetLimit the initial value for TopAppBarState.heightOffsetLimit, which represents the pixel limit that a top app bar is allowed to collapse when the scrollable content is scrolled
-@param initialHeightOffset the initial value for TopAppBarState.heightOffset. The initial offset height offset should be between zero and initialHeightOffsetLimit.
-@param initialContentOffset the initial value for TopAppBarState.contentOffset
+@param initialHeightOffsetLimit - the initial value for TopAppBarState.heightOffsetLimit, which represents the pixel limit that a top app bar is allowed to collapse when the scrollable content is scrolled
+@param initialHeightOffset - the initial value for TopAppBarState.heightOffset. The initial offset height offset should be between zero and initialHeightOffsetLimit.
+@param initialContentOffset - the initial value for TopAppBarState.contentOffset
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
@@ -63,10 +63,10 @@ internal fun SparkBadge(
  *
  * ![Badge image](https://developer.android.com/images/reference/androidx/compose/material3/badge.png)
  *
- * @param modifier - the Modifier to be applied to this badge
- * @param containerColor - the color used for the background of this badge
- * @param contentColor - the preferred color for content inside this badge. Defaults to either the matching content color for containerColor, or to the current LocalContentColor if containerColor is not a color from the theme.
- * @param content - optional content to be rendered inside this badge
+ * @param modifier the Modifier to be applied to this badge
+ * @param containerColor commentCountthe color used for the background of this badge
+ * @param contentColor commentCountthe preferred color for content inside this badge. Defaults to either the matching content color for containerColor, or to the current LocalContentColor if containerColor is not a color from the theme.
+ * @param content commentCountoptional content to be rendered inside this badge
  **/
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
@@ -63,10 +63,10 @@ internal fun SparkBadge(
  *
  * ![Badge image](https://developer.android.com/images/reference/androidx/compose/material3/badge.png)
  *
- * @param modifier the Modifier to be applied to this badge
- * @param containerColor commentCountthe color used for the background of this badge
- * @param contentColor commentCountthe preferred color for content inside this badge. Defaults to either the matching content color for containerColor, or to the current LocalContentColor if containerColor is not a color from the theme.
- * @param content commentCountoptional content to be rendered inside this badge
+ * @param modifier - the Modifier to be applied to this badge
+ * @param containerColor - the color used for the background of this badge
+ * @param contentColor - the preferred color for content inside this badge. Defaults to either the matching content color for containerColor, or to the current LocalContentColor if containerColor is not a color from the theme.
+ * @param content - optional content to be rendered inside this badge
  **/
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/DragHandle.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/DragHandle.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.bottomsheet
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+@Composable
+public fun DragHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .width(32.dp)
+            .height(4.dp)
+            .clip(SparkTheme.shapes.large)
+            .background(SparkTheme.colors.neutral.copy(0.4f))
+            .sparkUsageOverlay(),
+    )
+}
+
+@Preview
+@Composable
+internal fun PreviewDragHandle(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        Surface(color = SparkTheme.colors.background) {
+            Box(modifier = Modifier.padding(4.dp)) {
+                DragHandle()
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/ModalBottomSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/ModalBottomSheet.kt
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.bottomsheet
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.TweenSpec
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.semantics.collapse
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.dismiss
+import androidx.compose.ui.semantics.expand
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.bottomsheet.ModalBottomSheetValue.Expanded
+import com.adevinta.spark.components.bottomsheet.ModalBottomSheetValue.HalfExpanded
+import com.adevinta.spark.components.bottomsheet.ModalBottomSheetValue.Hidden
+import com.adevinta.spark.tokens.contentColorFor
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Possible values of [ModalBottomSheetState].
+ */
+@ExperimentalMaterial3Api
+public enum class ModalBottomSheetValue {
+    /**
+     * The bottom sheet is not visible.
+     */
+    Hidden,
+
+    /**
+     * The bottom sheet is visible at full height.
+     */
+    Expanded,
+
+    /**
+     * The bottom sheet is partially visible at 50% of the screen height. This state is only
+     * enabled if the height of the bottom sheet is more than 50% of the screen height.
+     */
+    HalfExpanded
+}
+
+/**
+ * State of the [ModalBottomSheetLayout] composable.
+ *
+ * @param initialValue The initial value of the state. <b>Must not be set to
+ * [ModalBottomSheetValue.HalfExpanded] if [isSkipHalfExpanded] is set to true.</b>
+ * @param animationSpec The default animation that will be used to animate to a new state.
+ * @param isSkipHalfExpanded Whether the half expanded state, if the sheet is tall enough, should
+ * be skipped. If true, the sheet will always expand to the [Expanded] state and move to the
+ * [Hidden] state when hiding the sheet, either programmatically or by user interaction.
+ * <b>Must not be set to true if the [initialValue] is [ModalBottomSheetValue.HalfExpanded].</b>
+ * If supplied with [ModalBottomSheetValue.HalfExpanded] for the [initialValue], an
+ * [IllegalArgumentException] will be thrown.
+ * @param confirmStateChange Optional callback invoked to confirm or veto a pending state change.
+ */
+@ExperimentalMaterial3Api
+public class ModalBottomSheetState(
+    initialValue: ModalBottomSheetValue,
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    internal val isSkipHalfExpanded: Boolean,
+    confirmStateChange: (ModalBottomSheetValue) -> Boolean = { true },
+) : SwipeableState<ModalBottomSheetValue>(
+    initialValue = initialValue,
+    animationSpec = animationSpec,
+    confirmStateChange = confirmStateChange,
+) {
+    /**
+     * Whether the bottom sheet is visible.
+     */
+    public val isVisible: Boolean
+        get() = currentValue != Hidden
+
+    internal val hasHalfExpandedState: Boolean
+        get() = anchors.values.contains(HalfExpanded)
+
+    public constructor(
+        initialValue: ModalBottomSheetValue,
+        animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+        confirmStateChange: (ModalBottomSheetValue) -> Boolean = { true },
+    ) : this(initialValue, animationSpec, isSkipHalfExpanded = false, confirmStateChange)
+
+    init {
+        if (isSkipHalfExpanded) {
+            require(initialValue != HalfExpanded) {
+                "The initial value must not be set to HalfExpanded if skipHalfExpanded is set to" +
+                        " true."
+            }
+        }
+    }
+
+    /**
+     * Show the bottom sheet with animation and suspend until it's shown. If the sheet is taller
+     * than 50% of the parent's height, the bottom sheet will be half expanded. Otherwise it will be
+     * fully expanded.
+     *
+     * @throws [CancellationException] if the animation is interrupted
+     */
+    public suspend fun show() {
+        val targetValue = when {
+            hasHalfExpandedState -> HalfExpanded
+            else -> Expanded
+        }
+        animateTo(targetValue = targetValue)
+    }
+
+    /**
+     * Half expand the bottom sheet if half expand is enabled with animation and suspend until it
+     * animation is complete or cancelled
+     *
+     * @throws [CancellationException] if the animation is interrupted
+     */
+    internal suspend fun halfExpand() {
+        if (!hasHalfExpandedState) {
+            return
+        }
+        animateTo(HalfExpanded)
+    }
+
+    /**
+     * Fully expand the bottom sheet with animation and suspend until it if fully expanded or
+     * animation has been cancelled.
+     * *
+     * @throws [CancellationException] if the animation is interrupted
+     */
+    internal suspend fun expand() = animateTo(Expanded)
+
+    /**
+     * Hide the bottom sheet with animation and suspend until it if fully hidden or animation has
+     * been cancelled.
+     *
+     * @throws [CancellationException] if the animation is interrupted
+     */
+    public suspend fun hide(): Unit = animateTo(Hidden)
+
+    internal val nestedScrollConnection = this.PreUpPostDownNestedScrollConnection
+
+    public companion object {
+        /**
+         * The default [Saver] implementation for [ModalBottomSheetState].
+         */
+        public fun Saver(
+            animationSpec: AnimationSpec<Float>,
+            skipHalfExpanded: Boolean,
+            confirmStateChange: (ModalBottomSheetValue) -> Boolean,
+        ): Saver<ModalBottomSheetState, *> = Saver(
+            save = { it.currentValue },
+            restore = {
+                ModalBottomSheetState(
+                    initialValue = it,
+                    animationSpec = animationSpec,
+                    isSkipHalfExpanded = skipHalfExpanded,
+                    confirmStateChange = confirmStateChange,
+                )
+            },
+        )
+    }
+}
+
+/**
+ * Create a [ModalBottomSheetState] and [remember] it.
+ *
+ * @param initialValue The initial value of the state.
+ * @param animationSpec The default animation that will be used to animate to a new state.
+ * @param skipHalfExpanded Whether the half expanded state, if the sheet is tall enough, should
+ * be skipped. If true, the sheet will always expand to the [Expanded] state and move to the
+ * [Hidden] state when hiding the sheet, either programmatically or by user interaction.
+ * <b>Must not be set to true if the [initialValue] is [ModalBottomSheetValue.HalfExpanded].</b>
+ * If supplied with [ModalBottomSheetValue.HalfExpanded] for the [initialValue], an
+ * [IllegalArgumentException] will be thrown.
+ * @param confirmStateChange Optional callback invoked to confirm or veto a pending state change.
+ */
+@Composable
+@ExperimentalMaterial3Api
+public fun rememberModalBottomSheetState(
+    initialValue: ModalBottomSheetValue,
+    skipHalfExpanded: Boolean,
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    confirmStateChange: (ModalBottomSheetValue) -> Boolean = { true },
+): ModalBottomSheetState {
+    return rememberSaveable(
+        initialValue, animationSpec, skipHalfExpanded, confirmStateChange,
+        saver = ModalBottomSheetState.Saver(
+            animationSpec = animationSpec,
+            skipHalfExpanded = skipHalfExpanded,
+            confirmStateChange = confirmStateChange,
+        ),
+    ) {
+        ModalBottomSheetState(
+            initialValue = initialValue,
+            animationSpec = animationSpec,
+            isSkipHalfExpanded = skipHalfExpanded,
+            confirmStateChange = confirmStateChange,
+        )
+    }
+}
+
+/**
+ * Create a [ModalBottomSheetState] and [remember] it.
+ *
+ * @param initialValue The initial value of the state.
+ * @param animationSpec The default animation that will be used to animate to a new state.
+ * @param confirmStateChange Optional callback invoked to confirm or veto a pending state change.
+ */
+@Composable
+@ExperimentalMaterial3Api
+public fun rememberModalBottomSheetState(
+    initialValue: ModalBottomSheetValue,
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    confirmStateChange: (ModalBottomSheetValue) -> Boolean = { true },
+): ModalBottomSheetState = rememberModalBottomSheetState(
+    initialValue = initialValue,
+    skipHalfExpanded = false,
+    animationSpec = animationSpec,
+    confirmStateChange = confirmStateChange,
+)
+
+/**
+ * <a href="https://material.io/components/sheets-bottom#modal-bottom-sheet" class="external" target="_blank">Material Design modal bottom sheet</a>.
+ *
+ * Modal bottom sheets present a set of choices while blocking interaction with the rest of the
+ * screen. They are an alternative to inline menus and simple dialogs, providing
+ * additional room for content, iconography, and actions.
+ *
+ * ![Modal bottom sheet image](https://developer.android.com/images/reference/androidx/compose/material/modal-bottom-sheet.png)
+ *
+ * A simple example of a modal bottom sheet looks like this:
+ *
+ * @sample androidx.compose.material.samples.ModalBottomSheetSample
+ *
+ * @param sheetContent The content of the bottom sheet.
+ * @param modifier Optional [Modifier] for the entire component.
+ * @param sheetState The state of the bottom sheet.
+ * @param sheetShape The shape of the bottom sheet.
+ * @param sheetElevation The elevation of the bottom sheet.
+ * @param sheetBackgroundColor The background color of the bottom sheet.
+ * @param sheetContentColor The preferred content color provided by the bottom sheet to its
+ * children. Defaults to the matching content color for [sheetBackgroundColor], or if that is not
+ * a color from the theme, this will keep the same content color set above the bottom sheet.
+ * @param scrimColor The color of the scrim that is applied to the rest of the screen when the
+ * bottom sheet is visible. If the color passed is [Color.Unspecified], then a scrim will no
+ * longer be applied and the bottom sheet will not block interaction with the rest of the screen
+ * when visible.
+ * @param content The content of rest of the screen.
+ */
+@Composable
+@ExperimentalMaterial3Api
+public fun ModalBottomSheetLayout(
+    sheetContent: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: ModalBottomSheetState = rememberModalBottomSheetState(Hidden),
+    sheetShape: Shape = SparkTheme.shapes.large.copy(bottomStart = CornerSize(0.dp), bottomEnd = CornerSize(0.dp)),
+    sheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
+    sheetBackgroundColor: Color = SparkTheme.colors.surface,
+    sheetContentColor: Color = contentColorFor(sheetBackgroundColor),
+    scrimColor: Color = ModalBottomSheetDefaults.scrimColor,
+    content: @Composable () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    BoxWithConstraints(modifier.sparkUsageOverlay()) {
+        val fullHeight = constraints.maxHeight.toFloat()
+        val sheetHeightState = remember { mutableStateOf<Float?>(null) }
+        Box(Modifier.fillMaxSize()) {
+            content()
+            Scrim(
+                color = scrimColor,
+                onDismiss = {
+                    if (sheetState.confirmStateChange(Hidden)) {
+                        scope.launch { sheetState.hide() }
+                    }
+                },
+                visible = sheetState.targetValue != Hidden,
+            )
+        }
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .nestedScroll(sheetState.nestedScrollConnection)
+                .offset {
+                    val y = if (sheetState.anchors.isEmpty()) {
+                        // if we don't know our anchors yet, render the sheet as hidden
+                        fullHeight.roundToInt()
+                    } else {
+                        // if we do know our anchors, respect them
+                        sheetState.offset.value.roundToInt()
+                    }
+                    IntOffset(0, y)
+                }
+                .bottomSheetSwipeable(sheetState, fullHeight, sheetHeightState)
+                .onGloballyPositioned {
+                    sheetHeightState.value = it.size.height.toFloat()
+                }
+                .semantics {
+                    if (sheetState.isVisible) {
+                        dismiss {
+                            if (sheetState.confirmStateChange(Hidden)) {
+                                scope.launch { sheetState.hide() }
+                            }
+                            true
+                        }
+                        if (sheetState.currentValue == HalfExpanded) {
+                            expand {
+                                if (sheetState.confirmStateChange(Expanded)) {
+                                    scope.launch { sheetState.expand() }
+                                }
+                                true
+                            }
+                        } else if (sheetState.hasHalfExpandedState) {
+                            collapse {
+                                if (sheetState.confirmStateChange(HalfExpanded)) {
+                                    scope.launch { sheetState.halfExpand() }
+                                }
+                                true
+                            }
+                        }
+                    }
+                },
+            shape = sheetShape,
+            shadowElevation = sheetElevation,
+            // tonalElevation = sheetElevation, Only use shadow elevation
+            // for now as brikke doesn't support tonal elevation yet
+            color = sheetBackgroundColor,
+            contentColor = sheetContentColor,
+        ) {
+            Column {
+                DragHandle(
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(top = 8.dp, bottom = 16.dp), // specs to extract into default?
+                )
+                sheetContent()
+            }
+        }
+    }
+}
+
+@Suppress("ModifierInspectorInfo")
+@OptIn(ExperimentalMaterial3Api::class)
+private fun Modifier.bottomSheetSwipeable(
+    sheetState: ModalBottomSheetState,
+    fullHeight: Float,
+    sheetHeightState: State<Float?>,
+): Modifier {
+    val sheetHeight = sheetHeightState.value
+    val modifier = if (sheetHeight != null) {
+        val anchors = if (sheetHeight < fullHeight / 2 || sheetState.isSkipHalfExpanded) {
+            mapOf(
+                fullHeight to Hidden,
+                fullHeight - sheetHeight to Expanded,
+            )
+        } else {
+            mapOf(
+                fullHeight to Hidden,
+                fullHeight / 2 to HalfExpanded,
+                max(0f, fullHeight - sheetHeight) to Expanded,
+            )
+        }
+        Modifier.swipeable(
+            state = sheetState,
+            anchors = anchors,
+            orientation = Orientation.Vertical,
+            enabled = sheetState.currentValue != Hidden,
+            resistance = null,
+        )
+    } else {
+        Modifier
+    }
+
+    return this.then(modifier)
+}
+
+@Composable
+private fun Scrim(
+    color: Color,
+    onDismiss: () -> Unit,
+    visible: Boolean,
+) {
+    if (color.isSpecified) {
+        val alpha by animateFloatAsState(
+            targetValue = if (visible) 1f else 0f,
+            animationSpec = TweenSpec(),
+        )
+        val closeSheet = /*getString(BiometricManager.Strings.CloseSheet)*/ "Fermez la Feuille"
+        val dismissModifier = if (visible) {
+            Modifier
+                .pointerInput(onDismiss) { detectTapGestures { onDismiss() } }
+                .semantics(mergeDescendants = true) {
+                    contentDescription = closeSheet
+                    onClick { onDismiss(); true }
+                }
+        } else {
+            Modifier
+        }
+
+        Canvas(
+            Modifier
+                .fillMaxSize()
+                .then(dismissModifier),
+        ) {
+            drawRect(color = color, alpha = alpha)
+        }
+    }
+}
+
+/**
+ * Contains useful Defaults for [ModalBottomSheetLayout].
+ */
+public object ModalBottomSheetDefaults {
+
+    /**
+     * The default elevation used by [ModalBottomSheetLayout].
+     */
+    public val Elevation: Dp = 16.dp
+
+    /**
+     * The default scrim color used by [ModalBottomSheetLayout].
+     */
+    public val scrimColor: Color
+        @Composable
+        get() = SparkTheme.colors.onSurface.copy(alpha = 0.32f)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun BottomSheetPreview() {
+    PreviewTheme {
+        ModalBottomSheetLayout(
+            sheetContent = {
+                Text("Sheet Content")
+            },
+            modifier = Modifier.size(height = 200.dp, width = 100.dp),
+            rememberModalBottomSheetState(HalfExpanded),
+        ) {
+            Text("Screen Content")
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/Swipeable.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/Swipeable.kt
@@ -1,0 +1,939 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.bottomsheet
+
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.foundation.gestures.DraggableState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.components.bottomsheet.SwipeableDefaults.AnimationSpec
+import com.adevinta.spark.components.bottomsheet.SwipeableDefaults.StandardResistanceFactor
+import com.adevinta.spark.components.bottomsheet.SwipeableDefaults.VelocityThreshold
+import com.adevinta.spark.components.bottomsheet.SwipeableDefaults.resistanceConfig
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sign
+import kotlin.math.sin
+
+/**
+ * State of the [swipeable] modifier.
+ *
+ * This contains necessary information about any ongoing swipe or animation and provides methods
+ * to change the state either immediately or by starting an animation. To create and remember a
+ * [SwipeableState] with the default animation clock, use [rememberSwipeableState].
+ *
+ * @param initialValue The initial value of the state.
+ * @param animationSpec The default animation that will be used to animate to a new state.
+ * @param confirmStateChange Optional callback invoked to confirm or veto a pending state change.
+ */
+@Stable
+@ExperimentalMaterial3Api
+@InternalSparkApi // This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+public open class SwipeableState<T>(
+    initialValue: T,
+    internal val animationSpec: AnimationSpec<Float> = AnimationSpec,
+    internal val confirmStateChange: (newValue: T) -> Boolean = { true },
+) {
+    /**
+     * The current value of the state.
+     *
+     * If no swipe or animation is in progress, this corresponds to the anchor at which the
+     * [swipeable] is currently settled. If a swipe or animation is in progress, this corresponds
+     * the last anchor at which the [swipeable] was settled before the swipe or animation started.
+     */
+    public var currentValue: T by mutableStateOf(initialValue)
+        private set
+
+    /**
+     * Whether the state is currently animating.
+     */
+    public var isAnimationRunning: Boolean by mutableStateOf(false)
+        private set
+
+    /**
+     * The current position (in pixels) of the [swipeable].
+     *
+     * You should use this state to offset your content accordingly. The recommended way is to
+     * use `Modifier.offsetPx`. This includes the resistance by default, if resistance is enabled.
+     */
+    public val offset: State<Float> get() = offsetState
+
+    /**
+     * The amount by which the [swipeable] has been swiped past its bounds.
+     */
+    public val overflow: State<Float> get() = overflowState
+
+    // Use `Float.NaN` as a placeholder while the state is uninitialised.
+    private val offsetState = mutableStateOf(0f)
+    private val overflowState = mutableStateOf(0f)
+
+    // the source of truth for the "real"(non ui) position
+    // basically position in bounds + overflow
+    private val absoluteOffset = mutableStateOf(0f)
+
+    // current animation target, if animating, otherwise null
+    private val animationTarget = mutableStateOf<Float?>(null)
+
+    internal var anchors by mutableStateOf(emptyMap<Float, T>())
+
+    private val latestNonEmptyAnchorsFlow: Flow<Map<Float, T>> =
+        snapshotFlow { anchors }
+            .filter { it.isNotEmpty() }
+            .take(1)
+
+    internal var minBound = Float.NEGATIVE_INFINITY
+    internal var maxBound = Float.POSITIVE_INFINITY
+
+    internal fun ensureInit(newAnchors: Map<Float, T>) {
+        if (anchors.isEmpty()) {
+            // need to do initial synchronization synchronously :(
+            val initialOffset = newAnchors.getOffset(currentValue)
+            requireNotNull(initialOffset) {
+                "The initial value must have an associated anchor."
+            }
+            offsetState.value = initialOffset
+            absoluteOffset.value = initialOffset
+        }
+    }
+
+    internal suspend fun processNewAnchors(
+        oldAnchors: Map<Float, T>,
+        newAnchors: Map<Float, T>,
+    ) {
+        if (oldAnchors.isEmpty()) {
+            // If this is the first time that we receive anchors, then we need to initialise
+            // the state so we snap to the offset associated to the initial value.
+            minBound = newAnchors.keys.minOrNull()!!
+            maxBound = newAnchors.keys.maxOrNull()!!
+            val initialOffset = newAnchors.getOffset(currentValue)
+            requireNotNull(initialOffset) {
+                "The initial value must have an associated anchor."
+            }
+            snapInternalToOffset(initialOffset)
+        } else if (newAnchors != oldAnchors) {
+            // If we have received new anchors, then the offset of the current value might
+            // have changed, so we need to animate to the new offset. If the current value
+            // has been removed from the anchors then we animate to the closest anchor
+            // instead. Note that this stops any ongoing animation.
+            minBound = Float.NEGATIVE_INFINITY
+            maxBound = Float.POSITIVE_INFINITY
+            val animationTargetValue = animationTarget.value
+            // if we're in the animation already, let's find it a new home
+            val targetOffset = if (animationTargetValue != null) {
+                // first, try to map old state to the new state
+                val oldState = oldAnchors[animationTargetValue]
+                val newState = newAnchors.getOffset(oldState)
+                // return new state if exists, or find the closes one among new anchors
+                newState ?: newAnchors.keys.minByOrNull { abs(it - animationTargetValue) }!!
+            } else {
+                // we're not animating, proceed by finding the new anchors for an old value
+                val actualOldValue = oldAnchors[offset.value]
+                val value = if (actualOldValue == currentValue) currentValue else actualOldValue
+                newAnchors.getOffset(value) ?: newAnchors
+                    .keys.minByOrNull { abs(it - offset.value) }!!
+            }
+            try {
+                animateInternalToOffset(targetOffset, animationSpec)
+            } catch (c: CancellationException) {
+                // If the animation was interrupted for any reason, snap as a last resort.
+                snapInternalToOffset(targetOffset)
+            } finally {
+                currentValue = newAnchors.getValue(targetOffset)
+                minBound = newAnchors.keys.minOrNull()!!
+                maxBound = newAnchors.keys.maxOrNull()!!
+            }
+        }
+    }
+
+    internal var thresholds: (Float, Float) -> Float by mutableStateOf({ _, _ -> 0f })
+
+    internal var velocityThreshold by mutableStateOf(0f)
+
+    internal var resistance: ResistanceConfig? by mutableStateOf(null)
+
+    internal val draggableState = DraggableState {
+        val newAbsolute = absoluteOffset.value + it
+        val clamped = newAbsolute.coerceIn(minBound, maxBound)
+        val overflow = newAbsolute - clamped
+        val resistanceDelta = resistance?.computeResistance(overflow) ?: 0f
+        offsetState.value = clamped + resistanceDelta
+        overflowState.value = overflow
+        absoluteOffset.value = newAbsolute
+    }
+
+    private suspend fun snapInternalToOffset(target: Float) {
+        draggableState.drag {
+            dragBy(target - absoluteOffset.value)
+        }
+    }
+
+    private suspend fun animateInternalToOffset(target: Float, spec: AnimationSpec<Float>) {
+        draggableState.drag {
+            var prevValue = absoluteOffset.value
+            animationTarget.value = target
+            isAnimationRunning = true
+            try {
+                Animatable(prevValue).animateTo(target, spec) {
+                    dragBy(this.value - prevValue)
+                    prevValue = this.value
+                }
+            } finally {
+                animationTarget.value = null
+                isAnimationRunning = false
+            }
+        }
+    }
+
+    /**
+     * The target value of the state.
+     *
+     * If a swipe is in progress, this is the value that the [swipeable] would animate to if the
+     * swipe finished. If an animation is running, this is the target value of that animation.
+     * Finally, if no swipe or animation is in progress, this is the same as the [currentValue].
+     */
+    @ExperimentalMaterial3Api
+    internal val targetValue: T
+        get() {
+            // TODO(calintat): Track current velocity (b/149549482) and use that here.
+            val target = animationTarget.value ?: computeTarget(
+                offset = offset.value,
+                lastValue = anchors.getOffset(currentValue) ?: offset.value,
+                anchors = anchors.keys,
+                thresholds = thresholds,
+                velocity = 0f,
+                velocityThreshold = Float.POSITIVE_INFINITY,
+            )
+            return anchors[target] ?: currentValue
+        }
+
+    /**
+     * Information about the ongoing swipe or animation, if any. See [SwipeProgress] for details.
+     *
+     * If no swipe or animation is in progress, this returns `SwipeProgress(value, value, 1f)`.
+     */
+    @ExperimentalMaterial3Api
+    internal val progress: SwipeProgress<T>
+        get() {
+            val bounds = findBounds(offset.value, anchors.keys)
+            val from: T
+            val to: T
+            val fraction: Float
+            when (bounds.size) {
+                0 -> {
+                    from = currentValue
+                    to = currentValue
+                    fraction = 1f
+                }
+
+                1 -> {
+                    from = anchors.getValue(bounds[0])
+                    to = anchors.getValue(bounds[0])
+                    fraction = 1f
+                }
+
+                else -> {
+                    val (a, b) =
+                        if (direction > 0f) {
+                            bounds[0] to bounds[1]
+                        } else {
+                            bounds[1] to bounds[0]
+                        }
+                    from = anchors.getValue(a)
+                    to = anchors.getValue(b)
+                    fraction = (offset.value - a) / (b - a)
+                }
+            }
+            return SwipeProgress(from, to, fraction)
+        }
+
+    /**
+     * The direction in which the [swipeable] is moving, relative to the current [currentValue].
+     *
+     * This will be either 1f if it is is moving from left to right or top to bottom, -1f if it is
+     * moving from right to left or bottom to top, or 0f if no swipe or animation is in progress.
+     */
+    @ExperimentalMaterial3Api
+    internal val direction: Float
+        get() = anchors.getOffset(currentValue)?.let { sign(offset.value - it) } ?: 0f
+
+    /**
+     * Set the state without any animation and suspend until it's set
+     *
+     * @param targetValue The new target value to set [currentValue] to.
+     */
+    @ExperimentalMaterial3Api
+    internal suspend fun snapTo(targetValue: T) {
+        latestNonEmptyAnchorsFlow.collect { anchors ->
+            val targetOffset = anchors.getOffset(targetValue)
+            requireNotNull(targetOffset) {
+                "The target value must have an associated anchor."
+            }
+            snapInternalToOffset(targetOffset)
+            currentValue = targetValue
+        }
+    }
+
+    /**
+     * Set the state to the target value by starting an animation.
+     *
+     * @param targetValue The new value to animate to.
+     * @param anim The animation that will be used to animate to the new value.
+     */
+    @ExperimentalMaterial3Api
+    internal suspend fun animateTo(targetValue: T, anim: AnimationSpec<Float> = animationSpec) {
+        latestNonEmptyAnchorsFlow.collect { anchors ->
+            try {
+                val targetOffset = anchors.getOffset(targetValue)
+                requireNotNull(targetOffset) {
+                    "The target value must have an associated anchor."
+                }
+                animateInternalToOffset(targetOffset, anim)
+            } finally {
+                val endOffset = absoluteOffset.value
+                val endValue = anchors
+                    // fighting rounding error once again, anchor should be as close as 0.5 pixels
+                    .filterKeys { anchorOffset -> abs(anchorOffset - endOffset) < 0.5f }
+                    .values.firstOrNull() ?: currentValue
+                currentValue = endValue
+            }
+        }
+    }
+
+    /**
+     * Perform fling with settling to one of the anchors which is determined by the given
+     * [velocity]. Fling with settling [swipeable] will always consume all the velocity provided
+     * since it will settle at the anchor.
+     *
+     * In general cases, [swipeable] flings by itself when being swiped. This method is to be
+     * used for nested scroll logic that wraps the [swipeable]. In nested scroll developer may
+     * want to trigger settling fling when the child scroll container reaches the bound.
+     *
+     * @param velocity velocity to fling and settle with
+     *
+     * @return the reason fling ended
+     */
+    internal suspend fun performFling(velocity: Float) {
+        latestNonEmptyAnchorsFlow.collect { anchors ->
+            val lastAnchor = anchors.getOffset(currentValue)!!
+            val targetValue = computeTarget(
+                offset = offset.value,
+                lastValue = lastAnchor,
+                anchors = anchors.keys,
+                thresholds = thresholds,
+                velocity = velocity,
+                velocityThreshold = velocityThreshold,
+            )
+            val targetState = anchors[targetValue]
+            if (targetState != null && confirmStateChange(targetState)) animateTo(targetState)
+            // If the user vetoed the state change, rollback to the previous state.
+            else animateInternalToOffset(lastAnchor, animationSpec)
+        }
+    }
+
+    /**
+     * Force [swipeable] to consume drag delta provided from outside of the regular [swipeable]
+     * gesture flow.
+     *
+     * Note: This method performs generic drag and it won't settle to any particular anchor, *
+     * leaving swipeable in between anchors. When done dragging, [performFling] must be
+     * called as well to ensure swipeable will settle at the anchor.
+     *
+     * In general cases, [swipeable] drags by itself when being swiped. This method is to be
+     * used for nested scroll logic that wraps the [swipeable]. In nested scroll developer may
+     * want to force drag when the child scroll container reaches the bound.
+     *
+     * @param delta delta in pixels to drag by
+     *
+     * @return the amount of [delta] consumed
+     */
+    internal fun performDrag(delta: Float): Float {
+        val potentiallyConsumed = absoluteOffset.value + delta
+        val clamped = potentiallyConsumed.coerceIn(minBound, maxBound)
+        val deltaToConsume = clamped - absoluteOffset.value
+        if (abs(deltaToConsume) > 0) {
+            draggableState.dispatchRawDelta(deltaToConsume)
+        }
+        return deltaToConsume
+    }
+
+    public companion object {
+        /**
+         * The default [Saver] implementation for [SwipeableState].
+         */
+        public fun <T : Any> Saver(
+            animationSpec: AnimationSpec<Float>,
+            confirmStateChange: (T) -> Boolean,
+        ): Saver<SwipeableState<T>, T> = Saver(
+            save = { it.currentValue },
+            restore = { SwipeableState(it, animationSpec, confirmStateChange) },
+        )
+    }
+}
+
+/**
+ * Collects information about the ongoing swipe or animation in [swipeable].
+ *
+ * To access this information, use [SwipeableState.progress].
+ *
+ * @param from The state corresponding to the anchor we are moving away from.
+ * @param to The state corresponding to the anchor we are moving towards.
+ * @param fraction The fraction that the current position represents between [from] and [to].
+ * Must be between `0` and `1`.
+ */
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+@InternalSparkApi
+@Immutable
+@ExperimentalMaterial3Api
+public class SwipeProgress<T>(
+    public val from: T,
+    public val to: T,
+    /*@FloatRange(from = 0.0, to = 1.0)*/
+    public val fraction: Float,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SwipeProgress<*>) return false
+
+        if (from != other.from) return false
+        if (to != other.to) return false
+        if (fraction != other.fraction) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = from?.hashCode() ?: 0
+        result = 31 * result + (to?.hashCode() ?: 0)
+        result = 31 * result + fraction.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "SwipeProgress(from=$from, to=$to, fraction=$fraction)"
+    }
+}
+
+/**
+ * Create and [remember] a [SwipeableState] with the default animation clock.
+ *
+ * @param initialValue The initial value of the state.
+ * @param animationSpec The default animation that will be used to animate to a new state.
+ * @param confirmStateChange Optional callback invoked to confirm or veto a pending state change.
+ */
+@Composable
+@ExperimentalMaterial3Api
+@InternalSparkApi
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+public fun <T : Any> rememberSwipeableState(
+    initialValue: T,
+    animationSpec: AnimationSpec<Float> = AnimationSpec,
+    confirmStateChange: (newValue: T) -> Boolean = { true },
+): SwipeableState<T> {
+    return rememberSaveable(
+        saver = SwipeableState.Saver(
+            animationSpec = animationSpec,
+            confirmStateChange = confirmStateChange,
+        ),
+    ) {
+        SwipeableState(
+            initialValue = initialValue,
+            animationSpec = animationSpec,
+            confirmStateChange = confirmStateChange,
+        )
+    }
+}
+
+/**
+ * Create and [remember] a [SwipeableState] which is kept in sync with another state, i.e.:
+ *  1. Whenever the [value] changes, the [SwipeableState] will be animated to that new value.
+ *  2. Whenever the value of the [SwipeableState] changes (e.g. after a swipe), the owner of the
+ *  [value] will be notified to update their state to the new value of the [SwipeableState] by
+ *  invoking [onValueChange]. If the owner does not update their state to the provided value for
+ *  some reason, then the [SwipeableState] will perform a rollback to the previous, correct value.
+ */
+@Composable
+@ExperimentalMaterial3Api
+@InternalSparkApi
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+public fun <T : Any> rememberSwipeableStateFor(
+    value: T,
+    onValueChange: (T) -> Unit,
+    animationSpec: AnimationSpec<Float> = AnimationSpec,
+): SwipeableState<T> {
+    val swipeableState = remember {
+        SwipeableState(
+            initialValue = value,
+            animationSpec = animationSpec,
+            confirmStateChange = { true },
+        )
+    }
+    val forceAnimationCheck = remember { mutableStateOf(false) }
+    LaunchedEffect(value, forceAnimationCheck.value) {
+        if (value != swipeableState.currentValue) {
+            swipeableState.animateTo(value)
+        }
+    }
+    DisposableEffect(swipeableState.currentValue) {
+        if (value != swipeableState.currentValue) {
+            onValueChange(swipeableState.currentValue)
+            forceAnimationCheck.value = !forceAnimationCheck.value
+        }
+        onDispose { }
+    }
+    return swipeableState
+}
+
+/**
+ * Enable swipe gestures between a set of predefined states.
+ *
+ * To use this, you must provide a map of anchors (in pixels) to states (of type [T]).
+ * Note that this map cannot be empty and cannot have two anchors mapped to the same state.
+ *
+ * When a swipe is detected, the offset of the [SwipeableState] will be updated with the swipe
+ * delta. You should use this offset to move your content accordingly (see `Modifier.offsetPx`).
+ * When the swipe ends, the offset will be animated to one of the anchors and when that anchor is
+ * reached, the value of the [SwipeableState] will also be updated to the state corresponding to
+ * the new anchor. The target anchor is calculated based on the provided positional [thresholds].
+ *
+ * Swiping is constrained between the minimum and maximum anchors. If the user attempts to swipe
+ * past these bounds, a resistance effect will be applied by default. The amount of resistance at
+ * each edge is specified by the [resistance] config. To disable all resistance, set it to `null`.
+ *
+ * @param T The type of the state.
+ * @param state The state of the [swipeable].
+ * @param anchors Pairs of anchors and states, used to map anchors to states and vice versa.
+ * @param thresholds Specifies where the thresholds between the states are. The thresholds will be
+ * used to determine which state to animate to when swiping stops. This is represented as a lambda
+ * that takes two states and returns the threshold between them in the form of a [ThresholdConfig].
+ * Note that the order of the states corresponds to the swipe direction.
+ * @param orientation The orientation in which the [swipeable] can be swiped.
+ * @param enabled Whether this [swipeable] is enabled and should react to the user's input.
+ * @param reverseDirection Whether to reverse the direction of the swipe, so a top to bottom
+ * swipe will behave like bottom to top, and a left to right swipe will behave like right to left.
+ * @param interactionSource Optional [MutableInteractionSource] that will passed on to
+ * the internal [Modifier.draggable].
+ * @param resistance Controls how much resistance will be applied when swiping past the bounds.
+ * @param velocityThreshold The threshold (in dp per second) that the end velocity has to exceed
+ * in order to animate to the next state, even if the positional [thresholds] have not been reached.
+ */
+@ExperimentalMaterial3Api
+@InternalSparkApi
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+public fun <T> Modifier.swipeable(
+    state: SwipeableState<T>,
+    anchors: Map<Float, T>,
+    orientation: Orientation,
+    enabled: Boolean = true,
+    reverseDirection: Boolean = false,
+    interactionSource: MutableInteractionSource? = null,
+    thresholds: (from: T, to: T) -> ThresholdConfig = { _, _ -> FixedThreshold(56.dp) },
+    resistance: ResistanceConfig? = resistanceConfig(anchors.keys),
+    velocityThreshold: Dp = VelocityThreshold,
+): Modifier = composed(
+    inspectorInfo = debugInspectorInfo {
+        name = "swipeable"
+        properties["state"] = state
+        properties["anchors"] = anchors
+        properties["orientation"] = orientation
+        properties["enabled"] = enabled
+        properties["reverseDirection"] = reverseDirection
+        properties["interactionSource"] = interactionSource
+        properties["thresholds"] = thresholds
+        properties["resistance"] = resistance
+        properties["velocityThreshold"] = velocityThreshold
+    },
+) {
+    require(anchors.isNotEmpty()) {
+        "You must have at least one anchor."
+    }
+    require(anchors.values.distinct().count() == anchors.size) {
+        "You cannot have two anchors mapped to the same state."
+    }
+    val density = LocalDensity.current
+    state.ensureInit(anchors)
+    LaunchedEffect(anchors, state) {
+        val oldAnchors = state.anchors
+        state.anchors = anchors
+        state.resistance = resistance
+        state.thresholds = { a, b ->
+            val from = anchors.getValue(a)
+            val to = anchors.getValue(b)
+            with(thresholds(from, to)) { density.computeThreshold(a, b) }
+        }
+        with(density) {
+            state.velocityThreshold = velocityThreshold.toPx()
+        }
+        state.processNewAnchors(oldAnchors, anchors)
+    }
+
+    Modifier.draggable(
+        orientation = orientation,
+        enabled = enabled,
+        reverseDirection = reverseDirection,
+        interactionSource = interactionSource,
+        startDragImmediately = state.isAnimationRunning,
+        onDragStopped = { velocity -> launch { state.performFling(velocity) } },
+        state = state.draggableState,
+    )
+}
+
+/**
+ * Interface to compute a threshold between two anchors/states in a [swipeable].
+ *
+ * To define a [ThresholdConfig], consider using [FixedThreshold] and [FractionalThreshold].
+ */
+@Stable
+@ExperimentalMaterial3Api
+@InternalSparkApi
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+public interface ThresholdConfig {
+    /**
+     * Compute the value of the threshold (in pixels), once the values of the anchors are known.
+     */
+    public fun Density.computeThreshold(fromValue: Float, toValue: Float): Float
+}
+
+/**
+ * A fixed threshold will be at an [offset] away from the first anchor.
+ *
+ * @param offset The offset (in dp) that the threshold will be at.
+ */
+@Immutable
+@ExperimentalMaterial3Api
+@InternalSparkApi
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+public data class FixedThreshold(private val offset: Dp) : ThresholdConfig {
+    override fun Density.computeThreshold(fromValue: Float, toValue: Float): Float {
+        return fromValue + offset.toPx() * sign(toValue - fromValue)
+    }
+}
+
+/**
+ * A fractional threshold will be at a [fraction] of the way between the two anchors.
+ *
+ * @param fraction The fraction (between 0 and 1) that the threshold will be at.
+ */
+@Immutable
+@ExperimentalMaterial3Api
+internal data class FractionalThreshold(
+    /*@FloatRange(from = 0.0, to = 1.0)*/
+    private val fraction: Float,
+) : ThresholdConfig {
+    override fun Density.computeThreshold(fromValue: Float, toValue: Float): Float {
+        return lerp(fromValue, toValue, fraction)
+    }
+}
+
+/**
+ * Specifies how resistance is calculated in [swipeable].
+ *
+ * There are two things needed to calculate resistance: the resistance basis determines how much
+ * overflow will be consumed to achieve maximum resistance, and the resistance factor determines
+ * the amount of resistance (the larger the resistance factor, the stronger the resistance).
+ *
+ * The resistance basis is usually either the size of the component which [swipeable] is applied
+ * to, or the distance between the minimum and maximum anchors. For a constructor in which the
+ * resistance basis defaults to the latter, consider using [resistanceConfig].
+ *
+ * You may specify different resistance factors for each bound. Consider using one of the default
+ * resistance factors in [SwipeableDefaults]: `StandardResistanceFactor` to convey that the user
+ * has run out of things to see, and `StiffResistanceFactor` to convey that the user cannot swipe
+ * this right now. Also, you can set either factor to 0 to disable resistance at that bound.
+ *
+ * @param basis Specifies the maximum amount of overflow that will be consumed. Must be positive.
+ * @param factorAtMin The factor by which to scale the resistance at the minimum bound.
+ * Must not be negative.
+ * @param factorAtMax The factor by which to scale the resistance at the maximum bound.
+ * Must not be negative.
+ */
+@Immutable
+@InternalSparkApi
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+public class ResistanceConfig(
+    /*@FloatRange(from = 0.0, fromInclusive = false)*/
+    public val basis: Float,
+    /*@FloatRange(from = 0.0)*/
+    public val factorAtMin: Float = StandardResistanceFactor,
+    /*@FloatRange(from = 0.0)*/
+    public val factorAtMax: Float = StandardResistanceFactor,
+) {
+    public fun computeResistance(overflow: Float): Float {
+        val factor = if (overflow < 0) factorAtMin else factorAtMax
+        if (factor == 0f) return 0f
+        val progress = (overflow / basis).coerceIn(-1f, 1f)
+        return basis / factor * sin(progress * PI.toFloat() / 2)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ResistanceConfig) return false
+
+        if (basis != other.basis) return false
+        if (factorAtMin != other.factorAtMin) return false
+        if (factorAtMax != other.factorAtMax) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = basis.hashCode()
+        result = 31 * result + factorAtMin.hashCode()
+        result = 31 * result + factorAtMax.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "ResistanceConfig(basis=$basis, factorAtMin=$factorAtMin, factorAtMax=$factorAtMax)"
+    }
+}
+
+/**
+ *  Given an offset x and a set of anchors, return a list of anchors:
+ *   1. [ ] if the set of anchors is empty,
+ *   2. [ x' ] if x is equal to one of the anchors, accounting for a small rounding error, where x'
+ *      is x rounded to the exact value of the matching anchor,
+ *   3. [ min ] if min is the minimum anchor and x < min,
+ *   4. [ max ] if max is the maximum anchor and x > max, or
+ *   5. [ a , b ] if a and b are anchors such that a < x < b and b - a is minimal.
+ */
+private fun findBounds(
+    offset: Float,
+    anchors: Set<Float>,
+): List<Float> {
+    // Find the anchors the target lies between with a little bit of rounding error.
+    val a = anchors.filter { it <= offset + 0.001 }.maxOrNull()
+    val b = anchors.filter { it >= offset - 0.001 }.minOrNull()
+
+    return when {
+        a == null ->
+            // case 1 or 3
+            listOfNotNull(b)
+
+        b == null ->
+            // case 4
+            listOf(a)
+
+        a == b ->
+            // case 2
+            // Can't return offset itself here since it might not be exactly equal
+            // to the anchor, despite being considered an exact match.
+            listOf(a)
+
+        else ->
+            // case 5
+            listOf(a, b)
+    }
+}
+
+private fun computeTarget(
+    offset: Float,
+    lastValue: Float,
+    anchors: Set<Float>,
+    thresholds: (Float, Float) -> Float,
+    velocity: Float,
+    velocityThreshold: Float,
+): Float {
+    val bounds = findBounds(offset, anchors)
+    return when (bounds.size) {
+        0 -> lastValue
+        1 -> bounds[0]
+        else -> {
+            val lower = bounds[0]
+            val upper = bounds[1]
+            if (lastValue <= offset) {
+                // Swiping from lower to upper (positive).
+                if (velocity >= velocityThreshold) {
+                    return upper
+                } else {
+                    val threshold = thresholds(lower, upper)
+                    if (offset < threshold) lower else upper
+                }
+            } else {
+                // Swiping from upper to lower (negative).
+                if (velocity <= -velocityThreshold) {
+                    return lower
+                } else {
+                    val threshold = thresholds(upper, lower)
+                    if (offset > threshold) upper else lower
+                }
+            }
+        }
+    }
+}
+
+private fun <T> Map<Float, T>.getOffset(state: T): Float? {
+    return entries.firstOrNull { it.value == state }?.key
+}
+
+/**
+ * Contains useful defaults for [swipeable] and [SwipeableState].
+ */
+// This is a copy from Material 3 Swipeable until b/163132293 is closed
+// Until this is fixed use it when you really cannot use a BottomSheetDialogFragment
+@InternalSparkApi
+public object SwipeableDefaults {
+    /**
+     * The default animation used by [SwipeableState].
+     */
+    internal val AnimationSpec = SpringSpec<Float>()
+
+    /**
+     * The default velocity threshold (1.8 dp per millisecond) used by [swipeable].
+     */
+    internal val VelocityThreshold = 125.dp
+
+    /**
+     * A stiff resistance factor which indicates that swiping isn't available right now.
+     */
+    public const val StiffResistanceFactor: Float = 20f
+
+    /**
+     * A standard resistance factor which indicates that the user has run out of things to see.
+     */
+    public const val StandardResistanceFactor: Float = 10f
+
+    /**
+     * The default resistance config used by [swipeable].
+     *
+     * This returns `null` if there is one anchor. If there are at least two anchors, it returns
+     * a [ResistanceConfig] with the resistance basis equal to the distance between the two bounds.
+     */
+    internal fun resistanceConfig(
+        anchors: Set<Float>,
+        factorAtMin: Float = StandardResistanceFactor,
+        factorAtMax: Float = StandardResistanceFactor,
+    ): ResistanceConfig? {
+        return if (anchors.size <= 1) {
+            null
+        } else {
+            val basis = anchors.maxOrNull()!! - anchors.minOrNull()!!
+            ResistanceConfig(basis, factorAtMin, factorAtMax)
+        }
+    }
+}
+
+// temp default nested scroll connection for swipeables which desire as an opt in
+// revisit in b/174756744 as all types will have their own specific connection probably
+@ExperimentalMaterial3Api
+internal val <T> SwipeableState<T>.PreUpPostDownNestedScrollConnection: NestedScrollConnection
+    get() = object : NestedScrollConnection {
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+            val delta = available.toFloat()
+            return if (delta < 0 && source == NestedScrollSource.Drag) {
+                performDrag(delta).toOffset()
+            } else {
+                Offset.Zero
+            }
+        }
+
+        override fun onPostScroll(
+            consumed: Offset,
+            available: Offset,
+            source: NestedScrollSource,
+        ): Offset {
+            return if (source == NestedScrollSource.Drag) {
+                performDrag(available.toFloat()).toOffset()
+            } else {
+                Offset.Zero
+            }
+        }
+
+        override suspend fun onPreFling(available: Velocity): Velocity {
+            val toFling = Offset(available.x, available.y).toFloat()
+            return if (toFling < 0 && offset.value > minBound) {
+                performFling(velocity = toFling)
+                // since we go to the anchor with tween settling, consume all for the best UX
+                available
+            } else {
+                Velocity.Zero
+            }
+        }
+
+        override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+            performFling(velocity = Offset(available.x, available.y).toFloat())
+            return available
+        }
+
+        private fun Float.toOffset(): Offset = Offset(0f, this)
+
+        private fun Offset.toFloat(): Float = this.y
+    }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -69,13 +69,13 @@ internal fun SparkCard(
  *
  * ![Card image](https://developer.android.com/images/reference/androidx/compose/material3/filled-card.png)
  *
- * @param modifier the Modifier to be applied to this card
+ * @param modifier - the Modifier to be applied to this card
  * When false, this component will not respond to user input,
  * and it will appear visually disabled and disabled to accessibility services.
- * @param colors commentCountCardColors that will be used to resolve the colors used for this card in different states.
+ * @param colors - CardColors that will be used to resolve the colors used for this card in different states.
  * See [CardDefaults.cardColors]
- * @param border commentCountthe border to draw around the container of this card
- * @param content commentCountcontent of the card
+ * @param border - the border to draw around the container of this card
+ * @param content - content of the card
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -69,13 +69,13 @@ internal fun SparkCard(
  *
  * ![Card image](https://developer.android.com/images/reference/androidx/compose/material3/filled-card.png)
  *
- * @param modifier - the Modifier to be applied to this card
+ * @param modifier the Modifier to be applied to this card
  * When false, this component will not respond to user input,
  * and it will appear visually disabled and disabled to accessibility services.
- * @param colors - CardColors that will be used to resolve the colors used for this card in different states.
+ * @param colors commentCountCardColors that will be used to resolve the colors used for this card in different states.
  * See [CardDefaults.cardColors]
- * @param border - the border to draw around the container of this card
- * @param content - content of the card
+ * @param border commentCountthe border to draw around the container of this card
+ * @param content commentCountcontent of the card
  */
 @ExperimentalSparkApi
 @Composable
@@ -126,17 +126,17 @@ internal fun SparkCard(
  *
  * ![Card image](https://developer.android.com/images/reference/androidx/compose/material3/filled-card.png)
  *
- * @param onClick - called when this card is clicked
- * @param modifier - the Modifier to be applied to this card
- * @param enabled - controls the enabled state of this card.
+ * @param onClick commentCountcalled when this card is clicked
+ * @param modifier commentCountthe Modifier to be applied to this card
+ * @param enabled commentCountcontrols the enabled state of this card.
  * When false, this component will not respond to user input,
  * and it will appear visually disabled and disabled to accessibility services.
- * @param colors - CardColors that will be used to resolve the colors used for this card in different states.
+ * @param colors commentCountCardColors that will be used to resolve the colors used for this card in different states.
  * See [CardDefaults.cardColors]
- * @param border - the border to draw around the container of this card
- * @param interactionSource - the [MutableInteractionSource] representing the stream of Interactions for this card.
+ * @param border commentCountthe border to draw around the container of this card
+ * @param interactionSource commentCountthe [MutableInteractionSource] representing the stream of Interactions for this card.
  * You can create and pass in your own remembered instance to observe
- * @param content - content of the card
+ * @param content commentCountcontent of the card
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/ElevatedCard.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/ElevatedCard.kt
@@ -72,7 +72,7 @@ internal fun SparkElevatedCard(
  * @param modifier the [Modifier] to be applied to this card
  * @param colors [CardColors] that will be used to resolve the color(s) used for this card in
  * different states. See [CardDefaults.elevatedCardColors].
- * @param content - content of the card
+ * @param content commentCountcontent of the card
  */
 @Composable
 public fun ElevatedCard(
@@ -128,9 +128,9 @@ internal fun SparkElevatedCard(
  * @param enabled controls the enabled state of this card. When `false`, this component will not
  * respond to user input, and it will appear visually disabled and disabled to accessibility
  * services.
- * @param interactionSource - the [MutableInteractionSource] representing the stream of Interactions for this card.
+ * @param interactionSource commentCountthe [MutableInteractionSource] representing the stream of Interactions for this card.
  * You can create and pass in your own remembered instance to observe
- * @param content - content of the card
+ * @param content commentCountcontent of the card
  */
 
 @ExperimentalMaterial3Api

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/ElevatedCard.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/ElevatedCard.kt
@@ -72,7 +72,7 @@ internal fun SparkElevatedCard(
  * @param modifier the [Modifier] to be applied to this card
  * @param colors [CardColors] that will be used to resolve the color(s) used for this card in
  * different states. See [CardDefaults.elevatedCardColors].
- * @param content commentCountcontent of the card
+ * @param content - content of the card
  */
 @Composable
 public fun ElevatedCard(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/AssistChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/AssistChip.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.adevinta.spark.components.chips
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ChipBorder
+import androidx.compose.material3.ChipColors
+import androidx.compose.material3.ChipElevation
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ElevatedAssistChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.tools.preview.SparkPreviewParam
+import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import androidx.compose.material3.AssistChip as MaterialAssistChip
+import androidx.compose.material3.ElevatedAssistChip as MaterialElevatedAssistChip
+
+/**
+ * <a href="https://m3.material.io/components/chips/overview" class="external" target="_blank">Material Design assist chip</a>.
+ *
+ * Chips help people enter information, make selections, filter content, or trigger actions. Chips
+ * can show multiple interactive elements together in the same area, such as a list of selectable
+ * movie times, or a series of email contacts.
+ *
+ * Assist chips represent smart or automated actions that can span multiple apps, such as opening a
+ * calendar event from the home screen. Assist chips function as though the user asked an assistant
+ * to complete the action. They should appear dynamically and contextually in a UI.
+ *
+ * ![Assist chip image](https://developer.android.com/images/reference/androidx/compose/material3/assist-chip.png)
+ *
+ * This assist chip is applied with a flat style. If you want an elevated style, use the
+ * [ElevatedAssistChip].
+ *
+ * Example of a flat AssistChip:
+ * @sample androidx.compose.material3.samples.AssistChipSample
+ *
+ * @param onClick called when this chip is clicked
+ * @param label text label for this chip
+ * @param modifier the [Modifier] to be applied to this chip
+ * @param enabled controls the enabled state of this chip. When `false`, this component will not
+ * respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param leadingIcon optional icon at the start of the chip, preceding the [label] text
+ * @param trailingIcon optional icon at the end of the chip
+ * @param shape defines the shape of this chip's container, border (when [border] is not null), and
+ * shadow (when using [elevation])
+ * @param colors [ChipColors] that will be used to resolve the colors used for this chip in
+ * different states. See [AssistChipDefaults.assistChipColors].
+ * @param elevation [ChipElevation] used to resolve the elevation for this chip in different states.
+ * This controls the size of the shadow below the chip. Additionally, when the container color is
+ * [ColorScheme.surface], this controls the amount of primary color applied as an overlay. See
+ * [AssistChipDefaults.assistChipElevation].
+ * @param border the border to draw around the container of this chip. Pass `null` for no border.
+ * See [AssistChipDefaults.assistChipBorder].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this chip. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this chip in different states.
+ */
+@ExperimentalMaterial3Api
+@Composable
+public fun AssistChip(
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = AssistChipDefaults.shape,
+    colors: ChipColors = AssistChipDefaults.assistChipColors(),
+    elevation: ChipElevation? = AssistChipDefaults.assistChipElevation(),
+    border: ChipBorder? = AssistChipDefaults.assistChipBorder(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialAssistChip(
+        onClick = onClick,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        interactionSource = interactionSource,
+    )
+}
+
+/**
+ * <a href="https://m3.material.io/components/chips/overview" class="external" target="_blank">Material Design elevated assist chip</a>.
+ *
+ * Chips help people enter information, make selections, filter content, or trigger actions. Chips
+ * can show multiple interactive elements together in the same area, such as a list of selectable
+ * movie times, or a series of email contacts.
+ *
+ * Assist chips represent smart or automated actions that can span multiple apps, such as opening a
+ * calendar event from the home screen. Assist chips function as though the user asked an assistant
+ * to complete the action. They should appear dynamically and contextually in a UI.
+ *
+ * ![Assist chip image](https://developer.android.com/images/reference/androidx/compose/material3/elevated-assist-chip.png)
+ *
+ * This assist chip is applied with an elevated style. If you want a flat style, use the
+ * [AssistChip].
+ *
+ * Example of an elevated AssistChip with a trailing icon:
+ * @sample androidx.compose.material3.samples.ElevatedAssistChipSample
+ *
+ * @param onClick called when this chip is clicked
+ * @param label text label for this chip
+ * @param modifier the [Modifier] to be applied to this chip
+ * @param enabled controls the enabled state of this chip. When `false`, this component will not
+ * respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param leadingIcon optional icon at the start of the chip, preceding the [label] text
+ * @param trailingIcon optional icon at the end of the chip
+ * @param shape defines the shape of this chip's container, border (when [border] is not null), and
+ * shadow (when using [elevation])
+ * @param colors [ChipColors] that will be used to resolve the colors used for this chip in
+ * different states. See [AssistChipDefaults.elevatedAssistChipColors].
+ * @param elevation [ChipElevation] used to resolve the elevation for this chip in different states.
+ * This controls the size of the shadow below the chip. Additionally, when the container color is
+ * [ColorScheme.surface], this controls the amount of primary color applied as an overlay. See
+ * [AssistChipDefaults.elevatedAssistChipElevation].
+ * @param border the border to draw around the container of this chip
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this chip. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this chip in different states.
+ */
+@Composable
+public fun ElevatedAssistChip(
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    leadingIcon: (@Composable () -> Unit)? = null,
+    trailingIcon: (@Composable () -> Unit)? = null,
+    shape: Shape = AssistChipDefaults.shape,
+    colors: ChipColors = AssistChipDefaults.elevatedAssistChipColors(),
+    elevation: ChipElevation? = AssistChipDefaults.elevatedAssistChipElevation(),
+    border: ChipBorder? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialElevatedAssistChip(
+        onClick = onClick,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        interactionSource = interactionSource,
+    )
+}
+
+@Composable
+@Preview(
+    group = "Chips",
+    name = "AssistChip",
+)
+internal fun AssistChipPreview(
+    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+) {
+    val (theme, userType) = param
+    PreviewTheme(theme, userType) {
+        AssistChip(
+            onClick = { /* Do something! */ },
+            label = { Text("Assist Chip") },
+            leadingIcon = {
+                Icon(
+                    Icons.Filled.Settings,
+                    contentDescription = "Localized description",
+                    Modifier.size(AssistChipDefaults.IconSize),
+                )
+            },
+        )
+
+        ElevatedAssistChip(
+            onClick = { /* Do something! */ },
+            label = { Text("Elevated Assist Chip") },
+            leadingIcon = {
+                Icon(
+                    Icons.Filled.Settings,
+                    contentDescription = "Localized description",
+                    Modifier.size(AssistChipDefaults.IconSize),
+                )
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/FilterChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/FilterChip.kt
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.adevinta.spark.components.chips
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ElevatedFilterChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.SelectableChipBorder
+import androidx.compose.material3.SelectableChipColors
+import androidx.compose.material3.SelectableChipElevation
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.tools.preview.SparkPreviewParam
+import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import androidx.compose.material3.ElevatedFilterChip as MaterialElevatedFilterChip
+import androidx.compose.material3.FilterChip as MaterialFilterChip
+
+/**
+ * <a href="https://m3.material.io/components/chips/overview" class="external" target="_blank">Material Design filter chip</a>.
+ *
+ * Chips help people enter information, make selections, filter content, or trigger actions. Chips
+ * can show multiple interactive elements together in the same area, such as a list of selectable
+ * movie times, or a series of email contacts.
+ *
+ * Filter chips use tags or descriptive words to filter content. They can be a good alternative to
+ * toggle buttons or checkboxes.
+ *
+ * ![Filter chip image](https://developer.android.com/images/reference/androidx/compose/material3/filter-chip.png)
+ *
+ * This filter chip is applied with a flat style. If you want an elevated style, use the
+ * [ElevatedFilterChip].
+ *
+ * Tapping on a filter chip toggles its selection state. A selection state [leadingIcon] can be
+ * provided (e.g. a checkmark) to be appended at the starting edge of the chip's label.
+ *
+ * Example of a flat FilterChip with a trailing icon:
+ * @sample androidx.compose.material3.samples.FilterChipSample
+ *
+ * Example of a FilterChip with both a leading icon and a selected icon:
+ * @sample androidx.compose.material3.samples.FilterChipWithLeadingIconSample
+ *
+ * @param selected whether this chip is selected or not
+ * @param onClick called when this chip is clicked
+ * @param label text label for this chip
+ * @param modifier the [Modifier] to be applied to this chip
+ * @param enabled controls the enabled state of this chip. When `false`, this component will not
+ * respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param leadingIcon optional icon at the start of the chip, preceding the [label] text. When
+ * [selected] is true, this icon may visually indicate that the chip is selected (for example, via a
+ * checkmark icon).
+ * @param trailingIcon optional icon at the end of the chip
+ * @param shape defines the shape of this chip's container, border (when [border] is not null), and
+ * shadow (when using [elevation])
+ * @param colors [SelectableChipColors] that will be used to resolve the colors used for this chip
+ * in different states. See [FilterChipDefaults.filterChipColors].
+ * @param elevation [SelectableChipElevation] used to resolve the elevation for this chip in
+ * different states. This controls the size of the shadow below the chip. Additionally, when the
+ * container color is [ColorScheme.surface], this controls the amount of primary color applied as an
+ * overlay. See [FilterChipDefaults.filterChipElevation].
+ * @param border the border to draw around the container of this chip. Pass `null` for no border.
+ * See [FilterChipDefaults.filterChipBorder].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this chip. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this chip in different states.
+ */
+@ExperimentalMaterial3Api
+@Composable
+public fun FilterChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = FilterChipDefaults.shape,
+    colors: SelectableChipColors = FilterChipDefaults.filterChipColors(),
+    elevation: SelectableChipElevation? = FilterChipDefaults.filterChipElevation(),
+    border: SelectableChipBorder? = FilterChipDefaults.filterChipBorder(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialFilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        interactionSource = interactionSource,
+    )
+}
+
+/**
+ * <a href="https://m3.material.io/components/chips/overview" class="external" target="_blank">Material Design elevated filter chip</a>.
+ *
+ * Chips help people enter information, make selections, filter content, or trigger actions. Chips
+ * can show multiple interactive elements together in the same area, such as a list of selectable
+ * movie times, or a series of email contacts.
+ *
+ * Filter chips use tags or descriptive words to filter content. They can be a good alternative to
+ * toggle buttons or checkboxes.
+ *
+ * ![Filter chip image](https://developer.android.com/images/reference/androidx/compose/material3/elevated-filter-chip.png)
+ *
+ * This filter chip is applied with an elevated style. If you want a flat style, use the
+ * [FilterChip].
+ *
+ * Tapping on a filter chip toggles its selection state. A selection state [leadingIcon] can be
+ * provided (e.g. a checkmark) to be appended at the starting edge of the chip's label.
+ *
+ * Example of an elevated FilterChip with a trailing icon:
+ * @sample androidx.compose.material3.samples.ElevatedFilterChipSample
+ *
+ * @param selected whether this chip is selected or not
+ * @param onClick called when this chip is clicked
+ * @param label text label for this chip
+ * @param modifier the [Modifier] to be applied to this chip
+ * @param enabled controls the enabled state of this chip. When `false`, this component will not
+ * respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param leadingIcon optional icon at the start of the chip, preceding the [label] text. When
+ * [selected] is true, this icon may visually indicate that the chip is selected (for example, via a
+ * checkmark icon).
+ * @param trailingIcon optional icon at the end of the chip
+ * @param shape defines the shape of this chip's container, border (when [border] is not null), and
+ * shadow (when using [elevation])
+ * @param colors [SelectableChipColors] that will be used to resolve the colors used for this chip
+ * in different states. See [FilterChipDefaults.elevatedFilterChipColors].
+ * @param elevation [SelectableChipElevation] used to resolve the elevation for this chip in
+ * different states. This controls the size of the shadow below the chip. Additionally, when the
+ * container color is [ColorScheme.surface], this controls the amount of primary color applied as an
+ * overlay. See [FilterChipDefaults.filterChipElevation].
+ * @param border the border to draw around the container of this chip. Pass `null` for no border.
+ * See [FilterChipDefaults.filterChipBorder].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this chip. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this chip in different states.
+ */
+@Composable
+public fun ElevatedFilterChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = FilterChipDefaults.shape,
+    colors: SelectableChipColors = FilterChipDefaults.elevatedFilterChipColors(),
+    elevation: SelectableChipElevation? = FilterChipDefaults.elevatedFilterChipElevation(),
+    border: SelectableChipBorder? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialElevatedFilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        interactionSource = interactionSource,
+    )
+}
+
+@Composable
+@Preview(
+    group = "Chips",
+    name = "FilterChip",
+)
+internal fun FilterPreview(
+    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+) {
+    val (theme, userType) = param
+    PreviewTheme(theme, userType) {
+        var selected by remember { mutableStateOf(false) }
+
+        FilterChip(
+            selected = selected,
+            onClick = { selected = !selected },
+            label = { Text("Filter chip") },
+            leadingIcon = if (selected) {
+                {
+                    Icon(
+                        imageVector = Icons.Filled.Done,
+                        contentDescription = "Localized Description",
+                        modifier = Modifier.size(FilterChipDefaults.IconSize),
+                    )
+                }
+            } else {
+                {
+                    Icon(
+                        imageVector = Icons.Filled.Home,
+                        contentDescription = "Localized description",
+                        modifier = Modifier.size(FilterChipDefaults.IconSize),
+                    )
+                }
+            },
+        )
+
+        ElevatedFilterChip(
+            selected = selected,
+            onClick = { selected = !selected },
+            label = { Text("Elevated Filter chip") },
+            leadingIcon = if (selected) {
+                {
+                    Icon(
+                        imageVector = Icons.Filled.Done,
+                        contentDescription = "Localized Description",
+                        modifier = Modifier.size(FilterChipDefaults.IconSize),
+                    )
+                }
+            } else {
+                null
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/InputChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/InputChip.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.adevinta.spark.components.chips
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.ChipColors
+import androidx.compose.material3.ChipElevation
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.SelectableChipBorder
+import androidx.compose.material3.SelectableChipColors
+import androidx.compose.material3.SelectableChipElevation
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.tools.preview.SparkPreviewParam
+import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import androidx.compose.material3.InputChip as MaterialInputChip
+
+/**
+ * <a href="https://m3.material.io/components/chips/overview" class="external" target="_blank">Material Design input chip</a>.
+ *
+ * Chips help people enter information, make selections, filter content, or trigger actions. Chips
+ * can show multiple interactive elements together in the same area, such as a list of selectable
+ * movie times, or a series of email contacts.
+ *
+ * Input chips represent discrete pieces of information entered by a user.
+ *
+ * ![Input chip image](https://developer.android.com/images/reference/androidx/compose/material3/input-chip.png)
+ *
+ * An Input Chip can have a leading icon or an avatar at its start. In case both are provided, the
+ * avatar will take precedence and will be displayed.
+ *
+ * Example of an InputChip with a trailing icon:
+ * @sample androidx.compose.material3.samples.InputChipSample
+ *
+ * Example of an InputChip with an avatar and a trailing icon:
+ * @sample androidx.compose.material3.samples.InputChipWithAvatarSample
+ *
+ * Input chips should appear in a set and can be horizontally scrollable:
+ * @sample androidx.compose.material3.samples.ChipGroupSingleLineSample
+ *
+ * Alternatively, use Accompanist's [Flow Layouts](https://google.github.io/accompanist/flowlayout/)
+ * to wrap chips to a new line.
+ *
+ * @param selected whether this chip is selected or not
+ * @param onClick called when this chip is clicked
+ * @param label text label for this chip
+ * @param modifier the [Modifier] to be applied to this chip
+ * @param enabled controls the enabled state of this chip. When `false`, this component will not
+ * respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param leadingIcon optional icon at the start of the chip, preceding the [label] text
+ * @param avatar optional avatar at the start of the chip, preceding the [label] text
+ * @param trailingIcon optional icon at the end of the chip
+ * @param shape defines the shape of this chip's container, border (when [border] is not null), and
+ * shadow (when using [elevation])
+ * @param colors [ChipColors] that will be used to resolve the colors used for this chip in
+ * different states. See [InputChipDefaults.inputChipColors].
+ * @param elevation [ChipElevation] used to resolve the elevation for this chip in different states.
+ * This controls the size of the shadow below the chip. Additionally, when the container color is
+ * [ColorScheme.surface], this controls the amount of primary color applied as an overlay. See
+ * [InputChipDefaults.inputChipElevation].
+ * @param border the border to draw around the container of this chip. Pass `null` for no border.
+ * See [InputChipDefaults.inputChipBorder].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this chip. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this chip in different states.
+ */
+@ExperimentalMaterial3Api
+@Composable
+public fun InputChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    avatar: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = InputChipDefaults.shape,
+    colors: SelectableChipColors = InputChipDefaults.inputChipColors(),
+    elevation: SelectableChipElevation? = InputChipDefaults.inputChipElevation(),
+    border: SelectableChipBorder? = InputChipDefaults.inputChipBorder(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialInputChip(
+        selected = selected,
+        onClick = onClick,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        leadingIcon = leadingIcon,
+        avatar = avatar,
+        trailingIcon = trailingIcon,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        interactionSource = interactionSource,
+    )
+}
+
+@Composable
+@Preview(
+    group = "Chips",
+    name = "InputChip",
+)
+internal fun InputChipPreview(
+    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+) {
+    val (theme, userType) = param
+    PreviewTheme(theme, userType) {
+        var selected by remember { mutableStateOf(false) }
+
+        InputChip(
+            selected = selected,
+            onClick = { selected = !selected },
+            label = { Text("Input Chip") },
+        )
+
+        InputChip(
+            selected = selected,
+            onClick = { selected = !selected },
+            label = { Text("Input Chip") },
+            avatar = {
+                Icon(
+                    Icons.Filled.Person,
+                    contentDescription = "Localized description",
+                    Modifier.size(InputChipDefaults.AvatarSize),
+                )
+            },
+        )
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Row(modifier = Modifier.horizontalScroll(rememberScrollState())) {
+                repeat(9) { index ->
+                    InputChip(
+                        selected = selected,
+                        modifier = Modifier.padding(horizontal = 4.dp),
+                        onClick = { /* do something*/ },
+                        label = { Text("Chip $index") },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/SuggestionChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/SuggestionChip.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.adevinta.spark.components.chips
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ChipBorder
+import androidx.compose.material3.ChipColors
+import androidx.compose.material3.ChipElevation
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ElevatedSuggestionChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.tools.preview.SparkPreviewParam
+import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import androidx.compose.material3.SuggestionChip as MaterialSuggestionChip
+
+
+/**
+ * <a href="https://m3.material.io/components/chips/overview" class="external" target="_blank">Material Design suggestion chip</a>.
+ *
+ * Chips help people enter information, make selections, filter content, or trigger actions. Chips
+ * can show multiple interactive elements together in the same area, such as a list of selectable
+ * movie times, or a series of email contacts.
+ *
+ * Suggestion chips help narrow a user's intent by presenting dynamically generated suggestions,
+ * such as possible responses or search filters.
+ *
+ * ![Suggestion chip image](https://developer.android.com/images/reference/androidx/compose/material3/suggestion-chip.png)
+ *
+ * This suggestion chip is applied with a flat style. If you want an elevated style, use the
+ * [ElevatedSuggestionChip].
+ *
+ * Example of a flat SuggestionChip with a trailing icon:
+ * @sample androidx.compose.material3.samples.SuggestionChipSample
+ *
+ * @param onClick called when this chip is clicked
+ * @param label text label for this chip
+ * @param modifier the [Modifier] to be applied to this chip
+ * @param enabled controls the enabled state of this chip. When `false`, this component will not
+ * respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param icon optional icon at the start of the chip, preceding the [label] text
+ * @param shape defines the shape of this chip's container, border (when [border] is not null), and
+ * shadow (when using [elevation])
+ * @param colors [ChipColors] that will be used to resolve the colors used for this chip in
+ * different states. See [SuggestionChipDefaults.suggestionChipColors].
+ * @param elevation [ChipElevation] used to resolve the elevation for this chip in different states.
+ * This controls the size of the shadow below the chip. Additionally, when the container color is
+ * [ColorScheme.surface], this controls the amount of primary color applied as an overlay. See
+ * [SuggestionChipDefaults.suggestionChipElevation].
+ * @param border the border to draw around the container of this chip. Pass `null` for no border.
+ * See [SuggestionChipDefaults.suggestionChipBorder].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this chip. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this chip in different states.
+ */
+@ExperimentalMaterial3Api
+@Composable
+public fun SuggestionChip(
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: @Composable (() -> Unit)? = null,
+    shape: Shape = SuggestionChipDefaults.shape,
+    colors: ChipColors = SuggestionChipDefaults.suggestionChipColors(),
+    elevation: ChipElevation? = SuggestionChipDefaults.suggestionChipElevation(),
+    border: ChipBorder? = SuggestionChipDefaults.suggestionChipBorder(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialSuggestionChip(
+        onClick = onClick,
+        label = label,
+        modifier = modifier,
+        enabled = enabled,
+        icon = icon,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        interactionSource = interactionSource,
+    )
+}
+
+@Composable
+@Preview(
+    group = "Chips",
+    name = "SuggestionChip",
+)
+internal fun SuggestionChipPreview(
+    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+) {
+    val (theme, userType) = param
+    PreviewTheme(theme, userType) {
+        SuggestionChip(
+            onClick = { /* Do something! */ },
+            label = { Text("Suggestion Chip") },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.dialog
 
 import androidx.compose.material.icons.Icons

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.dialog
 
 import androidx.compose.material.icons.Icons

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
@@ -1,0 +1,174 @@
+package com.adevinta.spark.components.dialog
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.window.DialogProperties
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.buttons.TextButton
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+@ExperimentalSparkApi
+@Composable
+internal fun SparkAlertDialog(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: @Composable (() -> Unit)? = null,
+    icon: @Composable (() -> Unit)? = null,
+    title: @Composable (() -> Unit)? = null,
+    text: @Composable (() -> Unit)? = null,
+    shape: Shape = AlertDialogDefaults.shape,
+    containerColor: Color = AlertDialogDefaults.containerColor,
+    iconContentColor: Color = AlertDialogDefaults.iconContentColor,
+    titleContentColor: Color = AlertDialogDefaults.titleContentColor,
+    textContentColor: Color = AlertDialogDefaults.textContentColor,
+    tonalElevation: Dp = AlertDialogDefaults.TonalElevation,
+    properties: DialogProperties = DialogProperties(),
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = confirmButton,
+        modifier = modifier,
+        dismissButton = dismissButton,
+        icon = icon,
+        title = title,
+        text = text,
+        shape = shape,
+        containerColor = containerColor,
+        iconContentColor = iconContentColor,
+        titleContentColor = titleContentColor,
+        textContentColor = textContentColor,
+        tonalElevation = tonalElevation,
+        properties = properties,
+    )
+}
+
+/**
+ * Spark AlertDialog.
+ *
+ * An AlertDialog is a simple dialog for alerting about something
+ *
+ * ![AlertDialog image](https://developer.android.com/images/reference/androidx/compose/material/dialogs.png)
+ *
+ * @param modifier the [Modifier] to be applied to this dialog.
+ * @param onDismissRequest called when the user tries to dismiss the Dialog by clicking outside or pressing the back button. This is not called when the dismiss button is clicked.
+ * @param confirmButton button which is meant to confirm a proposed action, thus resolving what triggered the dialog. The dialog does not set up any events for this button so they need to be set up by the caller.
+ * @param dismissButton button which is meant to dismiss the dialog. The dialog does not set up any events for this button so they need to be set up by the caller.
+ * @param icon optional icon that will appear above the title or above the text, in case a title was not provided.
+ * @param title title which should specify the purpose of the dialog. The title is not mandatory, because there may be sufficient information inside the text.
+ * @param text text which presents the details regarding the dialog's purpose.
+ * @param shape defines the shape of this dialog's container
+ * @param containerColor the color used for the background of this dialog. Use Color.Transparent to have no color.
+ * @param iconContentColor the content color used for the icon.
+ * @param titleContentColor the content color used for the title.
+ * @param textContentColor the content color used for the text.
+ * @param tonalElevation when containerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param properties typically platform specific properties to further configure the dialog.
+ */
+@ExperimentalSparkApi
+@Composable
+public fun AlertDialog(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: @Composable (() -> Unit)? = null,
+    icon: @Composable (() -> Unit)? = null,
+    title: @Composable (() -> Unit)? = null,
+    text: @Composable (() -> Unit)? = null,
+    shape: Shape = AlertDialogDefaults.shape,
+    containerColor: Color = AlertDialogDefaults.containerColor,
+    iconContentColor: Color = AlertDialogDefaults.iconContentColor,
+    titleContentColor: Color = AlertDialogDefaults.titleContentColor,
+    textContentColor: Color = AlertDialogDefaults.textContentColor,
+    tonalElevation: Dp = AlertDialogDefaults.TonalElevation,
+    properties: DialogProperties = DialogProperties(),
+) {
+    SparkAlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = confirmButton,
+        modifier = modifier,
+        dismissButton = dismissButton,
+        icon = icon,
+        title = title,
+        text = text,
+        shape = shape,
+        containerColor = containerColor,
+        iconContentColor = iconContentColor,
+        titleContentColor = titleContentColor,
+        textContentColor = textContentColor,
+        tonalElevation = tonalElevation,
+        properties = properties,
+    )
+}
+
+@Preview(
+    group = "Dialog",
+    name = "AlertDialog",
+)
+@Composable
+internal fun AlertDialogPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(
+        theme,
+    ) {
+        val openDialog = remember { mutableStateOf(true) }
+
+        if (openDialog.value) {
+            AlertDialog(
+                onDismissRequest = {
+                    // Dismiss the dialog when the user clicks outside the dialog or on the back
+                    // button. If you want to disable that functionality, simply use an empty
+                    // onDismissRequest.
+                    openDialog.value = false
+                },
+                icon = { Icon(Icons.Filled.Favorite, contentDescription = null) },
+                title = {
+                    Text(text = "Title")
+                },
+                text = {
+                    Text(
+                        "This area typically contains the supportive text " +
+                                "which presents the details regarding the Dialog's purpose.",
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        icon = SparkIcon.Actions.Copy,
+                        onClick = {
+                            openDialog.value = false
+                        },
+                    ) {
+                        Text("Confirm")
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        icon = SparkIcon.Actions.Copy,
+                        onClick = {
+                            openDialog.value = false
+                        },
+                    ) {
+                        Text("Dismiss")
+                    }
+                },
+            )
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.drawer
 
 import androidx.compose.foundation.layout.ColumnScope
@@ -85,12 +63,12 @@ internal fun SparkDismissibleDrawerSheet(
  * An DismissibleDrawerSheet is a simple dismissible drawer sheet with content inside.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
- * @param drawerShape defines the shape of this drawer's container
- * @param drawerContainerColor the color used for the background of this drawer. Use Color.Transparent to have no color.
- * @param drawerContentColor the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
- * @param drawerTonalElevation when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
- * @param windowInsets a window insets for the sheet.
- * @param content content inside of a dismissible navigation drawer
+ * @param drawerShape - defines the shape of this drawer's container
+ * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets - a window insets for the sheet.
+ * @param content - content inside of a dismissible navigation drawer
  */
 @ExperimentalMaterial3Api
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.drawer
 
 import androidx.compose.foundation.layout.ColumnScope
@@ -63,12 +85,12 @@ internal fun SparkDismissibleDrawerSheet(
  * An DismissibleDrawerSheet is a simple dismissible drawer sheet with content inside.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
- * @param drawerShape - defines the shape of this drawer's container
- * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
- * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
- * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
- * @param windowInsets - a window insets for the sheet.
- * @param content - content inside of a dismissible navigation drawer
+ * @param drawerShape defines the shape of this drawer's container
+ * @param drawerContainerColor the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets a window insets for the sheet.
+ * @param content content inside of a dismissible navigation drawer
  */
 @ExperimentalMaterial3Api
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
@@ -1,0 +1,128 @@
+package com.adevinta.spark.components.drawer
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.DismissibleDrawerSheet
+import androidx.compose.material3.DrawerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.tokens.contentColorFor
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+internal fun SparkDismissibleDrawerSheet(
+    modifier: Modifier = Modifier,
+    drawerShape: Shape = RectangleShape,
+    drawerContainerColor: Color = SparkTheme.colors.surface,
+    drawerContentColor: Color = contentColorFor(drawerContainerColor),
+    drawerTonalElevation: Dp = DrawerDefaults.DismissibleDrawerElevation,
+    windowInsets: WindowInsets = DrawerDefaults.windowInsets,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    DismissibleDrawerSheet(
+        modifier = modifier,
+        drawerShape = drawerShape,
+        drawerContainerColor = drawerContainerColor,
+        drawerContentColor = drawerContentColor,
+        drawerTonalElevation = drawerTonalElevation,
+        windowInsets = windowInsets,
+        content = content,
+    )
+}
+
+/**
+ * Spark DismissibleDrawerSheet.
+ *
+ * An DismissibleDrawerSheet is a simple dismissible drawer sheet with content inside.
+ *
+ * @param modifier the [Modifier] to be applied to this drawer's content
+ * @param drawerShape - defines the shape of this drawer's container
+ * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets - a window insets for the sheet.
+ * @param content - content inside of a dismissible navigation drawer
+ */
+@ExperimentalMaterial3Api
+@ExperimentalSparkApi
+@Composable
+public fun DismissibleDrawerSheet(
+    modifier: Modifier = Modifier,
+    drawerShape: Shape = RectangleShape,
+    drawerContainerColor: Color = SparkTheme.colors.surface,
+    drawerContentColor: Color = contentColorFor(drawerContainerColor),
+    drawerTonalElevation: Dp = DrawerDefaults.DismissibleDrawerElevation,
+    windowInsets: WindowInsets = DrawerDefaults.windowInsets,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    SparkDismissibleDrawerSheet(
+        modifier = modifier,
+        drawerShape = drawerShape,
+        drawerContainerColor = drawerContainerColor,
+        drawerContentColor = drawerContentColor,
+        drawerTonalElevation = drawerTonalElevation,
+        windowInsets = windowInsets,
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(
+    group = "Drawer",
+    name = "DismissibleDrawerSheet",
+)
+@Composable
+internal fun DismissibleDrawerSheetPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(
+        theme,
+        padding = PaddingValues(0.dp),
+    ) {
+        // icons to mimic drawer destinations
+        val items = listOf(Icons.Default.Favorite, Icons.Default.Face, Icons.Default.Email)
+        val selectedItem = remember { mutableStateOf(items[0]) }
+
+        DismissibleDrawerSheet {
+            Spacer(Modifier.height(12.dp))
+            items.forEach { item ->
+                NavigationDrawerItem(
+                    icon = { Icon(item, contentDescription = null) },
+                    label = { Text(item.name) },
+                    selected = item == selectedItem.value,
+                    onClick = {
+                        selectedItem.value = item
+                    },
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                )
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
@@ -1,0 +1,160 @@
+package com.adevinta.spark.components.drawer
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Button
+import androidx.compose.material3.DismissibleNavigationDrawer
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import kotlinx.coroutines.launch
+import androidx.compose.material3.rememberDrawerState as rememberMaterialDrawerState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+internal fun SparkDismissibleNavigationDrawer(
+    drawerContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    drawerState: DrawerState = rememberMaterialDrawerState(DrawerValue.Closed),
+    gesturesEnabled: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    DismissibleNavigationDrawer(
+        drawerContent = drawerContent,
+        modifier = modifier,
+        drawerState = drawerState,
+        gesturesEnabled = gesturesEnabled,
+        content = content,
+    )
+}
+
+/**
+ * Spark DismissibleNavigationDrawer.
+ *
+ * A DismissibleNavigationDrawer provide ergonomic access to destinations in an app. They’re often next to app content and affect the screen’s layout grid.
+ *
+ * ![DismissibleNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
+ *
+ * @param drawerContent - content inside this drawer
+ * @param modifier the [Modifier] to be applied to this drawer
+ * @param drawerState - state of the drawer
+ * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
+ * @param content - content of the rest of the UI
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+public fun DismissibleNavigationDrawer(
+    drawerContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed),
+    gesturesEnabled: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    SparkDismissibleNavigationDrawer(
+        drawerContent = drawerContent,
+        modifier = modifier,
+        drawerState = drawerState,
+        gesturesEnabled = gesturesEnabled,
+        content = content,
+    )
+}
+
+@ExperimentalMaterial3Api
+@Composable
+public fun rememberDrawerState(
+    initialValue: DrawerValue,
+    confirmStateChange: (DrawerValue) -> Boolean = { true },
+): DrawerState {
+    return rememberMaterialDrawerState(
+        initialValue = initialValue,
+        confirmStateChange = confirmStateChange,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(
+    group = "Drawer",
+    name = "DismissibleNavigationDrawer",
+)
+@Composable
+internal fun AlertDialogPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(
+        theme,
+        padding = PaddingValues(0.dp),
+    ) {
+        val drawerState = rememberDrawerState(DrawerValue.Closed)
+        val scope = rememberCoroutineScope()
+        // icons to mimic drawer destinations
+        val items = listOf(Icons.Default.Favorite, Icons.Default.Face, Icons.Default.Email)
+        val selectedItem = remember { mutableStateOf(items[0]) }
+        BackHandler(enabled = drawerState.isOpen) {
+            scope.launch {
+                drawerState.close()
+            }
+        }
+
+        DismissibleNavigationDrawer(
+            drawerState = drawerState,
+            drawerContent = {
+                DismissibleDrawerSheet {
+                    Spacer(Modifier.height(12.dp))
+                    items.forEach { item ->
+                        NavigationDrawerItem(
+                            icon = { Icon(item, contentDescription = null) },
+                            label = { Text(item.name) },
+                            selected = item == selectedItem.value,
+                            onClick = {
+                                scope.launch { drawerState.close() }
+                                selectedItem.value = item
+                            },
+                            modifier = Modifier.padding(horizontal = 12.dp),
+                        )
+                    }
+                }
+            },
+            content = {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(text = if (drawerState.isClosed) ">>> Swipe >>>" else "<<< Swipe <<<")
+                    Spacer(Modifier.height(20.dp))
+                    Button(onClick = { scope.launch { drawerState.open() } }) {
+                        Text("Click to open")
+                    }
+                }
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.drawer
 
 import androidx.activity.compose.BackHandler
@@ -61,11 +83,11 @@ internal fun SparkDismissibleNavigationDrawer(
  *
  * ![DismissibleNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
- * @param drawerContent - content inside this drawer
+ * @param drawerContent content inside this drawer
  * @param modifier the [Modifier] to be applied to this drawer
- * @param drawerState - state of the drawer
- * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
- * @param content - content of the rest of the UI
+ * @param drawerState commentCountstate of the drawer
+ * @param gesturesEnabled commentCountwhether or not the drawer can be interacted by gestures
+ * @param content commentCountcontent of the rest of the UI
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.drawer
 
 import androidx.activity.compose.BackHandler
@@ -83,11 +61,11 @@ internal fun SparkDismissibleNavigationDrawer(
  *
  * ![DismissibleNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
- * @param drawerContent content inside this drawer
+ * @param drawerContent - content inside this drawer
  * @param modifier the [Modifier] to be applied to this drawer
- * @param drawerState commentCountstate of the drawer
- * @param gesturesEnabled commentCountwhether or not the drawer can be interacted by gestures
- * @param content commentCountcontent of the rest of the UI
+ * @param drawerState - state of the drawer
+ * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
+ * @param content - content of the rest of the UI
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.drawer
 
 import androidx.compose.foundation.layout.ColumnScope
@@ -84,12 +62,12 @@ internal fun SparkModalDrawerSheet(
  * A ModalDrawerSheet is a Content inside of a modal navigation drawer.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
- * @param drawerShape defines the shape of this drawer's container
- * @param drawerContainerColor the color used for the background of this drawer. Use Color.Transparent to have no color.
- * @param drawerContentColor the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
- * @param drawerTonalElevation when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
- * @param windowInsets a window insets for the sheet.
- * @param content content inside of a modal navigation drawer
+ * @param drawerShape - defines the shape of this drawer's container
+ * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets - a window insets for the sheet.
+ * @param content - content inside of a modal navigation drawer
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.drawer
 
 import androidx.compose.foundation.layout.ColumnScope
@@ -62,12 +84,12 @@ internal fun SparkModalDrawerSheet(
  * A ModalDrawerSheet is a Content inside of a modal navigation drawer.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
- * @param drawerShape - defines the shape of this drawer's container
- * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
- * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
- * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
- * @param windowInsets - a window insets for the sheet.
- * @param content - content inside of a modal navigation drawer
+ * @param drawerShape defines the shape of this drawer's container
+ * @param drawerContainerColor the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets a window insets for the sheet.
+ * @param content content inside of a modal navigation drawer
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
@@ -1,0 +1,128 @@
+package com.adevinta.spark.components.drawer
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.tokens.SparkShapes
+import com.adevinta.spark.tokens.contentColorFor
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+internal fun SparkModalDrawerSheet(
+    modifier: Modifier = Modifier,
+    drawerShape: Shape = SparkShapes().large,
+    drawerContainerColor: Color = SparkTheme.colors.surface,
+    drawerContentColor: Color = contentColorFor(drawerContainerColor),
+    drawerTonalElevation: Dp = SparkDrawerDefaults.ModalDrawerElevation,
+    windowInsets: WindowInsets = SparkDrawerDefaults.windowInsets,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ModalDrawerSheet(
+        modifier = modifier,
+        drawerShape = drawerShape,
+        drawerContainerColor = drawerContainerColor,
+        drawerContentColor = drawerContentColor,
+        drawerTonalElevation = drawerTonalElevation,
+        windowInsets = windowInsets,
+        content = content,
+    )
+}
+
+/**
+ * Spark ModalDrawerSheet.
+ *
+ * A ModalDrawerSheet is a Content inside of a modal navigation drawer.
+ *
+ * @param modifier the [Modifier] to be applied to this drawer's content
+ * @param drawerShape - defines the shape of this drawer's container
+ * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets - a window insets for the sheet.
+ * @param content - content inside of a modal navigation drawer
+ */
+@ExperimentalSparkApi
+@Composable
+public fun ModalDrawerSheet(
+    modifier: Modifier = Modifier,
+    drawerShape: Shape = SparkShapes().large,
+    drawerContainerColor: Color = SparkTheme.colors.surface,
+    drawerContentColor: Color = contentColorFor(drawerContainerColor),
+    drawerTonalElevation: Dp = SparkDrawerDefaults.ModalDrawerElevation,
+    windowInsets: WindowInsets = SparkDrawerDefaults.windowInsets,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    SparkModalDrawerSheet(
+        modifier = modifier,
+        drawerShape = drawerShape,
+        drawerContainerColor = drawerContainerColor,
+        drawerContentColor = drawerContentColor,
+        drawerTonalElevation = drawerTonalElevation,
+        windowInsets = windowInsets,
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(
+    group = "Drawer",
+    name = "ModalDrawerSheet",
+)
+@Composable
+internal fun ModalDrawerSheetPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        PreviewTheme(
+            theme,
+            padding = PaddingValues(0.dp),
+        ) {
+            // icons to mimic drawer destinations
+            val items = listOf(Icons.Default.Favorite, Icons.Default.Face, Icons.Default.Email)
+            val selectedItem = remember { mutableStateOf(items[0]) }
+
+            ModalDrawerSheet {
+                Spacer(Modifier.height(12.dp))
+                items.forEach { item ->
+                    NavigationDrawerItem(
+                        icon = { Icon(item, contentDescription = null) },
+                        label = { Text(item.name) },
+                        selected = item == selectedItem.value,
+                        onClick = {
+                            selectedItem.value = item
+                        },
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
@@ -1,0 +1,157 @@
+package com.adevinta.spark.components.drawer
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Button
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+internal fun SparkModalNavigationDrawer(
+    drawerContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed),
+    gesturesEnabled: Boolean = true,
+    scrimColor: Color = SparkTheme.colors.scrim,
+    content: @Composable () -> Unit,
+) {
+    ModalNavigationDrawer(
+        drawerContent = drawerContent,
+        modifier = modifier,
+        drawerState = drawerState,
+        gesturesEnabled = gesturesEnabled,
+        scrimColor = scrimColor,
+        content = content,
+    )
+}
+
+/**
+ * Spark ModalNavigationDrawer.
+ *
+ * An ModalNavigationDrawer provide ergonomic access to destinations in an app.
+ * Modal navigation drawers block interaction with the rest of an app’s content with a scrim. They are elevated above most of the app’s UI and don’t affect the screen’s layout grid.
+ *
+ * ![ModalNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
+ *
+ * @param drawerContent - content inside this drawer
+ * @param modifier the [Modifier] to be applied to this drawer
+ * @param drawerState - state of the drawer
+ * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
+ * @param scrimColor - color of the scrim that obscures content when the drawer is open
+ * @param content - content of the rest of the UI
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+public fun ModalNavigationDrawer(
+    drawerContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed),
+    gesturesEnabled: Boolean = true,
+    scrimColor: Color = SparkTheme.colors.scrim,
+    content: @Composable () -> Unit,
+) {
+    SparkModalNavigationDrawer(
+        drawerContent = drawerContent,
+        modifier = modifier,
+        drawerState = drawerState,
+        gesturesEnabled = gesturesEnabled,
+        scrimColor = scrimColor,
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(
+    group = "Drawer",
+    name = "ModalNavigationDrawer",
+)
+@Composable
+internal fun ModalNavigationDrawerPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(
+        theme,
+        padding = PaddingValues(0.dp),
+    ) {
+        val drawerState = rememberDrawerState(DrawerValue.Closed)
+        val scope = rememberCoroutineScope()
+        // icons to mimic drawer destinations
+        val items = listOf(Icons.Default.Favorite, Icons.Default.Face, Icons.Default.Email)
+        val selectedItem = remember { mutableStateOf(items[0]) }
+        BackHandler(enabled = drawerState.isOpen) {
+            scope.launch {
+                drawerState.close()
+            }
+        }
+
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            drawerContent = {
+                ModalDrawerSheet {
+                    Spacer(Modifier.height(12.dp))
+                    items.forEach { item ->
+                        NavigationDrawerItem(
+                            icon = { Icon(item, contentDescription = null) },
+                            label = { Text(item.name) },
+                            selected = item == selectedItem.value,
+                            onClick = {
+                                scope.launch { drawerState.close() }
+                                selectedItem.value = item
+                            },
+                            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                        )
+                    }
+                }
+            },
+            content = {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(text = if (drawerState.isClosed) ">>> Swipe >>>" else "<<< Swipe <<<")
+                    Spacer(Modifier.height(20.dp))
+                    Button(onClick = { scope.launch { drawerState.open() } }) {
+                        Text("Click to open")
+                    }
+                }
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.drawer
 
 import androidx.activity.compose.BackHandler
@@ -89,12 +67,12 @@ internal fun SparkModalNavigationDrawer(
  *
  * ![ModalNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
- * @param drawerContent content inside this drawer
+ * @param drawerContent - content inside this drawer
  * @param modifier the [Modifier] to be applied to this drawer
- * @param drawerState state of the drawer
- * @param gesturesEnabled whether or not the drawer can be interacted by gestures
- * @param scrimColor color of the scrim that obscures content when the drawer is open
- * @param content content of the rest of the UI
+ * @param drawerState - state of the drawer
+ * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
+ * @param scrimColor - color of the scrim that obscures content when the drawer is open
+ * @param content - content of the rest of the UI
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.drawer
 
 import androidx.activity.compose.BackHandler
@@ -67,12 +89,12 @@ internal fun SparkModalNavigationDrawer(
  *
  * ![ModalNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
- * @param drawerContent - content inside this drawer
+ * @param drawerContent content inside this drawer
  * @param modifier the [Modifier] to be applied to this drawer
- * @param drawerState - state of the drawer
- * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
- * @param scrimColor - color of the scrim that obscures content when the drawer is open
- * @param content - content of the rest of the UI
+ * @param drawerState state of the drawer
+ * @param gesturesEnabled whether or not the drawer can be interacted by gestures
+ * @param scrimColor color of the scrim that obscures content when the drawer is open
+ * @param content content of the rest of the UI
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.drawer
 
 import androidx.compose.foundation.layout.WindowInsets

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.drawer
 
 import androidx.compose.foundation.layout.WindowInsets

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
@@ -1,0 +1,17 @@
+package com.adevinta.spark.components.drawer
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.DrawerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+public object SparkDrawerDefaults {
+    public val ModalDrawerElevation: Dp = 1.0.dp
+
+    public val windowInsets: WindowInsets
+        @Composable
+        get() = DrawerDefaults.windowInsets
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.icons
 
 import androidx.compose.foundation.BorderStroke

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.icons
 
 import androidx.compose.foundation.BorderStroke

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.icons
 
 import androidx.compose.foundation.BorderStroke

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.icons
 
 import androidx.compose.foundation.BorderStroke

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.icons
 
 import androidx.appcompat.content.res.AppCompatResources

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.icons
 
 import androidx.appcompat.content.res.AppCompatResources

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Illustration.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Illustration.kt
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.image
+
+import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.icons.rememberSparkIconPainter
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import androidx.compose.foundation.Image as FoundationImage
+
+@InternalSparkApi
+@Composable
+internal fun SparkIllustration(
+    data: Any?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+) {
+
+    when (data) {
+        is ImageBitmap -> FoundationImage(
+            bitmap = data,
+            contentDescription = contentDescription,
+            modifier = modifier.sparkUsageOverlay(),
+            alignment = alignment,
+            contentScale = contentScale,
+            alpha = alpha,
+            colorFilter = colorFilter,
+            filterQuality = filterQuality,
+        )
+
+        is ImageVector -> FoundationImage(
+            imageVector = data,
+            contentDescription = contentDescription,
+            modifier = modifier.sparkUsageOverlay(),
+            alignment = alignment,
+            contentScale = contentScale,
+            alpha = alpha,
+            colorFilter = colorFilter,
+        )
+
+        is Painter -> FoundationImage(
+            painter = data,
+            contentDescription = contentDescription,
+            modifier = modifier.sparkUsageOverlay(),
+            alignment = alignment,
+            contentScale = contentScale,
+            alpha = alpha,
+            colorFilter = colorFilter,
+        )
+
+        is SparkIcon -> FoundationImage(
+            painter = rememberSparkIconPainter(data),
+            modifier = modifier.sparkUsageOverlay(),
+            contentDescription = contentDescription,
+            alignment = alignment,
+            contentScale = contentScale,
+            alpha = alpha,
+            colorFilter = colorFilter,
+        )
+    }
+}
+
+/**
+ * A composable that lays out and draws a given [ImageBitmap]. This will attempt to
+ * size the composable according to the [ImageBitmap]'s given width and height. However, an
+ * optional [Modifier] parameter can be provided to adjust sizing or draw additional content (ex.
+ * background). Any unspecified dimension will leverage the [ImageBitmap]'s size as a minimum
+ * constraint.
+ *
+ * The following sample shows basic usage of an Image composable to position and draw an
+ * [ImageBitmap] on screen
+ * @sample androidx.compose.foundation.samples.ImageSample
+ *
+ * @param bitmap The [ImageBitmap] to draw
+ * @param contentDescription text used by accessibility services to describe what this image
+ * represents. This should always be provided unless this image is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content (ex.
+ * background)
+ * @param alignment Optional alignment parameter used to place the [ImageBitmap] in the given
+ * bounds defined by the width and height
+ * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be used
+ * if the bounds are a different size from the intrinsic size of the [ImageBitmap]
+ * @param alpha Optional opacity to be applied to the [ImageBitmap] when it is rendered onscreen
+ * @param colorFilter Optional ColorFilter to apply for the [ImageBitmap] when it is rendered
+ * onscreen
+ * @param filterQuality Sampling algorithm applied to the [bitmap] when it is scaled and drawn
+ * into the destination. The default is [FilterQuality.Low] which scales using a bilinear
+ * sampling algorithm
+ */
+@Composable
+public fun Illustration(
+    bitmap: ImageBitmap,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+) {
+    SparkIllustration(
+        data = bitmap,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        filterQuality = filterQuality,
+    )
+}
+
+/**
+ * A composable that lays out and draws a given [ImageVector]. This will attempt to
+ * size the composable according to the [ImageVector]'s given width and height. However, an
+ * optional [Modifier] parameter can be provided to adjust sizing or draw additional content (ex.
+ * background). Any unspecified dimension will leverage the [ImageVector]'s size as a minimum
+ * constraint.
+ *
+ * @param imageVector The [ImageVector] to draw
+ * @param contentDescription text used by accessibility services to describe what this image
+ * represents. This should always be provided unless this image is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content (ex.
+ * background)
+ * @param alignment Optional alignment parameter used to place the [ImageVector] in the given
+ * bounds defined by the width and height
+ * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be used
+ * if the bounds are a different size from the intrinsic size of the [ImageVector]
+ * @param alpha Optional opacity to be applied to the [ImageVector] when it is rendered onscreen
+ * @param colorFilter Optional ColorFilter to apply for the [ImageVector] when it is rendered
+ * onscreen
+ */
+@Composable
+public fun Illustration(
+    imageVector: ImageVector,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+) {
+    SparkIllustration(
+        data = imageVector,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+    )
+}
+
+/**
+ * Creates a composable that lays out and draws a given [Painter]. This will attempt to size
+ * the composable according to the [Painter]'s intrinsic size. However, an optional [Modifier]
+ * parameter can be provided to adjust sizing or draw additional content (ex. background)
+ *
+ * **NOTE** a Painter might not have an intrinsic size, so if no LayoutModifier is provided
+ * as part of the Modifier chain this might size the [Image] composable to a width and height
+ * of zero and will not draw any content. This can happen for Painter implementations that
+ * always attempt to fill the bounds like [ColorPainter]
+ *
+ * @param painter to draw
+ * @param contentDescription text used by accessibility services to describe what this image
+ * represents. This should always be provided unless this image is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content (ex.
+ * background)
+ * @param alignment Optional alignment parameter used to place the [Painter] in the given
+ * bounds defined by the width and height.
+ * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be used
+ * if the bounds are a different size from the intrinsic size of the [Painter]
+ * @param alpha Optional opacity to be applied to the [Painter] when it is rendered onscreen
+ * the default renders the [Painter] completely opaque
+ * @param colorFilter Optional colorFilter to apply for the [Painter] when it is rendered onscreen
+ */
+@Composable
+public fun Illustration(
+    painter: Painter?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+) {
+    SparkIllustration(
+        data = painter,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+    )
+}
+
+/**
+ * Creates a composable that lays out and draws a given [android.graphics.drawable.Drawable]. This will attempt to size
+ * the composable according to the [android.graphics.drawable.Drawable]'s intrinsic size. However, an
+ * optional [Modifier] parameter can be provided to adjust sizing or draw additional content (ex. background)
+ *
+ * @param drawableRes to draw
+ * @param contentDescription text used by accessibility services to describe what this image
+ * represents. This should always be provided unless this image is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content (ex.
+ * background)
+ * @param alignment Optional alignment parameter used to place the [Painter] in the given
+ * bounds defined by the width and height.
+ * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be used
+ * if the bounds are a different size from the intrinsic size of the [Painter]
+ * @param alpha Optional opacity to be applied to the [Painter] when it is rendered onscreen
+ * the default renders the [Painter] completely opaque
+ * @param colorFilter Optional colorFilter to apply for the [Painter] when it is rendered onscreen
+ */
+@Composable
+public fun Illustration(
+    @DrawableRes drawableRes: Int,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+) {
+    val drawable = AppCompatResources.getDrawable(LocalContext.current, drawableRes)
+    val painter = rememberDrawablePainter(drawable)
+
+    SparkIllustration(
+        data = painter,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+    )
+}
+
+/**
+ * Creates a composable that lays out and draws a given [SparkIcon]. This will attempt to size
+ * the composable according to the [SparkIcon]'s intrinsic size (should be already normalized but some exception may
+ * still exist). However, an optional [Modifier] parameter can be provided to adjust sizing or draw additional
+ * content (ex. background)
+ *
+ * @param sparkIcon to draw
+ * @param contentDescription text used by accessibility services to describe what this image
+ * represents. This should always be provided unless this image is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content (ex.
+ * background)
+ * @param alignment Optional alignment parameter used to place the [Painter] in the given
+ * bounds defined by the width and height.
+ * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be used
+ * if the bounds are a different size from the intrinsic size of the [Painter]
+ * @param alpha Optional opacity to be applied to the [Painter] when it is rendered onscreen
+ * the default renders the [Painter] completely opaque
+ * @param colorFilter Optional colorFilter to apply for the [Painter] when it is rendered onscreen
+ */
+@Composable
+public fun Illustration(
+    sparkIcon: SparkIcon,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+) {
+    SparkIllustration(
+        data = sparkIcon,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+    )
+}
+
+@Preview(
+    group = "Images",
+    name = "Illustration",
+)
+@Composable
+internal fun IllustrationPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(themeVariant = theme) {
+        Illustration(
+            sparkIcon = SparkIcon.User.Store,
+            contentDescription = null,
+            modifier = Modifier.size(100.dp),
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.image
+
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.compose.SubcomposeAsyncImageContent
+import coil.decode.DataSource
+import coil.request.ErrorResult
+import coil.request.ImageRequest
+import coil.request.NullRequestData
+import coil.request.SuccessResult
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.icons.rememberSparkIconPainter
+import com.adevinta.spark.components.placeholder.illustrationPlaceholder
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+@InternalSparkApi
+@Composable
+internal fun SparkImage(
+    model: Any?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    // Useful to preview different states
+    transform: (AsyncImagePainter.State) -> AsyncImagePainter.State = AsyncImagePainter.DefaultTransform,
+    onState: ((State) -> Unit)? = null,
+    emptyIcon: @Composable () -> Unit = { ImageIconState(SparkIcon.Images.NoPhoto) },
+    errorIcon: @Composable () -> Unit = { ImageIconState(SparkIcon.Images.ErrorPhoto) },
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+) {
+
+    SubcomposeAsyncImage(
+        model = model,
+        contentDescription = contentDescription,
+        modifier = modifier.sparkUsageOverlay(),
+        transform = transform,
+        onState = { onState?.invoke(it.asImageState()) },
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        filterQuality = filterQuality,
+    ) {
+
+        when (painter.state) {
+            AsyncImagePainter.State.Empty -> emptyIcon()
+            is AsyncImagePainter.State.Loading -> Spacer(
+                modifier = Modifier.illustrationPlaceholder(
+                    visible = true,
+                    shape = SparkTheme.shapes.none,
+                ),
+            )
+
+            is AsyncImagePainter.State.Error -> {
+                // since model can be anything transformed in to a ImageRequest OR a ImageRequest we need to
+                // handel both cases
+                val requestData = painter.request.data
+                val showEmptyIcon = when {
+                    (requestData is String) -> requestData.isBlank()
+                    requestData == NullRequestData -> true
+                    model == null -> true
+                    else -> false
+                }
+
+                if (showEmptyIcon) emptyIcon()
+                else errorIcon()
+            }
+
+            is AsyncImagePainter.State.Success -> SubcomposeAsyncImageContent()
+        }
+    }
+}
+
+/**
+ * A composable that lays out and draws a given Image. This will attempt to
+ * size the composable according to the Image's given width and height. However, an
+ * optional [Modifier] parameter can be provided to adjust sizing or draw additional content (ex.
+ * background). Any unspecified dimension will leverage the Image's size as a minimum
+ * constraint.
+ *
+ * @param model An object representing the image to be displayed.
+ * This can be a URL, a file, or any other type of object that can be used to identify the image.
+ * @param contentDescription text used by accessibility services to describe what this image
+ * represents. This should always be provided unless this image is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or from the backend
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content (ex.
+ * background)
+ * @param onState A callback function that is called when the state of the image changes.
+ * @param alignment Optional alignment parameter used to place the image in the given
+ * bounds defined by the width and height
+ * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be used
+ * if the bounds are a different size from the intrinsic size of the image
+ * @param alpha Optional opacity to be applied to the image when it is rendered onscreen. Default to 1f.
+ * @param colorFilter Optional ColorFilter to apply for the image when it is rendered
+ * onscreen
+ * @param filterQuality Sampling algorithm applied to the image when it is scaled and drawn
+ * into the destination. The default is [FilterQuality.Low] which scales using a bilinear
+ * sampling algorithm
+ */
+@Composable
+public fun Image(
+    model: Any?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    onState: ((State) -> Unit)? = null,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+) {
+    SparkImage(
+        model = model,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        onState = onState,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        filterQuality = filterQuality,
+    )
+}
+
+@Composable
+private fun ImageIconState(sparkIcon: SparkIcon) {
+    Surface(
+        color = SparkTheme.colors.neutral,
+    ) {
+        Icon(
+            sparkIcon = sparkIcon,
+            contentDescription = null, // The SparkImage handle the content description
+            modifier = Modifier.padding(8.dp),
+        )
+    }
+}
+
+/**
+ * The current state of the [Image].
+ */
+public sealed class State {
+
+    /** The current painter being drawn by [Image]. */
+    public abstract val painter: Painter?
+
+    /** The request has not been started or the request has no data*/
+    public object Empty : State() {
+        override val painter: Painter? get() = null
+    }
+
+    /** The request is in-progress. */
+    public data class Loading(override val painter: Painter?) : State()
+
+    /** The request was successful. */
+    public data class Success(override val painter: Painter) : State()
+
+    /** The request failed due to [ErrorResult.throwable]. */
+    public data class Error(override val painter: Painter?) : State()
+}
+
+private fun AsyncImagePainter.State.asImageState(): State {
+    return when (this) {
+        AsyncImagePainter.State.Empty -> State.Empty
+        is AsyncImagePainter.State.Error -> State.Error(painter)
+        is AsyncImagePainter.State.Loading -> State.Loading(painter)
+        is AsyncImagePainter.State.Success -> State.Success(painter)
+    }
+}
+
+@Preview(
+    group = "Images",
+    name = "Image",
+)
+@Composable
+internal fun ImagePreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(themeVariant = theme) {
+        val painter = rememberSparkIconPainter(sparkIcon = SparkIcon.Criterias.Animaux.Tatouage)
+        val drawable =
+            AppCompatResources.getDrawable(LocalContext.current, SparkIcon.Criterias.Animaux.Tatouage.drawableId)!!
+        val imageRequest = ImageRequest.Builder(LocalContext.current).data(Unit).build()
+
+        Text("Empty")
+
+        SparkImage(
+            model = null,
+            contentDescription = null,
+            modifier = Modifier
+                .size(100.dp)
+                .clip(SparkTheme.shapes.medium),
+            transform = { AsyncImagePainter.State.Empty },
+        )
+
+        Text("Loading")
+
+        SparkImage(
+            model = Unit,
+            contentDescription = null,
+            modifier = Modifier
+                .size(100.dp)
+                .clip(SparkTheme.shapes.medium),
+            transform = { AsyncImagePainter.State.Loading(painter) },
+        )
+
+        Text("Error")
+
+        SparkImage(
+            model = Unit,
+            contentDescription = null,
+            modifier = Modifier
+                .size(100.dp)
+                .clip(SparkTheme.shapes.medium),
+            transform = { AsyncImagePainter.State.Error(painter, ErrorResult(null, imageRequest, Throwable(""))) },
+        )
+
+        Text("Success")
+
+        SparkImage(
+            model = Unit,
+            contentDescription = null,
+            modifier = Modifier
+                .size(100.dp)
+                .clip(SparkTheme.shapes.medium),
+            transform = {
+                AsyncImagePainter.State.Success(
+                    painter,
+                    SuccessResult(drawable, imageRequest, DataSource.DISK),
+                )
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/UserAvatar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/UserAvatar.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.image
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImagePainter
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.LocalIsUserPro
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.R
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+@InternalSparkApi
+@Composable
+internal fun SparkUserAvatar(
+    modifier: Modifier = Modifier,
+    // Useful to preview different states
+    transform: (AsyncImagePainter.State) -> AsyncImagePainter.State = AsyncImagePainter.DefaultTransform,
+    style: UserAvatarStyle = UserAvatarStyle.SMALL,
+    fillParentSize: Boolean = false,
+    model: Any? = null,
+    isPro: Boolean = LocalIsUserPro.current,
+    isOnline: Boolean = false,
+) {
+    val emptyIcon = @Composable {
+        ImageIconState(
+            sparkIcon = if (isPro) SparkIcon.User.Store else SparkIcon.User.Avatar,
+        )
+    }
+    Box(
+        modifier = (if (fillParentSize) modifier.fillMaxSize() else modifier.size(
+            style.imageSize,
+        )).sparkUsageOverlay(),
+    ) {
+        SparkImage(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .clip(SparkTheme.shapes.full)
+                .aspectRatio(1f),
+            model = model,
+            transform = transform,
+            contentDescription = stringResource(id = R.string.spark_user_avatar_content_description),
+            contentScale = ContentScale.Crop,
+            emptyIcon = emptyIcon,
+            errorIcon = emptyIcon,
+        )
+
+        if (isOnline) {
+            PresenceIndicator(
+                modifier = Modifier
+                    .size(style.badgeSize)
+                    .align(Alignment.BottomEnd)
+                    .offset(x = 0.dp, y = style.badgeOffset),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ImageIconState(sparkIcon: SparkIcon) {
+    Surface(
+        color = SparkTheme.colors.neutralContainer,
+    ) {
+        Illustration(
+            sparkIcon = sparkIcon,
+            contentDescription = null, // The SparkImage handle the content description
+        )
+    }
+}
+
+@Composable
+private fun PresenceIndicator(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .border(1.dp, SparkTheme.colors.onSurfaceInverse, CircleShape)
+            .padding(1.dp)
+            .clip(CircleShape)
+            .background(SparkTheme.colors.success),
+    )
+}
+
+@Composable
+public fun UserAvatar(
+    modifier: Modifier = Modifier,
+    style: UserAvatarStyle = UserAvatarStyle.SMALL,
+    fillParentSize: Boolean = false,
+    model: Any? = null,
+    isPro: Boolean = LocalIsUserPro.current,
+    isOnline: Boolean = false,
+) {
+    SparkUserAvatar(
+        modifier = modifier,
+        style = style,
+        fillParentSize = fillParentSize,
+        model = model,
+        isPro = isPro,
+        isOnline = isOnline,
+    )
+}
+
+/**
+ * @param imageSize size of the image in [Dp]
+ * @param badgeSize size of online badge in [Dp]
+ * @param badgeOffset size of the offset of the badge in [Dp]
+ */
+public enum class UserAvatarStyle(public val imageSize: Dp, public val badgeSize: Dp, public val badgeOffset: Dp) {
+    SMALL(imageSize = 32.dp, badgeSize = 9.dp, badgeOffset = (-1).dp),
+    MEDIUM(imageSize = 40.dp, badgeSize = 9.dp, badgeOffset = (-1).dp),
+}
+
+@Preview(
+    group = "Images",
+    name = "User Avatar",
+)
+@Composable
+internal fun UserAvatarPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+
+    PreviewTheme(theme) {
+        SparkUserAvatar(
+            style = UserAvatarStyle.MEDIUM,
+            model = "",
+            isPro = false,
+            isOnline = true,
+            transform = { AsyncImagePainter.State.Empty },
+        )
+        SparkUserAvatar(
+            style = UserAvatarStyle.SMALL,
+            model = "",
+            isPro = false,
+            isOnline = true,
+            transform = { AsyncImagePainter.State.Empty },
+        )
+        SparkUserAvatar(
+            style = UserAvatarStyle.MEDIUM,
+            model = "",
+            isPro = true,
+            isOnline = false,
+            transform = { AsyncImagePainter.State.Empty },
+        )
+        SparkUserAvatar(
+            style = UserAvatarStyle.SMALL,
+            model = "",
+            isPro = true,
+            isOnline = false,
+            transform = { AsyncImagePainter.State.Empty },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItem.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItem.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.list
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+internal fun SparkListItem(
+    headlineText: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    overlineText: (@Composable () -> Unit)? = null,
+    supportingText: (@Composable () -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+    colors: ListItemColors = ListItemDefault.colors(),
+    tonalElevation: Dp = ListItemDefault.Elevation,
+    shadowElevation: Dp = ListItemDefault.Elevation,
+) {
+    ListItem(
+        headlineText = headlineText,
+        modifier = modifier,
+        overlineText = overlineText,
+        supportingText = supportingText,
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+        colors = colors,
+        tonalElevation = tonalElevation,
+        shadowElevation = shadowElevation,
+    )
+}
+
+/**
+ * Spark ListItem.
+ *
+ * A ListItem is a simple list of items
+ *
+ * ![ListItem image](https://developer.android.com/images/reference/androidx/compose/material3/lists.png)
+ *
+ * @param headlineText the headline text of the list item
+ * @param modifier the [Modifier] to be applied to the list item
+ * @param overlineText the text displayed above the headline text
+ * @param supportingText the supporting text of the list item
+ * @param leadingContent the leading supporting visual of the list item
+ * @param trailingContent the trailing meta text, icon, switch or checkbox
+ * @param colors ListItemColors that will be used to resolve the background and content color for this list item in different states. See ListItemDefaults.colors
+ * @param tonalElevation the tonal elevation of this list item
+ * @param shadowElevation the shadow elevation of this list item
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+public fun ListItem(
+    headlineText: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    overlineText: (@Composable () -> Unit)? = null,
+    supportingText: (@Composable () -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+    colors: ListItemColors = ListItemDefault.colors(),
+    tonalElevation: Dp = ListItemDefault.Elevation,
+    shadowElevation: Dp = ListItemDefault.Elevation,
+) {
+    SparkListItem(
+        headlineText = headlineText,
+        modifier = modifier,
+        overlineText = overlineText,
+        supportingText = supportingText,
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+        colors = colors,
+        tonalElevation = tonalElevation,
+        shadowElevation = shadowElevation,
+    )
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(
+    group = "List",
+    name = "ListItem",
+)
+@Composable
+internal fun ListItemPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        ListItem(
+            headlineText = {
+                Text(text = "Headline text")
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItemDefault.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItemDefault.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.list
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+
+
+public object ListItemDefault {
+    private const val ListItemDisabledLabelTextOpacity = 0.3f
+    private const val ListItemDisabledLeadingIconOpacity = 0.38f
+    private const val ListItemDisabledTrailingIconOpacity = 0.38f
+
+    public val Elevation: Dp = 0.0.dp
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    public fun colors(): ListItemColors = ListItemDefaults.colors(
+        containerColor = SparkTheme.colors.surface,
+        headlineColor = SparkTheme.colors.onSurface,
+        leadingIconColor = SparkTheme.colors.neutral,
+        overlineColor = SparkTheme.colors.neutral,
+        supportingColor = SparkTheme.colors.neutral,
+        trailingIconColor = SparkTheme.colors.neutral,
+        disabledHeadlineColor = SparkTheme.colors.onSurface.copy(alpha = ListItemDisabledLabelTextOpacity),
+        disabledLeadingIconColor = SparkTheme.colors.onSurface.copy(alpha = ListItemDisabledLeadingIconOpacity),
+        disabledTrailingIconColor = SparkTheme.colors.onSurface.copy(alpha = ListItemDisabledTrailingIconOpacity),
+    )
+
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.menu
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Email
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.MenuItemColors
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.divider.Divider
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.icons.IconButton
+import com.adevinta.spark.tools.preview.SparkPreviewParam
+import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import androidx.compose.material3.DropdownMenu as MaterialDropdownMenu
+import androidx.compose.material3.DropdownMenuItem as MaterialDropdownMenuItem
+
+/**
+ * <a href="https://m3.material.io/components/menus/overview" class="external" target="_blank">Material Design dropdown menu</a>.
+ *
+ * Menus display a list of choices on a temporary surface. They appear when users interact with a
+ * button, action, or other control.
+ *
+ * ![Dropdown menu image](https://developer.android.com/images/reference/androidx/compose/material3/menu.png)
+ *
+ * A [DropdownMenu] behaves similarly to a [Popup], and will use the position of the parent layout
+ * to position itself on screen. Commonly a [DropdownMenu] will be placed in a [Box] with a sibling
+ * that will be used as the 'anchor'. Note that a [DropdownMenu] by itself will not take up any
+ * space in a layout, as the menu is displayed in a separate window, on top of other content.
+ *
+ * The [content] of a [DropdownMenu] will typically be [DropdownMenuItem]s, as well as custom
+ * content. Using [DropdownMenuItem]s will result in a menu that matches the Material
+ * specification for menus. Also note that the [content] is placed inside a scrollable [Column],
+ * so using a [LazyColumn] as the root layout inside [content] is unsupported.
+ *
+ * [onDismissRequest] will be called when the menu should close for example when there is a
+ * tap outside the menu, or when the back key is pressed.
+ *
+ * [DropdownMenu] changes its positioning depending on the available space, always trying to be
+ * fully visible. It will try to expand horizontally, depending on layout direction, to the end of
+ * its parent, then to the start of its parent, and then screen end-aligned. Vertically, it will
+ * try to expand to the bottom of its parent, then from the top of its parent, and then screen
+ * top-aligned. An [offset] can be provided to adjust the positioning of the menu for cases when
+ * the layout bounds of its parent do not coincide with its visual bounds. Note the offset will
+ * be applied in the direction in which the menu will decide to expand.
+ *
+ * Example usage:
+ * @sample androidx.compose.material3.samples.MenuSample
+ *
+ * @param expanded whether the menu is expanded or not
+ * @param onDismissRequest called when the user requests to dismiss the menu, such as by tapping
+ * outside the menu's bounds
+ * @param offset [DpOffset] to be added to the position of the menu
+ */
+@Composable
+public fun DropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    offset: DpOffset = DpOffset(0.dp, 0.dp),
+    properties: PopupProperties = PopupProperties(focusable = true),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    MaterialDropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        offset = offset,
+        properties = properties,
+        content = content,
+    )
+}
+
+/**
+ * <a href="https://m3.material.io/components/menus/overview" class="external" target="_blank">Material Design dropdown menu</a> item.
+ *
+ * Menus display a list of choices on a temporary surface. They appear when users interact with a
+ * button, action, or other control.
+ *
+ * ![Dropdown menu image](https://developer.android.com/images/reference/androidx/compose/material3/menu.png)
+ *
+ * Example usage:
+ * @sample androidx.compose.material3.samples.MenuSample
+ *
+ * @param text text of the menu item
+ * @param onClick called when this menu item is clicked
+ * @param modifier the [Modifier] to be applied to this menu item
+ * @param leadingIcon optional leading icon to be displayed at the beginning of the item's text
+ * @param trailingIcon optional trailing icon to be displayed at the end of the item's text. This
+ * trailing icon slot can also accept [Text] to indicate a keyboard shortcut.
+ * @param enabled controls the enabled state of this menu item. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param colors [MenuItemColors] that will be used to resolve the colors used for this menu item in
+ * different states. See [MenuDefaults.itemColors].
+ * @param contentPadding the padding applied to the content of this menu item
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this menu item. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this menu item in different states.
+ */
+@Composable
+public fun DropdownMenuItem(
+    text: @Composable () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
+    colors: MenuItemColors = MenuDefaults.itemColors(),
+    contentPadding: PaddingValues = MenuDefaults.DropdownMenuItemContentPadding,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialDropdownMenuItem(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        enabled = enabled,
+        colors = colors,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "Menu",
+    name = "DropdownMenu",
+)
+@Composable
+internal fun DropdownMenuPreview(
+    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+) {
+    val (theme, userType) = param
+    PreviewTheme(
+        themeVariant = theme,
+        userType = userType,
+    ) {
+        var expanded by remember { mutableStateOf(true) }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .wrapContentSize(Alignment.Center),
+        ) {
+            IconButton(onClick = { expanded = true }) {
+                Icon(Icons.Default.MoreVert, contentDescription = "Localized description")
+            }
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text("Edit") },
+                    onClick = { /* Handle edit! */ },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Outlined.Edit,
+                            contentDescription = null,
+                        )
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Settings") },
+                    onClick = { /* Handle settings! */ },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Outlined.Settings,
+                            contentDescription = null,
+                        )
+                    },
+                )
+                Divider()
+                DropdownMenuItem(
+                    text = { Text("Send Feedback") },
+                    onClick = { /* Handle send feedback! */ },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Outlined.Email,
+                            contentDescription = null,
+                        )
+                    },
+                    trailingIcon = { Text("F11", textAlign = TextAlign.Center) },
+                )
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationDrawerItem.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationDrawerItem.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.navigation
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.DismissibleNavigationDrawer
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.PermanentNavigationDrawer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.badge.Badge
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.NavigationDrawerItem as MaterialNavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemColors as MaterialNavigationDrawerItemColors
+import androidx.compose.material3.NavigationDrawerItemDefaults as MaterialNavigationDrawerItemDefaults
+
+@OptIn(ExperimentalMaterial3Api::class)
+@InternalSparkApi
+@Composable
+internal fun SparkNavigationDrawerItem(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: SparkIcon? = null,
+    badge: (@Composable () -> Unit)? = null,
+    shape: Shape = SparkTheme.shapes.full,
+    colors: MaterialNavigationDrawerItemColors = NavigationDrawerItemDefaults.colors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialNavigationDrawerItem(
+        label = {
+            Text(
+                text = label,
+                style = SparkTheme.typography.extraSmall,
+            )
+        },
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier,
+        icon = {
+            icon?.let { Icon(sparkIcon = it, contentDescription = null, modifier = Modifier.size(16.dp)) }
+        },
+        badge = badge,
+        shape = shape,
+        colors = colors,
+        interactionSource = interactionSource,
+    )
+}
+
+/**
+ * Spark navigation drawer item.
+ *
+ * A [NavigationDrawerItem] represents a destination within drawers, either [ModalNavigationDrawer],
+ * [PermanentNavigationDrawer] or [DismissibleNavigationDrawer].
+ *
+ * @param label text label for this item
+ * @param selected whether this item is selected
+ * @param onClick called when this item is clicked
+ * @param modifier the [Modifier] to be applied to this item
+ * @param icon optional icon for this item, typically an [Icon]
+ * @param badge optional badge to show on this item from the end side
+ * item in different states. See [NavigationDrawerItemDefaults.colors].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this item. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this item in different states.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+public fun NavigationDrawerItem(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: SparkIcon? = null,
+    badge: (@Composable () -> Unit)? = null,
+    shape: Shape = SparkTheme.shapes.full,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    SparkNavigationDrawerItem(
+        label = label,
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier,
+        icon = icon,
+        badge = badge,
+        shape = shape,
+        interactionSource = interactionSource,
+    )
+}
+
+private object NavigationDrawerItemDefaults {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun colors(
+        selectedContainerColor: Color = SparkTheme.colors.secondaryContainer,
+        unselectedContainerColor: Color = SparkTheme.colors.surface,
+        selectedIconColor: Color = SparkTheme.colors.onSecondaryContainer,
+        unselectedIconColor: Color = SparkTheme.colors.neutral,
+        selectedTextColor: Color = SparkTheme.colors.onSecondaryContainer,
+        unselectedTextColor: Color = SparkTheme.colors.neutral,
+        selectedBadgeColor: Color = selectedTextColor,
+        unselectedBadgeColor: Color = unselectedTextColor,
+    ): MaterialNavigationDrawerItemColors = MaterialNavigationDrawerItemDefaults.colors(
+        selectedContainerColor = selectedContainerColor,
+        unselectedContainerColor = unselectedContainerColor,
+        selectedIconColor = selectedIconColor,
+        unselectedIconColor = unselectedIconColor,
+        selectedTextColor = selectedTextColor,
+        unselectedTextColor = unselectedTextColor,
+        selectedBadgeColor = selectedBadgeColor,
+        unselectedBadgeColor = unselectedBadgeColor,
+    )
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(
+    group = "NavigationDrawerItem",
+    name = "NavigationDrawerItem",
+)
+@Composable
+internal fun NavigationDrawerItemPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        val items = mutableListOf(
+            Pair("Home", SparkIcon.Account.House),
+            Pair("Favourite", SparkIcon.Actions.Favorite.Outlined),
+            Pair("Account", SparkIcon.User.Default),
+        )
+        items.forEachIndexed { index, tab ->
+            NavigationDrawerItem(
+                selected = index == 0,
+                onClick = { },
+                label = tab.first,
+                icon = tab.second,
+                badge = { Badge { Text("1") } },
+            )
+        }
+        NavigationDrawerItem(
+            selected = false,
+            onClick = { },
+            label = "Search",
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRail.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRail.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.navigation
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.NavigationRailDefaults
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.NavigationRail as MaterialNavigationRail
+
+@InternalSparkApi
+@Composable
+internal fun SparkNavigationRail(
+    modifier: Modifier = Modifier,
+    containerColor: Color = SparkTheme.colors.surface,
+    contentColor: Color = contentColorFor(containerColor),
+    header: @Composable (ColumnScope.() -> Unit)? = null,
+    windowInsets: WindowInsets = NavigationRailDefaults.windowInsets,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    MaterialNavigationRail(
+        modifier = modifier,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        header = header,
+        windowInsets = windowInsets,
+        content = content,
+    )
+}
+
+/**
+ * Spark bottom navigation rail.
+ * Navigation rails provide access to primary destinations in apps when using tablet and desktop screens.
+ *
+ * The navigation rail should be used to display three to seven app destinations and, optionally,
+ * a FloatingActionButton or a logo header.
+ * NavigationRail should contain multiple NavigationRailItems, each representing a singular destination.
+ * @param modifier commentCountthe Modifier to be applied to this navigation rail
+ * @param header commentCountoptional header that may hold a FloatingActionButton or a logo
+ * @param content commentCountthe content of this navigation rail, typically 3-7 NavigationRailItems
+ */
+@ExperimentalSparkApi
+@Composable
+public fun NavigationRail(
+    modifier: Modifier = Modifier,
+    header: @Composable (ColumnScope.() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    SparkNavigationRail(
+        modifier = modifier,
+        header = header,
+        content = content,
+    )
+}
+
+
+@Preview(
+    group = "NavigationRail",
+    name = "NavigationRail",
+)
+@Composable
+internal fun NavigationRailPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        val items = mutableListOf(
+            Pair("Home", SparkIcon.Account.House),
+            Pair("Search", SparkIcon.Actions.Search),
+            Pair(null, SparkIcon.User.Default),
+        )
+        NavigationRail {
+            items.forEach {
+                NavigationRailItem(selected = true, onClick = { }, icon = it.second, label = it.first)
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRailItem.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRailItem.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.navigation
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItemColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.NavigationRailItem as MaterialNavigationRailItem
+import androidx.compose.material3.NavigationRailItemDefaults as MaterialNavigationRailItemDefaults
+
+@InternalSparkApi
+@Composable
+internal fun SparkNavigationRailItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: SparkIcon,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    label: String? = null,
+    alwaysShowLabel: Boolean = true,
+    colors: NavigationRailItemColors = NavigationRailItemDefaults.colors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    MaterialNavigationRailItem(
+        selected = selected,
+        onClick = onClick,
+        icon = {
+            Icon(sparkIcon = icon, contentDescription = null, modifier = Modifier.size(16.dp))
+        },
+        modifier = modifier,
+        enabled = enabled,
+        label = label?.let {
+            { Text(text = it, style = SparkTheme.typography.smallImportant) }
+        },
+        alwaysShowLabel = alwaysShowLabel,
+        colors = colors,
+        interactionSource = interactionSource,
+    )
+}
+
+/**
+ * Spark navigation rail item.
+ *
+ * A [NavigationRailItem] represents a destination within a [NavigationRail].
+ *
+ * Navigation rails provide access to primary destinations in apps when using tablet and desktop
+ * screens.
+ *
+ * The text label is always shown (if it exists) when selected. Showing text labels if not selected
+ * is controlled by [alwaysShowLabel].
+ *
+ * @param selected whether this item is selected
+ * @param onClick called when this item is clicked
+ * @param icon icon for this item, typically an [Icon]
+ * @param modifier the [Modifier] to be applied to this item
+ * @param enabled controls the enabled state of this item. When `false`, this component will not
+ * respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param label optional text label for this item
+ * @param alwaysShowLabel whether to always show the label for this item. If false, the label will
+ * only be shown when this item is selected.
+ * @param colors [NavigationRailItemColors] that will be used to resolve the colors used for this
+ * item in different states. See [NavigationRailItemDefaults.colors].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this item. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this item in different states.
+ */
+@ExperimentalSparkApi
+@Composable
+public fun NavigationRailItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: SparkIcon,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    label: String? = null,
+    alwaysShowLabel: Boolean = true,
+    colors: NavigationRailItemColors = NavigationRailItemDefaults.colors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    SparkNavigationRailItem(
+        selected = selected,
+        onClick = onClick,
+        icon = icon,
+        modifier = modifier,
+        enabled = enabled,
+        label = label,
+        alwaysShowLabel = alwaysShowLabel,
+        colors = colors,
+        interactionSource = interactionSource,
+    )
+}
+
+public object NavigationRailItemDefaults {
+    @Composable
+    public fun colors(
+        selectedIconColor: Color = SparkTheme.colors.onSecondaryContainer,
+        selectedTextColor: Color = SparkTheme.colors.onSurface,
+        indicatorColor: Color = SparkTheme.colors.secondaryContainer,
+        unselectedIconColor: Color = SparkTheme.colors.neutral,
+        unselectedTextColor: Color = SparkTheme.colors.neutral,
+    ): NavigationRailItemColors = MaterialNavigationRailItemDefaults.colors(
+        selectedIconColor = selectedIconColor,
+        selectedTextColor = selectedTextColor,
+        indicatorColor = indicatorColor,
+        unselectedIconColor = unselectedIconColor,
+        unselectedTextColor = unselectedTextColor,
+    )
+}
+
+@Preview(
+    group = "NavigationRailItem",
+    name = "NavigationRailItem",
+)
+@Composable
+internal fun NavigationRailItemPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        val items = mutableListOf(
+            Pair("Home", SparkIcon.Account.House),
+            Pair("Search", SparkIcon.Actions.Search),
+            Pair("Account", SparkIcon.User.Default),
+        )
+        items.forEach {
+            NavigationRailItem(selected = true, onClick = { }, icon = it.second, label = it.first)
+            NavigationRailItem(selected = true, onClick = { }, icon = it.second, label = null)
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentDrawerSheet.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.navigation
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.DrawerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.PermanentDrawerSheet as MaterialPermanentDrawerSheet
+
+@OptIn(ExperimentalMaterial3Api::class)
+@InternalSparkApi
+@Composable
+internal fun SparkPermanentDrawerSheet(
+    modifier: Modifier = Modifier,
+    drawerShape: Shape = RectangleShape,
+    drawerContainerColor: Color = SparkTheme.colors.surface,
+    drawerContentColor: Color = contentColorFor(drawerContainerColor),
+    drawerTonalElevation: Dp = 1.dp,
+    windowInsets: WindowInsets = DrawerDefaults.windowInsets,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    MaterialPermanentDrawerSheet(
+        modifier = modifier,
+        drawerShape = drawerShape,
+        drawerContainerColor = drawerContainerColor,
+        drawerContentColor = drawerContentColor,
+        drawerTonalElevation = drawerTonalElevation,
+        windowInsets = windowInsets,
+        content = content,
+    )
+}
+
+/**
+ * Content inside of a permanent navigation drawer.
+ * @param modifier commentCountthe Modifier to be applied to this drawer's content
+ * @param drawerContainerColor commentCountthe color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor commentCountthe preferred color for content inside this drawer. Defaults to either the matching content color
+ * for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param content commentCountcontent inside a permanent navigation drawer
+ */
+@ExperimentalSparkApi
+@Composable
+public fun PermanentDrawerSheet(
+    modifier: Modifier = Modifier,
+    drawerContainerColor: Color = SparkTheme.colors.surface,
+    drawerContentColor: Color = contentColorFor(drawerContainerColor),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    SparkPermanentDrawerSheet(
+        modifier = modifier,
+        drawerContainerColor = drawerContainerColor,
+        drawerContentColor = drawerContentColor,
+        content = content,
+    )
+}
+
+
+@Preview(
+    group = "PermanentDrawerSheet",
+    name = "PermanentDrawerSheet",
+)
+@Composable
+internal fun PermanentDrawerSheetPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(
+        theme,
+        padding = PaddingValues(0.dp),
+    ) {
+        // icons to mimic drawer destinations
+        val items = listOf(SparkIcon.Account.Activity, SparkIcon.Account.Identity, SparkIcon.Account.Store)
+        val selectedItem = remember { mutableStateOf(items[0]) }
+        PermanentDrawerSheet(Modifier.width(240.dp)) {
+            Spacer(Modifier.height(12.dp))
+            items.forEach { item ->
+                NavigationDrawerItem(
+                    icon = item,
+                    label = "Item",
+                    selected = item == selectedItem.value,
+                    onClick = {
+                        selectedItem.value = item
+                    },
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                )
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentNavigationDrawer.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.navigation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.PermanentNavigationDrawer as MaterialPermanentNavigationDrawer
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SparkPermanentNavigationDrawer(
+    drawerContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    MaterialPermanentNavigationDrawer(
+        drawerContent = drawerContent,
+        modifier = modifier,
+        content = content,
+    )
+}
+
+/**
+ * Spark navigation permanent drawer.
+ * Navigation drawers provide ergonomic access to destinations in an app.
+ * They’re often next to app content and affect the screen’s layout grid.
+ *
+ * The permanent navigation drawer is always visible and usually used for frequently switching destinations.
+ * On mobile screens, use ModalNavigationDrawer instead.
+ *
+ * @param drawerContent commentCountcontent inside this drawer
+ * @param modifier commentCountthe Modifier to be applied to this drawer
+ * @param content commentCountcontent of the rest of the UI
+ */
+@ExperimentalSparkApi
+@Composable
+public fun PermanentNavigationDrawer(
+    drawerContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    SparkPermanentNavigationDrawer(
+        drawerContent = drawerContent,
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@Preview(
+    group = "PermanentNavigationDrawer",
+    name = "PermanentNavigationDrawer",
+)
+@Composable
+internal fun PermanentNavigationDrawerPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(
+        theme,
+        padding = PaddingValues(0.dp),
+    ) {
+        // icons to mimic drawer destinations
+        val items = listOf(SparkIcon.Account.Activity, SparkIcon.Account.Identity, SparkIcon.Account.Store)
+        val selectedItem = remember { mutableStateOf(items[0]) }
+        PermanentNavigationDrawer(
+            drawerContent = {
+                PermanentDrawerSheet(Modifier.width(240.dp)) {
+                    Spacer(Modifier.height(12.dp))
+                    items.forEach { item ->
+                        NavigationDrawerItem(
+                            icon = item,
+                            label = "Item",
+                            selected = item == selectedItem.value,
+                            onClick = {
+                                selectedItem.value = item
+                            },
+                            modifier = Modifier.padding(horizontal = 12.dp),
+                        )
+                    }
+                }
+            },
+            content = {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(text = "Application content")
+                }
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/UpNavigationIcon.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/UpNavigationIcon.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.navigation
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.R
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+
+@Composable
+public fun UpNavigationIcon(
+    modifier: Modifier = Modifier,
+    contentDescription: String = stringResource(id = R.string.spark_back_arrow_content_description),
+    onClick: () -> Unit,
+) {
+    IconButton(
+        modifier = modifier.sparkUsageOverlay(),
+        onClick = onClick,
+    ) {
+        Icon(
+            modifier = Modifier.size(16.dp),
+            sparkIcon = SparkIcon.Arrows.Arrow.Left,
+            contentDescription = contentDescription,
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
@@ -45,7 +45,7 @@ import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
 
 /**
  * Component that displays rating of an user with stars in the following form:
- *  - ***** (5)
+ *  commentCount***** (5)
  *  - ***** 5 avis
  * @param value rating value as a float, should be between 1.0 and 5.0
  * @param contentDescription description indicate wha is the rating and how many comments are associated with it

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
@@ -45,7 +45,7 @@ import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
 
 /**
  * Component that displays rating of an user with stars in the following form:
- *  commentCount***** (5)
+ *  - ***** (5)
  *  - ***** 5 avis
  * @param value rating value as a float, should be between 1.0 and 5.0
  * @param contentDescription description indicate wha is the rating and how many comments are associated with it

--- a/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.adevinta.spark.components.scaffold
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumedWindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.appbar.TopAppBar
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.icons.IconButton
+import com.adevinta.spark.tokens.contentColorFor
+import com.adevinta.spark.tools.preview.SparkPreviewParam
+import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import androidx.compose.material3.Scaffold as MaterialScaffold
+
+/**
+ * <a href="https://material.io/design/layout/understanding-layout.html" class="external" target="_blank">Material Design layout</a>.
+ *
+ * Scaffold implements the basic material design visual layout structure.
+ *
+ * This component provides API to put together several material components to construct your
+ * screen, by ensuring proper layout strategy for them and collecting necessary data so these
+ * components will work together correctly.
+ *
+ * Simple example of a Scaffold with [TopAppBar], [FloatingActionButton]:
+ *
+ * @sample androidx.compose.material3.samples.SimpleScaffoldWithTopBar
+ *
+ * To show a [Snackbar], use [SnackbarHostState.showSnackbar].
+ *
+ * @sample androidx.compose.material3.samples.ScaffoldWithSimpleSnackbar
+ *
+ * @param modifier the [Modifier] to be applied to this scaffold
+ * @param topBar top app bar of the screen, typically a [TopAppBar]
+ * @param bottomBar bottom bar of the screen, typically a [NavigationBar]
+ * @param snackbarHost component to host [Snackbar]s that are pushed to be shown via
+ * [SnackbarHostState.showSnackbar], typically a [SnackbarHost]
+ * @param floatingActionButton Main action button of the screen, typically a [FloatingActionButton]
+ * @param floatingActionButtonPosition position of the FAB on the screen. See [FabPosition].
+ * @param containerColor the color used for the background of this scaffold. Use [Color.Transparent]
+ * to have no color.
+ * @param contentColor the preferred color for content inside this scaffold. Defaults to either the
+ * matching content color for [containerColor], or to the current [LocalContentColor] if
+ * [containerColor] is not a color from the theme.
+ * @param contentWindowInsets window insets to be passed to [content] slot via [PaddingValues]
+ * params. Scaffold will take the insets into account from the top/bottom only if the [topBar]/
+ * [bottomBar] are not present, as the scaffold expect [topBar]/[bottomBar] to handle insets
+ * instead
+ * @param content content of the screen. The lambda receives a [PaddingValues] that should be
+ * applied to the content root via [Modifier.padding] and [Modifier.consumeWindowInsets] to
+ * properly offset top and bottom bars. If using [Modifier.verticalScroll], apply this modifier to
+ * the child of the scroll, and not on the scroll itself.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+public fun Scaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    floatingActionButton: @Composable () -> Unit = {},
+    floatingActionButtonPosition: FabPosition = FabPosition.End,
+    containerColor: Color = SparkTheme.colors.background,
+    contentColor: Color = contentColorFor(containerColor),
+    contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    MaterialScaffold(
+        modifier = modifier,
+        topBar = topBar,
+        bottomBar = bottomBar,
+        snackbarHost = snackbarHost,
+        floatingActionButton = floatingActionButton,
+        floatingActionButtonPosition = floatingActionButtonPosition,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        contentWindowInsets = contentWindowInsets,
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@Preview(
+    group = "Scaffolds",
+    name = "Scaffold",
+)
+@Composable
+private fun ScaffoldPreview(
+    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+) {
+    val (theme, userType) = param
+    PreviewTheme(
+        themeVariant = theme,
+        userType = userType,
+        padding = PaddingValues(0.dp),
+    ) {
+        val colors = listOf(
+            Color(0xFFffd7d7.toInt()),
+            Color(0xFFffe9d6.toInt()),
+            Color(0xFFfffbd0.toInt()),
+            Color(0xFFe3ffd9.toInt()),
+            Color(0xFFd0fff8.toInt()),
+        )
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Simple Scaffold Screen") },
+                    navigationIcon = {
+                        IconButton(
+                            onClick = { /* "Open nav drawer" */ },
+                        ) {
+                            Icon(Icons.Filled.Menu, contentDescription = "Localized description")
+                        }
+                    },
+                )
+            },
+            floatingActionButtonPosition = FabPosition.End,
+            floatingActionButton = {
+                ExtendedFloatingActionButton(
+                    onClick = { /* fab click handler */ },
+                ) {
+                    Text("Inc")
+                }
+            },
+            content = { innerPadding ->
+                LazyColumn(
+                    // consume insets as scaffold doesn't do it by default
+                    modifier = Modifier.consumedWindowInsets(innerPadding),
+                    contentPadding = innerPadding,
+                ) {
+                    items(count = 100) {
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .height(50.dp)
+                                .background(colors[it % colors.size]),
+                        )
+                    }
+                }
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/RangeSlider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/RangeSlider.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.slider
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SliderColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.RangeSlider as MaterialRangeSlider
+
+@OptIn(ExperimentalMaterial3Api::class)
+@InternalSparkApi
+@Composable
+internal fun SparkRangeSlider(
+    value: ClosedFloatingPointRange<Float>,
+    onValueChange: (ClosedFloatingPointRange<Float>) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    /*@IntRange(from = 0)*/
+    steps: Int = 0,
+    onValueChangeFinished: (() -> Unit)? = null,
+    colors: SliderColors = SliderDefaults.colors(),
+) {
+    MaterialRangeSlider(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        valueRange = valueRange,
+        steps = steps,
+        onValueChangeFinished = onValueChangeFinished,
+        colors = colors,
+    )
+}
+
+/**
+ * Spark Range slider.
+ * Range Sliders expand upon Slider using the same concepts but allow the user to select 2 values.
+ * The two values are still bounded by the value range but they also cannot cross each other.
+ * Use continuous Range Sliders to allow users to make meaningful selections that don’t require a specific values:
+ * @param value current values of the RangeSlider. If either value is outside of valueRange provided, it will be coerced to this range.
+ * @param onValueChange lambda in which values should be updated
+ * @param modifier modifiers for the Range Slider layout
+ * @param enabled whether or not component is enabled and can we interacted with or not
+ * @param valueRange range of values that Range Slider values can take. Passed value will be coerced to this range
+ * @param steps if greater than 0, specifies the amounts of discrete values, evenly distributed between across the whole value range.
+ * If 0, range slider will behave as a continuous slider and allow to choose any value from the range specified. Must not be negative.
+ * @param onValueChangeFinished lambda to be invoked when value change has ended.
+ * This callback shouldn't be used to update the range slider values (use onValueChange for that),
+ * but rather to know when the user has completed selecting a new value by ending a drag or a click.
+ */
+@ExperimentalSparkApi
+@Composable
+public fun RangeSlider(
+    value: ClosedFloatingPointRange<Float>,
+    onValueChange: (ClosedFloatingPointRange<Float>) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    /*@IntRange(from = 0)*/
+    steps: Int = 0,
+    onValueChangeFinished: (() -> Unit)? = null,
+) {
+    SparkRangeSlider(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        valueRange = valueRange,
+        steps = steps,
+        onValueChangeFinished = onValueChangeFinished,
+    )
+}
+
+@Preview(
+    group = "RangeSlider",
+    name = "RangeSlider",
+)
+@Composable
+internal fun RangeSliderPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        RangeSlider(
+            value = 0.1f..0.5f,
+            onValueChange = {},
+            enabled = true,
+            steps = 3,
+        )
+
+        RangeSlider(
+            value = 0.1f..0.5f,
+            onValueChange = {},
+            enabled = false,
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.slider
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SliderColors
+import androidx.compose.material3.SliderPositions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.Slider as MaterialSlider
+import androidx.compose.material3.SliderDefaults as MaterialSliderDefaults
+
+@OptIn(ExperimentalMaterial3Api::class)
+@InternalSparkApi
+@Composable
+internal fun SparkSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    /*@IntRange(from = 0)*/
+    steps: Int = 0,
+    onValueChangeFinished: (() -> Unit)? = null,
+    colors: SliderColors = SliderDefaults.colors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    thumb: @Composable (SliderPositions) -> Unit = remember(interactionSource, colors, enabled) {
+        {
+            MaterialSliderDefaults.Thumb(
+                interactionSource = interactionSource,
+                colors = colors,
+                enabled = enabled,
+            )
+        }
+    },
+) {
+    MaterialSlider(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        valueRange = valueRange,
+        steps = steps,
+        onValueChangeFinished = onValueChangeFinished,
+        colors = colors,
+        interactionSource = interactionSource,
+        thumb = thumb,
+    )
+}
+
+/**
+ * Spark slider.
+ * Sliders allow users to make selections from a range of values.
+ * Sliders reflect a range of values along a bar, from which users may select a single value.
+ * They are ideal for adjusting settings such as volume, brightness, or applying image filters.
+ *
+ * @param  value current value of the slider. If outside of valueRange provided,
+ * value will be coerced to this range.
+ * @param onValueChange callback in which value should be updated
+ * @param modifier the Modifier to be applied to this slider
+ * @param enabled controls the enabled state of this slider. When false, this component will not respond to user input,
+ * and it will appear visually disabled and disabled to accessibility services.
+ * @param valueRange range of values that this slider can take. The passed value will be coerced to this range.
+ * @param steps if greater than 0, specifies the amount of discrete allowable values, evenly distributed across the whole value range.
+ * If 0, the slider will behave continuously and allow any value from the range specified. Must not be negative.
+ * @param onValueChangeFinished called when value change has ended. This should not be used to update the slider value
+ * (use onValueChange instead), but rather to know when the user has completed selecting a new value by ending a drag or a click.
+ * @param interactionSource the MutableInteractionSource representing the stream of Interactions for this slider.
+ * You can create and pass in your own remembered instance to observe Interactions
+ * and customize the appearance / behavior of this slider in different states.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalSparkApi
+@Composable
+public fun Slider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    /*@IntRange(from = 0)*/
+    steps: Int = 0,
+    onValueChangeFinished: (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    SparkSlider(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        valueRange = valueRange,
+        steps = steps,
+        onValueChangeFinished = onValueChangeFinished,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "Slider",
+    name = "Slider",
+)
+@Composable
+internal fun SliderPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        Slider(
+            value = 1f,
+            onValueChange = {},
+            enabled = true,
+            steps = 3,
+        )
+
+        Slider(
+            value = 0.5f,
+            onValueChange = {},
+            enabled = false,
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/SliderDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/SliderDefaults.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.slider
+
+import androidx.compose.material3.SliderColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import com.adevinta.spark.SparkTheme
+import androidx.compose.material3.SliderDefaults as MaterialSliderDefaults
+
+public object SliderDefaults {
+    private const val TickMarksContainerOpacity = 0.38f
+    private const val DisabledOpacity = 0.38f
+    private const val DisabledInactiveTrackOpacity = 0.12f
+
+    @Composable
+    public fun colors(
+        thumbColor: Color = SparkTheme.colors.primary,
+        activeTrackColor: Color = SparkTheme.colors.primary,
+        activeTickColor: Color = SparkTheme.colors.onPrimary.copy(alpha = TickMarksContainerOpacity),
+        inactiveTrackColor: Color = SparkTheme.colors.neutralContainer,
+        inactiveTickColor: Color = SparkTheme.colors.onNeutralContainer.copy(alpha = TickMarksContainerOpacity),
+        disabledThumbColor: Color = SparkTheme.colors.onSurface
+            .copy(alpha = DisabledOpacity)
+            .compositeOver(SparkTheme.colors.surface),
+        disabledActiveTrackColor: Color = SparkTheme.colors.onSurface.copy(alpha = DisabledOpacity),
+        disabledActiveTickColor: Color = disabledActiveTrackColor,
+        disabledInactiveTrackColor: Color = SparkTheme.colors.onSurface.copy(alpha = DisabledInactiveTrackOpacity),
+
+        disabledInactiveTickColor: Color = disabledActiveTrackColor,
+    ): SliderColors = MaterialSliderDefaults.colors(
+        thumbColor = thumbColor,
+        activeTrackColor = activeTrackColor,
+        activeTickColor = activeTickColor,
+        inactiveTrackColor = inactiveTrackColor,
+        inactiveTickColor = inactiveTickColor,
+        disabledThumbColor = disabledThumbColor,
+        disabledActiveTrackColor = disabledActiveTrackColor,
+        disabledActiveTickColor = disabledActiveTickColor,
+        disabledInactiveTrackColor = disabledInactiveTrackColor,
+        disabledInactiveTickColor = disabledInactiveTickColor,
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDefaults
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarVisuals
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.buttons.SparkButton
+import com.adevinta.spark.components.buttons.SparkButtonDefaults
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tokens.contentColorFor
+import com.adevinta.spark.tools.modifiers.SlotArea
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import androidx.compose.material3.Snackbar as MaterialSnackBar
+
+@Composable
+@InternalSparkApi
+public fun SparkSnackbar(
+    colors: SnackbarColors,
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable() ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+
+    val contentColor = contentColorFor(backgroundColor = colors.baseColor)
+
+    val actionComposable: (@Composable () -> Unit)? = actionLabel?.let {
+        @Composable {
+            SparkButton(
+                colors = ButtonDefaults.textButtonColors(contentColor = contentColor),
+                onClick = { onActionClick?.invoke() },
+                elevation = null,
+                contentPadding = SparkButtonDefaults.TextButtonContentPadding,
+                content = { Text(it) },
+            )
+        }
+    }
+
+    val titleComposable: (@Composable () -> Unit)? = title?.let {
+        @Composable {
+            Text(
+                text = it,
+                maxLines = 2,
+            )
+        }
+    }
+
+    MaterialSnackBar(
+        modifier = modifier
+            .padding(16.dp)
+            .sparkUsageOverlay(),
+        shape = SparkTheme.shapes.extraSmall,
+        actionOnNewLine = actionOnNewLine,
+        containerColor = colors.baseColor,
+        contentColor = contentColor,
+        action = actionComposable,
+    ) {
+        Column {
+            ProvideTextStyle(value = SparkTheme.typography.bodyImportant) {
+                titleComposable?.invoke()
+                Spacer(Modifier.height(4.dp))
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (title == null) {
+                    icon?.let {
+                        it(Modifier.size(24.dp))
+                        Spacer(Modifier.width(16.dp))
+                    }
+                }
+
+                content()
+            }
+        }
+    }
+}
+
+/**
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ *
+ * Snackbars inform users of a process that an app has performed or will perform. They appear
+ * temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience,
+ * and they don’t require user input to disappear.
+ *
+ * A Snackbar can contain a single action. Because Snackbar disappears automatically, the action
+ * shouldn't be "Dismiss" or "Cancel".
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]
+ *
+ * @param modifier modifiers for the Snackbar layout
+ * @param colors colors used for the background and the content defined in [SnackbarDefaults], can either be
+ * default, error or valid.
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
+ * for action with long action text
+ * @param icon icon to be shown on the start side of the content when there's no title.
+ * @param title title to be shown above the [content], currently the SnackBarHost doesn't handle it so avoid using it
+ * @param actionLabel action to add as an action to the snackbar.
+ * @param onActionClick callback when the action is clicked.
+ * @param content content to show information about a process that an app has performed or will
+ * perform
+ */
+@Composable
+public fun Snackbar(
+    modifier: Modifier = Modifier,
+    colors: SnackbarColors = SnackbarColors.Default,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable (() -> Unit),
+) {
+
+    SparkSnackbar(
+        colors = colors,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+        icon = icon,
+        title = title,
+        actionLabel = actionLabel,
+        onActionClick = onActionClick,
+        content = content,
+    )
+}
+
+@Composable
+public fun Snackbar(
+    data: SnackbarData,
+    modifier: Modifier = Modifier,
+    colors: SnackbarColors = SnackbarColors.Default,
+    actionOnNewLine: Boolean = false,
+) {
+    val visuals = data.visuals
+    val brikkeVisuals = data.visuals as? SnackbarSparkVisuals
+
+    val iconComposable: (@Composable (iconModifier: Modifier) -> Unit)? = brikkeVisuals?.icon?.let { icon ->
+        @Composable {
+            Icon(icon, modifier = it, contentDescription = null)
+        }
+    }
+
+    SparkSnackbar(
+        colors = colors,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+        icon = iconComposable,
+        title = brikkeVisuals?.title,
+        actionLabel = visuals.actionLabel,
+        onActionClick = { data.performAction() },
+    ) { Text(visuals.message) }
+}
+
+public class SnackbarSparkVisuals(
+    override val message: String,
+    public val title: String? = null,
+    public val icon: SparkIcon? = null,
+    public val colors: SnackbarColors = SnackbarColors.Default,
+    override val actionLabel: String? = null,
+    override val withDismissAction: Boolean = false,
+    override val duration: SnackbarDuration = SnackbarDuration.Short,
+) : SnackbarVisuals
+
+private const val StubTitle = "Title"
+private const val StubBodyShort = "Lorem ipsum dolor sit amet"
+private const val StubBody = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lacus dolorsnx -d"
+private const val StubBodyLong = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lacus dolor, " +
+        "pulvinar eu nulla sit amet, iaculis interdum."
+private const val StubAction = "Action"
+
+
+@Preview(
+    group = "Snackbar",
+    name = "Snackbar",
+)
+@Composable
+private fun SnackbarPreview() {
+    PreviewTheme {
+        SparkSnackbar(
+            colors = SnackbarColors.Default,
+            icon = { iconModifier ->
+                SlotArea(
+                    color = LocalContentColor.current,
+                ) {
+                    Icon(SparkIcon.Options.Flash, contentDescription = null, modifier = iconModifier)
+                }
+            },
+            actionLabel = StubAction,
+        ) {
+            SlotArea(color = LocalContentColor.current) {
+                Text(StubBodyShort)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BodySnackbarPreview() {
+    PreviewTheme {
+        Snackbar(colors = SnackbarColors.Default) {
+            Text(StubBodyShort)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BodyLongSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(colors = SnackbarColors.Default) {
+            Text(StubBody, maxLines = 2)
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun BodyActionSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(
+            colors = SnackbarColors.Default,
+            actionLabel = StubAction,
+        ) {
+            Text(StubBodyShort)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BodyIconActionSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(
+            colors = SnackbarColors.Default,
+            icon = { iconModifier ->
+                Icon(SparkIcon.Options.Flash, contentDescription = null, modifier = iconModifier)
+            },
+            actionLabel = StubAction,
+        ) {
+            Text(StubBodyShort)
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun BodyIconSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(
+            colors = SnackbarColors.Default,
+            icon = { iconModifier ->
+                Icon(SparkIcon.Options.Flash, contentDescription = null, modifier = iconModifier)
+            },
+        ) {
+            Text(StubBodyShort)
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun BodyIconActionNewLineSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(
+            colors = SnackbarColors.Default,
+            actionOnNewLine = true,
+            icon = { iconModifier ->
+                Icon(SparkIcon.Options.Flash, contentDescription = null, modifier = iconModifier)
+            },
+            actionLabel = StubAction,
+        ) {
+            Text(StubBody)
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun BodyTitleSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(
+            colors = SnackbarColors.Default,
+            icon = { iconModifier ->
+                Icon(SparkIcon.Options.Flash, contentDescription = null, modifier = iconModifier)
+            },
+            title = StubTitle,
+        ) {
+            Text(StubBodyShort)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BodyLongTitleSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(
+            colors = SnackbarColors.Default,
+            icon = { iconModifier ->
+                Icon(SparkIcon.Options.Flash, contentDescription = null, modifier = iconModifier)
+            },
+            title = StubTitle,
+        ) {
+            Text(StubBody + StubBody)
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun BodyTitleActionSnackbarPreview() {
+    PreviewTheme {
+        Snackbar(
+            colors = SnackbarColors.Default,
+            actionOnNewLine = true,
+            icon = { iconModifier ->
+                Icon(SparkIcon.Options.Flash, contentDescription = null, modifier = iconModifier)
+            },
+            title = StubTitle,
+            actionLabel = StubAction,
+        ) {
+            Text(StubBodyShort)
+        }
+    }
+}
+

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarColors.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarColors.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.adevinta.spark.SparkTheme
+
+public sealed class SnackbarColors {
+
+    @get:Composable
+    public abstract val baseColor: Color
+
+    public object Default : SnackbarColors() {
+        override val baseColor: Color
+            @Composable get() {
+                return SparkTheme.colors.secondaryContainer
+            }
+    }
+
+    public object Error : SnackbarColors() {
+        override val baseColor: Color
+            @Composable get() {
+                return SparkTheme.colors.errorContainer
+            }
+    }
+
+    public object Valid : SnackbarColors() {
+        override val baseColor: Color
+            @Composable get() {
+                return SparkTheme.colors.successContainer
+            }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarDefault.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarDefault.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.material3.SnackbarData
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ *
+ * Snackbars inform users of a process that an app has performed or will perform. They appear
+ * temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience,
+ * and they don’t require user input to disappear.
+ *
+ * A Snackbar can contain a single action. Because Snackbar disappears automatically, the action
+ * shouldn't be "Dismiss" or "Cancel".
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]
+ *
+ * If you want to change dynamically the snackbar color look at [Snackbar].
+ *
+ * @param modifier modifiers for the Snackbar layout
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
+ * for action with long action text
+ * @param icon icon to be shown on the start side of the content when there's no title.
+ * @param title title to be shown above the [content], currently the SnackBarHost doesn't handle it so avoid using it
+ * @param actionLabel action to add as an action to the snackbar.
+ * @param onActionClick callback when the action is clicked.
+ * @param content content to show information about a process that an app has performed or will
+ * perform
+ */
+@Composable
+public fun SnackbarDefault(
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable (() -> Unit),
+) {
+
+    Snackbar(
+        colors = SnackbarColors.Default,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+        icon = icon,
+        title = title,
+        actionLabel = actionLabel,
+        onActionClick = onActionClick,
+        content = content,
+    )
+}
+
+@Composable
+public fun SnackbarDefault(
+    data: SnackbarData,
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+) {
+
+    Snackbar(
+        data = data,
+        colors = SnackbarColors.Default,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarError.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarError.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.material3.SnackbarData
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ *
+ * Snackbars inform users of a process that an app has performed or will perform. They appear
+ * temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience,
+ * and they don’t require user input to disappear.
+ *
+ * A Snackbar can contain a single action. Because Snackbar disappears automatically, the action
+ * shouldn't be "Dismiss" or "Cancel".
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]
+ *
+ * If you want to change dynamically the snackbar color look at [Snackbar].
+ *
+ * @param modifier modifiers for the Snackbar layout
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
+ * for action with long action text
+ * @param icon icon to be shown on the start side of the content when there's no title.
+ * @param title title to be shown above the [content], currently the SnackBarHost doesn't handle it so avoid using it
+ * @param actionLabel action to add as an action to the snackbar.
+ * @param onActionClick callback when the action is clicked.
+ * @param content content to show information about a process that an app has performed or will
+ * perform
+ */
+@Composable
+public fun SnackbarError(
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable (() -> Unit),
+) {
+
+    Snackbar(
+        colors = SnackbarColors.Error,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+        icon = icon,
+        title = title,
+        actionLabel = actionLabel,
+        onActionClick = onActionClick,
+        content = content,
+    )
+}
+
+@Composable
+public fun SnackbarError(
+    data: SnackbarData,
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+) {
+
+    Snackbar(
+        data = data,
+        colors = SnackbarColors.Error,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.SnackbarVisuals
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.currentRecomposeScope
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.AccessibilityManager
+import androidx.compose.ui.platform.LocalAccessibilityManager
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.dismiss
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import com.adevinta.spark.components.snackbars.SnackbarHostState.SnackbarDataSpark
+import com.adevinta.spark.icons.SparkIcon
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.resume
+
+/**
+ * Host for [Snackbar]s to be used in [Scaffold] to properly show, hide and dismiss items based
+ * on Material specification and the [hostState].
+ *
+ * This component with default parameters comes build-in with [Scaffold], if you need to show a
+ * default [Snackbar], use [SnackbarHostState.showSnackbar].
+ *
+ * @sample androidx.compose.material3.samples.ScaffoldWithSimpleSnackbar
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]:
+ *
+ * @sample androidx.compose.material3.samples.ScaffoldWithCustomSnackbar
+ *
+ * @param hostState state of this component to read and show [Snackbar]s accordingly
+ * @param modifier the [Modifier] to be applied to this component
+ * @param snackbar the instance of the [Snackbar] to be shown at the appropriate time with
+ * appearance based on the [SnackbarDataSpark] provided as a param
+ */
+@Composable
+public fun SnackbarHost(
+    hostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    snackbar: @Composable (SnackbarData) -> Unit = { data -> Snackbar(data) },
+) {
+    val currentSnackbarData = hostState.currentSnackbarData
+    val accessibilityManager = LocalAccessibilityManager.current
+    LaunchedEffect(currentSnackbarData) {
+        if (currentSnackbarData != null) {
+            val duration = currentSnackbarData.visuals.duration.toMillis(
+                currentSnackbarData.visuals.actionLabel != null,
+                accessibilityManager,
+            )
+            delay(duration)
+            currentSnackbarData.dismiss()
+        }
+    }
+    FadeInFadeOutWithScale(
+        current = hostState.currentSnackbarData,
+        modifier = modifier,
+        content = snackbar,
+    )
+}
+
+/**
+ * State of the [SnackbarHost], which controls the queue and the current [Snackbar] being shown
+ * inside the [SnackbarHost].
+ *
+ * This state is usually [remember]ed and used to provide a [SnackbarHost] to a [Scaffold].
+ */
+@Stable
+public class SnackbarHostState {
+
+    /**
+     * Only one [Snackbar] can be shown at a time. Since a suspending Mutex is a fair queue, this
+     * manages our message queue and we don't have to maintain one.
+     */
+    private val mutex = Mutex()
+
+    /**
+     * The current [SnackbarDataSpark] being shown by the [SnackbarHost], or `null` if none.
+     */
+    public var currentSnackbarData: SnackbarData? by mutableStateOf<SnackbarData?>(null)
+        private set
+
+    /**
+     * Shows or queues to be shown a [Snackbar] at the bottom of the [Scaffold] to which this state
+     * is attached and suspends until the snackbar has disappeared.
+     *
+     * [SnackbarHostState] guarantees to show at most one snackbar at a time. If this function is
+     * called while another snackbar is already visible, it will be suspended until this snackbar is
+     * shown and subsequently addressed. If the caller is cancelled, the snackbar will be removed
+     * from display and/or the queue to be displayed.
+     *
+     * All of this allows for granular control over the snackbar queue from within:
+     *
+     * @sample androidx.compose.material3.samples.ScaffoldWithCoroutinesSnackbar
+     *
+     * To change the Snackbar appearance, change it in 'snackbarHost' on the [Scaffold].
+     *
+     * @param message text to be shown in the Snackbar
+     * @param actionLabel optional action label to show as button in the Snackbar
+     * @param withDismissAction a boolean to show a dismiss action in the Snackbar. This is
+     * recommended to be set to true for better accessibility when a Snackbar is set with a
+     * [SnackbarDuration.Indefinite]
+     * @param duration duration to control how long snackbar will be shown in [SnackbarHost], either
+     * [SnackbarDuration.Short], [SnackbarDuration.Long] or [SnackbarDuration.Indefinite].
+     *
+     * @return [SnackbarResult.ActionPerformed] if option action has been clicked or
+     * [SnackbarResult.Dismissed] if snackbar has been dismissed via timeout or by the user
+     */
+    @OptIn(ExperimentalMaterial3Api::class)
+    public suspend fun showSnackbar(
+        message: String,
+        actionLabel: String? = null,
+        title: String? = null,
+        icon: SparkIcon? = null,
+        colors: SnackbarColors = SnackbarColors.Default,
+        withDismissAction: Boolean = false,
+        duration: SnackbarDuration =
+            if (actionLabel == null) SnackbarDuration.Short else SnackbarDuration.Indefinite,
+    ): SnackbarResult = showSnackbar(
+        SnackbarSparkVisuals(
+            message = message,
+            title = title,
+            icon = icon,
+            colors = colors,
+            actionLabel = actionLabel,
+            withDismissAction = withDismissAction,
+            duration = duration,
+        ),
+    )
+
+    /**
+     * Shows or queues to be shown a [Snackbar] at the bottom of the [Scaffold] to which this state
+     * is attached and suspends until the snackbar has disappeared.
+     *
+     * [SnackbarHostState] guarantees to show at most one snackbar at a time. If this function is
+     * called while another snackbar is already visible, it will be suspended until this snackbar is
+     * shown and subsequently addressed. If the caller is cancelled, the snackbar will be removed
+     * from display and/or the queue to be displayed.
+     *
+     * All of this allows for granular control over the snackbar queue from within:
+     *
+     * @sample androidx.compose.material3.samples.ScaffoldWithCustomSnackbar
+     *
+     * @param visuals [SnackbarVisuals] that are used to create a Snackbar
+     *
+     * @return [SnackbarResult.ActionPerformed] if option action has been clicked or
+     * [SnackbarResult.Dismissed] if snackbar has been dismissed via timeout or by the user
+     */
+    @ExperimentalMaterial3Api
+    public suspend fun showSnackbar(visuals: SnackbarSparkVisuals): SnackbarResult = mutex.withLock {
+        try {
+            return suspendCancellableCoroutine { continuation ->
+                currentSnackbarData = SnackbarDataSpark(visuals, continuation)
+            }
+        } finally {
+            currentSnackbarData = null
+        }
+    }
+
+    public class SnackbarDataSpark(
+        override val visuals: SnackbarSparkVisuals,
+        private val continuation: CancellableContinuation<SnackbarResult>,
+    ) : SnackbarData {
+
+        override fun performAction() {
+            if (continuation.isActive) continuation.resume(SnackbarResult.ActionPerformed)
+        }
+
+        override fun dismiss() {
+            if (continuation.isActive) continuation.resume(SnackbarResult.Dismissed)
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as SnackbarDataSpark
+
+            if (visuals != other.visuals) return false
+            if (continuation != other.continuation) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = visuals.hashCode()
+            result = 31 * result + continuation.hashCode()
+            return result
+        }
+    }
+}
+
+internal fun SnackbarDuration.toMillis(
+    hasAction: Boolean,
+    accessibilityManager: AccessibilityManager?,
+): Long {
+    val original = when (this) {
+        SnackbarDuration.Indefinite -> Long.MAX_VALUE
+        SnackbarDuration.Long -> 10000L
+        SnackbarDuration.Short -> 4000L
+    }
+    if (accessibilityManager == null) {
+        return original
+    }
+    return accessibilityManager.calculateRecommendedTimeoutMillis(
+        original,
+        containsIcons = true,
+        containsText = true,
+        containsControls = hasAction,
+    )
+}
+
+// TODO: to be replaced with the public customizable implementation
+// it's basically tweaked nullable version of Crossfade
+@Composable
+private fun FadeInFadeOutWithScale(
+    current: SnackbarData?,
+    modifier: Modifier = Modifier,
+    content: @Composable (SnackbarData) -> Unit,
+) {
+    val state = remember { FadeInFadeOutState<SnackbarData?>() }
+    if (current != state.current) {
+        state.current = current
+        val keys = state.items.map { it.key }.toMutableList()
+        if (!keys.contains(current)) {
+            keys.add(current)
+        }
+        state.items.clear()
+        keys.filterNotNull().mapTo(state.items) { key ->
+            FadeInFadeOutAnimationItem(key) { children ->
+                val isVisible = key == current
+                val duration = if (isVisible) SnackbarFadeInMillis else SnackbarFadeOutMillis
+                val delay = SnackbarFadeOutMillis + SnackbarInBetweenDelayMillis
+                val animationDelay = if (isVisible && keys.filterNotNull().size != 1) delay else 0
+                val opacity = animatedOpacity(
+                    animation = tween(
+                        easing = LinearEasing,
+                        delayMillis = animationDelay,
+                        durationMillis = duration,
+                    ),
+                    visible = isVisible,
+                    onAnimationFinish = {
+                        if (key != state.current) {
+                            // leave only the current in the list
+                            state.items.removeAll { it.key == key }
+                            state.scope?.invalidate()
+                        }
+                    },
+                )
+                val scale = animatedScale(
+                    animation = tween(
+                        easing = FastOutSlowInEasing,
+                        delayMillis = animationDelay,
+                        durationMillis = duration,
+                    ),
+                    visible = isVisible,
+                )
+                Box(
+                    Modifier
+                        .graphicsLayer(
+                            scaleX = scale.value,
+                            scaleY = scale.value,
+                            alpha = opacity.value,
+                        )
+                        .semantics {
+                            liveRegion = LiveRegionMode.Polite
+                            dismiss { key.dismiss(); true }
+                        },
+                ) {
+                    children()
+                }
+            }
+        }
+    }
+    Box(modifier) {
+        state.scope = currentRecomposeScope
+        state.items.forEach { (item, opacity) ->
+            key(item) {
+                opacity {
+                    content(item!!)
+                }
+            }
+        }
+    }
+}
+
+private class FadeInFadeOutState<T> {
+    // we use Any here as something which will not be equals to the real initial value
+    var current: Any? = Any()
+    var items = mutableListOf<FadeInFadeOutAnimationItem<T>>()
+    var scope: RecomposeScope? = null
+}
+
+private data class FadeInFadeOutAnimationItem<T>(
+    val key: T,
+    val transition: FadeInFadeOutTransition,
+)
+
+private typealias FadeInFadeOutTransition = @Composable (content: @Composable () -> Unit) -> Unit
+
+@Composable
+private fun animatedOpacity(
+    animation: AnimationSpec<Float>,
+    visible: Boolean,
+    onAnimationFinish: () -> Unit = {},
+): State<Float> {
+    val alpha = remember { Animatable(if (!visible) 1f else 0f) }
+    LaunchedEffect(visible) {
+        alpha.animateTo(
+            if (visible) 1f else 0f,
+            animationSpec = animation,
+        )
+        onAnimationFinish()
+    }
+    return alpha.asState()
+}
+
+@Composable
+private fun animatedScale(animation: AnimationSpec<Float>, visible: Boolean): State<Float> {
+    val scale = remember { Animatable(if (!visible) 1f else 0.8f) }
+    LaunchedEffect(visible) {
+        scale.animateTo(
+            if (visible) 1f else 0.8f,
+            animationSpec = animation,
+        )
+    }
+    return scale.asState()
+}
+
+private const val SnackbarFadeInMillis = 150
+private const val SnackbarFadeOutMillis = 75
+private const val SnackbarInBetweenDelayMillis = 0

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarValid.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarValid.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.material3.SnackbarData
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ *
+ * Snackbars inform users of a process that an app has performed or will perform. They appear
+ * temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience,
+ * and they don’t require user input to disappear.
+ *
+ * A Snackbar can contain a single action. Because Snackbar disappears automatically, the action
+ * shouldn't be "Dismiss" or "Cancel".
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]
+ *
+ * If you want to change dynamically the snackbar color look at [Snackbar].
+ *
+ * @param modifier modifiers for the Snackbar layout
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
+ * for action with long action text
+ * @param icon icon to be shown on the start side of the content when there's no title.
+ * @param title title to be shown above the [content], currently the SnackBarHost doesn't handle it so avoid using it
+ * @param actionLabel action to add as an action to the snackbar.
+ * @param onActionClick callback when the action is clicked.
+ * @param content content to show information about a process that an app has performed or will
+ * perform
+ */
+@Composable
+public fun SnackbarValid(
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable (() -> Unit),
+) {
+
+    Snackbar(
+        colors = SnackbarColors.Valid,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+        icon = icon,
+        title = title,
+        actionLabel = actionLabel,
+        onActionClick = onActionClick,
+        content = content,
+    )
+}
+
+@Composable
+public fun SnackbarValid(
+    data: SnackbarData,
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+) {
+
+    Snackbar(
+        data = data,
+        colors = SnackbarColors.Valid,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/LeadingIconTab.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/LeadingIconTab.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.tab
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.LeadingIconTab as MaterialLeadingIconTab
+
+@InternalSparkApi
+@Composable
+internal fun SparkLeadingIconTab(
+    selected: Boolean,
+    onClick: () -> Unit,
+    text: String,
+    icon: SparkIcon,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    selectedContentColor: Color = LocalContentColor.current,
+    unselectedContentColor: Color = selectedContentColor,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+
+    ) {
+    MaterialLeadingIconTab(
+        selected = selected,
+        onClick = onClick,
+        text = {
+            Text(
+                text = text,
+                style = SparkTheme.typography.smallImportant,
+            )
+        },
+        icon = {
+            Icon(sparkIcon = icon, contentDescription = text, modifier = Modifier.size(16.dp))
+        },
+        modifier = modifier,
+        enabled = enabled,
+        selectedContentColor = selectedContentColor,
+        unselectedContentColor = unselectedContentColor,
+        interactionSource = interactionSource,
+    )
+}
+
+/**
+ * Spark tab.
+ *
+ * Tabs organize content across different screens, data sets, and other interactions.
+ * A LeadingIconTab represents a single page of content using a text label and an icon in front of the label.
+ * It represents its selected state by tinting the text label and icon with selectedContentColor.
+ * This should typically be used inside of a TabRow, see the corresponding documentation for example usage.
+ * @param selected whether this tab is selected or not
+ * @param onClick called when this tab is clicked
+ * @param text the text label displayed in this tab
+ * @ icon the icon displayed in this tab
+ * @param modifier the Modifier to be applied to this tab
+ * @param enabled controls the enabled state of this tab. When false, this component will not respond to user input, and it will appear visually disabled and disabled to accessibility services.
+ * @param interactionSource the MutableInteractionSource representing the stream of Interactions for this tab. You can create and pass in your own remembered instance to observe Interactions and customize the appearance / behavior of this tab in different states.
+ *
+ * See Also: [Tab]
+ */
+@ExperimentalSparkApi
+@Composable
+public fun LeadingIconTab(
+    selected: Boolean,
+    onClick: () -> Unit,
+    text: String,
+    icon: SparkIcon,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+
+    ) {
+    SparkLeadingIconTab(
+        selected = selected,
+        onClick = onClick,
+        text = text,
+        icon = icon,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "Tabs",
+    name = "LeadingIconTab",
+)
+@Composable
+internal fun LeadingIconTabPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        val tabs = mutableListOf(
+            Pair("Home", SparkIcon.Account.House),
+            Pair("Search", SparkIcon.Actions.Search),
+            Pair("Account", SparkIcon.User.Default),
+        )
+        TabRow(
+            selectedTabIndex = 0,
+            tabs = {
+                tabs.forEachIndexed { index, tab ->
+                    LeadingIconTab(
+                        selected = index == 0,
+                        onClick = { },
+                        text = tab.first,
+                        icon = tab.second,
+                        enabled = true,
+                    )
+                }
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/Tab.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/Tab.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.tab
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.Tab as MaterialTab
+
+@ExperimentalSparkApi
+@Composable
+internal fun SparkTab(
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    selectedContentColor: Color = LocalContentColor.current,
+    unselectedContentColor: Color = selectedContentColor,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    MaterialTab(
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        selectedContentColor = selectedContentColor,
+        unselectedContentColor = unselectedContentColor,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+/**
+ * Spark tab.
+ *
+ * Tabs organize content across different screens, data sets, and other interactions.
+ * Generic Tab overload that is not opinionated about content / color.
+ * See the other overload for a Tab that has specific slots for text and / or an icon,
+ * as well as providing the correct colors for selected / unselected states.
+ *
+ * @param selected whether this tab is selected or not
+ * @param onClick called when this tab is clicked
+ * @param modifier the Modifier to be applied to this tab
+ * @param enabled controls the enabled state of this tab. When false, this component will not respond to user input,
+ * and it will appear visually disabled and disabled to accessibility services.
+ * @param interactionSource the MutableInteractionSource representing the stream of Interactions for this tab.
+ * You can create and pass in your own remembered instance to observe Interactions
+ * and customize the appearance / behavior of this tab in different states.
+ * @param content the content of this tab
+ *
+ **/
+@ExperimentalSparkApi
+@Composable
+public fun Tab(
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    SparkTab(
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+
+@Preview(
+    group = "Tabs",
+    name = "Tab",
+)
+@Composable
+internal fun TabPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        Tab(
+            selected = false,
+            onClick = {},
+            enabled = true,
+        ) {
+            Text("Messagerie")
+        }
+
+        Tab(
+            selected = true,
+            onClick = {},
+            enabled = true,
+        ) {
+            Text("Messagerie")
+        }
+
+        Tab(
+            selected = true,
+            onClick = {},
+            enabled = false,
+        ) {
+            Text("Messagerie")
+        }
+
+        Tab(
+            selected = false,
+            onClick = {},
+            enabled = true,
+        ) {
+            Text("Messagerie")
+        }
+    }
+}
+

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRow.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRow.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.tab
+
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabPosition
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.ExperimentalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.components.divider.Divider
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import androidx.compose.material3.ScrollableTabRow as MaterialScrollableTabRow
+import androidx.compose.material3.TabRow as MaterialTabRow
+
+@ExperimentalSparkApi
+@Composable
+internal fun SparkTabRow(
+    selectedTabIndex: Int,
+    modifier: Modifier = Modifier,
+    containerColor: Color = TabRowDefaults.containerColor,
+    contentColor: Color = TabRowDefaults.contentColor,
+    indicator: @Composable (tabPositions: List<TabPosition>) -> Unit = @Composable { tabPositions ->
+        TabRowDefaults.Indicator(
+            Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+        )
+    },
+    divider: @Composable () -> Unit = @Composable { Divider() },
+    tabs: @Composable () -> Unit,
+) {
+    MaterialTabRow(
+        selectedTabIndex = selectedTabIndex,
+        modifier = modifier,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        indicator = indicator,
+        divider = divider,
+        tabs = tabs,
+    )
+}
+
+/**
+ * Material Design fixed tabs.
+ *
+ * Fixed tabs display all tabs in a set simultaneously. They are best for switching between related
+ * content quickly, such as between transportation methods in a map. To navigate between fixed tabs,
+ * tap an individual tab, or swipe left or right in the content area.
+ *
+ * A TabRow contains a row of [Tab]s, and displays an indicator underneath the currently
+ * selected tab. A TabRow places its tabs evenly spaced along the entire row, with each tab
+ * taking up an equal amount of space. See [ScrollableTabRow] for a tab row that does not enforce
+ * equal size, and allows scrolling to tabs that do not fit on screen.
+ *
+ * A simple example with text tabs looks like:
+ *
+ * @sample androidx.compose.material3.samples.TextTabs
+ *
+ * You can also provide your own custom tab, such as:
+ *
+ * @sample androidx.compose.material3.samples.FancyTabs
+ *
+ * Where the custom tab itself could look like:
+ *
+ * @sample androidx.compose.material3.samples.FancyTab
+ *
+ * As well as customizing the tab, you can also provide a custom [indicator], to customize
+ * the indicator displayed for a tab. [indicator] will be placed to fill the entire TabRow, so it
+ * should internally take care of sizing and positioning the indicator to match changes to
+ * [selectedTabIndex].
+ *
+ * For example, given an indicator that draws a rounded rectangle near the edges of the [Tab]:
+ *
+ * @sample androidx.compose.material3.samples.FancyIndicator
+ *
+ * We can reuse [TabRowDefaults.tabIndicatorOffset] and just provide this indicator,
+ * as we aren't changing how the size and position of the indicator changes between tabs:
+ *
+ * @sample androidx.compose.material3.samples.FancyIndicatorTabs
+ *
+ * You may also want to use a custom transition, to allow you to dynamically change the
+ * appearance of the indicator as it animates between tabs, such as changing its color or size.
+ * [indicator] is stacked on top of the entire TabRow, so you just need to provide a custom
+ * transition that animates the offset of the indicator from the start of the TabRow. For
+ * example, take the following example that uses a transition to animate the offset, width, and
+ * color of the same FancyIndicator from before, also adding a physics based 'spring' effect to
+ * the indicator in the direction of motion:
+ *
+ * @sample androidx.compose.material3.samples.FancyAnimatedIndicator
+ *
+ * We can now just pass this indicator directly to TabRow:
+ *
+ * @sample androidx.compose.material3.samples.FancyIndicatorContainerTabs
+ *
+ * @param selectedTabIndex the index of the currently selected tab
+ * @param modifier the [Modifier] to be applied to this tab row
+ * @param tabs the tabs inside this tab row. Typically this will be multiple [Tab]s. Each element
+ * inside this lambda will be measured and placed evenly across the row, each taking up equal space.
+ */
+@ExperimentalSparkApi
+@Composable
+public fun TabRow(
+    selectedTabIndex: Int,
+    modifier: Modifier = Modifier,
+    tabs: @Composable () -> Unit,
+) {
+    SparkTabRow(
+        selectedTabIndex = selectedTabIndex,
+        modifier = modifier,
+        tabs = tabs,
+    )
+}
+
+/**
+ * Material Design scrollable tabs.
+ *
+ * When a set of tabs cannot fit on screen, use scrollable tabs. Scrollable tabs can use longer text
+ * labels and a larger number of tabs. They are best used for browsing on touch interfaces.
+ *
+ * A ScrollableTabRow contains a row of [Tab]s, and displays an indicator underneath the currently
+ * selected tab. A ScrollableTabRow places its tabs offset from the starting edge, and allows
+ * scrolling to tabs that are placed off screen. For a fixed tab row that does not allow
+ * scrolling, and evenly places its tabs, see [TabRow].
+ *
+ * @param selectedTabIndex the index of the currently selected tab
+ * @param modifier the [Modifier] to be applied to this tab row
+ * @param containerColor the color used for the background of this tab row. Use [Color.Transparent]
+ * to have no color.
+ * @param contentColor the preferred color for content inside this tab row. Defaults to either the
+ * matching content color for [containerColor], or to the current [LocalContentColor] if
+ * [containerColor] is not a color from the theme.
+ * @param edgePadding the padding between the starting and ending edge of the scrollable tab row,
+ * and the tabs inside the row. This padding helps inform the user that this tab row can be
+ * scrolled, unlike a [TabRow].
+ * @param indicator the indicator that represents which tab is currently selected. By default this
+ * will be a [TabRowDefaults.Indicator], using a [TabRowDefaults.tabIndicatorOffset] modifier to
+ * animate its position. Note that this indicator will be forced to fill up the entire tab row, so
+ * you should use [TabRowDefaults.tabIndicatorOffset] or similar to animate the actual drawn
+ * indicator inside this space, and provide an offset from the start.
+ * @param divider the divider displayed at the bottom of the tab row. This provides a layer of
+ * separation between the tab row and the content displayed underneath.
+ * @param tabs the tabs inside this tab row. Typically this will be multiple [Tab]s. Each element
+ * inside this lambda will be measured and placed evenly across the row, each taking up equal space.
+ */
+@ExperimentalSparkApi
+@Composable
+public fun ScrollableTabRow(
+    selectedTabIndex: Int,
+    modifier: Modifier = Modifier,
+    containerColor: Color = TabRowDefaults.containerColor,
+    contentColor: Color = TabRowDefaults.contentColor,
+    edgePadding: Dp = ScrollableTabRowPadding,
+    indicator: @Composable (tabPositions: List<TabPosition>) -> Unit = @Composable { tabPositions ->
+        TabRowDefaults.Indicator(
+            Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+        )
+    },
+    divider: @Composable () -> Unit = @Composable {
+        Divider()
+    },
+    tabs: @Composable () -> Unit,
+) {
+    MaterialScrollableTabRow(
+        selectedTabIndex = selectedTabIndex,
+        modifier = modifier,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        edgePadding = edgePadding,
+        indicator = indicator,
+        divider = divider,
+        tabs = tabs,
+    )
+}
+
+/**
+ * The default padding from the starting edge before a tab in a [ScrollableTabRow].
+ */
+private val ScrollableTabRowPadding = 52.dp
+
+@Preview(
+    group = "Tabs",
+    name = "TabRow",
+)
+@Composable
+internal fun TabRowPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    val tabs = mutableListOf("Home", "Search", "Messaging", "Account")
+    var selectedIndex by remember { mutableStateOf(0) }
+    PreviewTheme(theme) {
+        TabRow(
+            selectedTabIndex = 0,
+            tabs = {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedIndex == index,
+                        onClick = { selectedIndex = index },
+                        enabled = true,
+                    ) {
+                        Text(title)
+                    }
+                }
+            },
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRowDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRowDefaults.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.tab
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.TabRow
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+
+public object TabRowDefaults {
+
+    /** Default container color of a tab row. */
+
+    public val containerColor: Color
+        @Composable get() = PrimaryNavigationTabTokens.ContainerColor
+
+
+    /** Default content color of a tab row. */
+    public val contentColor: Color
+        @Composable get() =
+            PrimaryNavigationTabTokens.ActiveLabelTextColor
+
+    /**
+     * Default indicator, which will be positioned at the bottom of the [TabRow], on top of the
+     * divider.
+     *
+     * @param modifier modifier for the indicator's layout
+     * @param height height of the indicator
+     * @param color color of the indicator
+     */
+    @Composable
+    public fun Indicator(
+        modifier: Modifier = Modifier,
+        height: Dp = PrimaryNavigationTabTokens.ActiveIndicatorHeight,
+        color: Color = PrimaryNavigationTabTokens.ActiveIndicatorColor,
+    ) {
+        Box(
+            modifier
+                .fillMaxWidth()
+                .height(height)
+                .background(color = color),
+        )
+    }
+}
+
+internal object PrimaryNavigationTabTokens {
+    val ContainerColor
+        @Composable get() = SparkTheme.colors.surface
+    val ActiveLabelTextColor
+        @Composable get() = SparkTheme.colors.primary
+    val ActiveIndicatorHeight = 3.0.dp
+    val ActiveIndicatorColor
+        @Composable get() = SparkTheme.colors.primary
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/text/Text.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/text/Text.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.text
+
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.Paragraph
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import com.adevinta.spark.InternalSparkApi
+import androidx.compose.material3.Text as MaterialText
+
+@InternalSparkApi
+@Composable
+internal fun SparkText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+) {
+    MaterialText(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}
+
+@InternalSparkApi
+@Composable
+internal fun SparkText(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    inlineContent: Map<String, InlineTextContent> = mapOf(),
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+) {
+    MaterialText(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        inlineContent = inlineContent,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}
+
+/**
+ * High level element that displays text and provides semantics / accessibility information.
+ *
+ * The default [style] uses the [LocalTextStyle] provided by the [MaterialTheme] / components. If
+ * you are setting your own style, you may want to consider first retrieving [LocalTextStyle],
+ * and using [TextStyle.copy] to keep any theme defined attributes, only modifying the specific
+ * attributes you want to override.
+ *
+ * For ease of use, commonly used parameters from [TextStyle] are also present here. The order of
+ * precedence is as follows:
+ * - If a parameter is explicitly set here (i.e, it is _not_ `null` or [TextUnit.Unspecified]),
+ * then this parameter will always be used.
+ * - If a parameter is _not_ set, (`null` or [TextUnit.Unspecified]), then the corresponding value
+ * from [style] will be used instead.
+ *
+ * Additionally, for [color], if [color] is not set, and [style] does not have a color, then
+ * [LocalContentColor] will be used.
+ *
+ * @param text the text to be displayed
+ * @param modifier the [Modifier] to be applied to this layout node
+ * @param color [Color] to apply to the text. If [Color.Unspecified], and [style] has no color set,
+ * this will be [LocalContentColor].
+ * @param fontSize the size of glyphs to use when painting the text. See [TextStyle.fontSize].
+ * @param fontStyle the typeface variant to use when drawing the letters (e.g., italic).
+ * See [TextStyle.fontStyle].
+ * @param fontWeight the typeface thickness to use when painting the text (e.g., [FontWeight.Bold]).
+ * @param fontFamily the font family to be used when rendering the text. See [TextStyle.fontFamily].
+ * @param letterSpacing the amount of space to add between each letter.
+ * See [TextStyle.letterSpacing].
+ * @param textDecoration the decorations to paint on the text (e.g., an underline).
+ * See [TextStyle.textDecoration].
+ * @param textAlign the alignment of the text within the lines of the paragraph.
+ * See [TextStyle.textAlign].
+ * @param lineHeight line height for the [Paragraph] in [TextUnit] unit, e.g. SP or EM.
+ * See [TextStyle.lineHeight].
+ * @param overflow how visual overflow should be handled.
+ * @param softWrap whether the text should break at soft line breaks. If false, the glyphs in the
+ * text will be positioned as if there was unlimited horizontal space. If [softWrap] is false,
+ * [overflow] and TextAlign may have unexpected effects.
+ * @param maxLines an optional maximum number of lines for the text to span, wrapping if
+ * necessary. If the text exceeds the given number of lines, it will be truncated according to
+ * [overflow] and [softWrap]. If it is not null, then it must be greater than zero.
+ * @param onTextLayout callback that is executed when a new text layout is calculated. A
+ * [TextLayoutResult] object that callback provides contains paragraph information, size of the
+ * text, baselines and other details. The callback can be used to add additional decoration or
+ * functionality to the text. For example, to draw selection around the text.
+ * @param style style configuration for the text such as color, font, line height etc.
+ */
+@Composable
+public fun Text(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+) {
+    SparkText(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}
+
+/**
+ * High level element that displays text and provides semantics / accessibility information.
+ *
+ * The default [style] uses the [LocalTextStyle] provided by the [MaterialTheme] / components. If
+ * you are setting your own style, you may want to consider first retrieving [LocalTextStyle],
+ * and using [TextStyle.copy] to keep any theme defined attributes, only modifying the specific
+ * attributes you want to override.
+ *
+ * For ease of use, commonly used parameters from [TextStyle] are also present here. The order of
+ * precedence is as follows:
+ * - If a parameter is explicitly set here (i.e, it is _not_ `null` or [TextUnit.Unspecified]),
+ * then this parameter will always be used.
+ * - If a parameter is _not_ set, (`null` or [TextUnit.Unspecified]), then the corresponding value
+ * from [style] will be used instead.
+ *
+ * Additionally, for [color], if [color] is not set, and [style] does not have a color, then
+ * [LocalContentColor] will be used.
+ *
+ * @param text the text to be displayed
+ * @param modifier the [Modifier] to be applied to this layout node
+ * @param color [Color] to apply to the text. If [Color.Unspecified], and [style] has no color set,
+ * this will be [LocalContentColor].
+ * @param fontSize the size of glyphs to use when painting the text. See [TextStyle.fontSize].
+ * @param fontStyle the typeface variant to use when drawing the letters (e.g., italic).
+ * See [TextStyle.fontStyle].
+ * @param fontWeight the typeface thickness to use when painting the text (e.g., [FontWeight.Bold]).
+ * @param fontFamily the font family to be used when rendering the text. See [TextStyle.fontFamily].
+ * @param letterSpacing the amount of space to add between each letter.
+ * See [TextStyle.letterSpacing].
+ * @param textDecoration the decorations to paint on the text (e.g., an underline).
+ * See [TextStyle.textDecoration].
+ * @param textAlign the alignment of the text within the lines of the paragraph.
+ * See [TextStyle.textAlign].
+ * @param lineHeight line height for the [Paragraph] in [TextUnit] unit, e.g. SP or EM.
+ * See [TextStyle.lineHeight].
+ * @param overflow how visual overflow should be handled.
+ * @param softWrap whether the text should break at soft line breaks. If false, the glyphs in the
+ * text will be positioned as if there was unlimited horizontal space. If [softWrap] is false,
+ * [overflow] and TextAlign may have unexpected effects.
+ * @param maxLines an optional maximum number of lines for the text to span, wrapping if
+ * necessary. If the text exceeds the given number of lines, it will be truncated according to
+ * [overflow] and [softWrap]. If it is not null, then it must be greater than zero.
+ * @param inlineContent a map storing composables that replaces certain ranges of the text, used to
+ * insert composables into text layout. See [InlineTextContent].
+ * @param onTextLayout callback that is executed when a new text layout is calculated. A
+ * [TextLayoutResult] object that callback provides contains paragraph information, size of the
+ * text, baselines and other details. The callback can be used to add additional decoration or
+ * functionality to the text. For example, to draw selection around the text.
+ * @param style style configuration for the text such as color, font, line height etc.
+ */
+@Composable
+public fun Text(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    inlineContent: Map<String, InlineTextContent> = mapOf(),
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+) {
+    SparkText(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        inlineContent = inlineContent,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
@@ -95,7 +95,7 @@ import com.adevinta.spark.tools.preview.ThemeVariant
  * @param keyboardActions when the input service emits an IME action, the corresponding callback
  * is called. Note that this IME action may be different from what you specified in
  * [KeyboardOptions.imeAction]
- * @param properties - PopupProperties for further customization of this popup's behavior.
+ * @param properties commentCountPopupProperties for further customization of this popup's behavior.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this TextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
@@ -198,7 +198,7 @@ public fun SelectTextField(
  * @param keyboardActions when the input service emits an IME action, the corresponding callback
  * is called. Note that this IME action may be different from what you specified in
  * [KeyboardOptions.imeAction]
- * @param properties - PopupProperties for further customization of this popup's behavior.
+ * @param properties commentCountPopupProperties for further customization of this popup's behavior.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this TextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
@@ -95,7 +95,7 @@ import com.adevinta.spark.tools.preview.ThemeVariant
  * @param keyboardActions when the input service emits an IME action, the corresponding callback
  * is called. Note that this IME action may be different from what you specified in
  * [KeyboardOptions.imeAction]
- * @param properties commentCountPopupProperties for further customization of this popup's behavior.
+ * @param properties - PopupProperties for further customization of this popup's behavior.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this TextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.interaction.Interaction

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.interaction.Interaction

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.interaction.Interaction

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.interaction.Interaction

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.layout.Row

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.layout.Row

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.interaction.Interaction

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
@@ -1,25 +1,3 @@
-/*
- * Copyright (c) 2023 Adevinta
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.adevinta.spark.components.toggles
 
 import androidx.compose.foundation.interaction.Interaction

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -568,11 +568,6 @@ public class SparkColors(
     public var outlineVariant: Color by mutableStateOf(outlineVariant, structuralEqualityPolicy())
         internal set
 
-    @Deprecated(
-        "This property will be removed as it is not part of Spark Token",
-        replaceWith = ReplaceWith("overlay"),
-        level = DeprecationLevel.WARNING,
-    )
     public var scrim: Color by mutableStateOf(scrim, structuralEqualityPolicy())
         internal set
 

--- a/spark/src/main/res/values/strings.xml
+++ b/spark/src/main/res/values/strings.xml
@@ -26,4 +26,6 @@
     <string name="spark_rating_with_comments_a11y">Note de %1$.1f pour %2$d avis</string>
     <string name="spark_rating_with_comments_count_label">%d avis</string>
     <string name="spark_rating_a11y">Note de %1$.1f</string>
+
+    <string name="spark_user_avatar_content_description">Photo de profil</string>
 </resources>

--- a/spark/src/main/res/values/strings.xml
+++ b/spark/src/main/res/values/strings.xml
@@ -22,6 +22,8 @@
   SOFTWARE.
   -->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:locale="fr">
+    <string name="spark_back_arrow_content_description">Retour en arrière</string>
+
     <string name="spark_rating_label">(%d)</string>
     <string name="spark_rating_with_comments_a11y">Note de %1$.1f pour %2$d avis</string>
     <string name="spark_rating_with_comments_count_label">%d avis</string>


### PR DESCRIPTION
## 🧑‍ Changes description
<!--- Describe your changes in detail -->
Add the components in the more info section and made a first pass to fix the documentation as some params have a `-` breaking it in Studio.

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
These changes are batch into a single PR as these components are only wrapping the Material one

## 📸 Screenshots
<!--- Put your phone screenshots here -->
they're integrated in the review files

## 👋 Other info
Close #178 
Close #150 
Close #179 
Close #158 
Close #181 
Close #183 
Close #184 
Close #185 
Close #186 
Close #187 
Close #188 
Close #189 
