### PR TITLE
fix: Remove `  - ` in doc param as it breaks doc rendering

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
@@ -43,9 +43,9 @@ internal fun rememberSparkTopAppBarState(
 
 /**
  * Creates a TopAppBarState that is remembered across compositions.
-@param initialHeightOffsetLimit - the initial value for TopAppBarState.heightOffsetLimit, which represents the pixel limit that a top app bar is allowed to collapse when the scrollable content is scrolled
-@param initialHeightOffset - the initial value for TopAppBarState.heightOffset. The initial offset height offset should be between zero and initialHeightOffsetLimit.
-@param initialContentOffset - the initial value for TopAppBarState.contentOffset
+ * @param initialHeightOffsetLimit the initial value for TopAppBarState.heightOffsetLimit, which represents the pixel limit that a top app bar is allowed to collapse when the scrollable content is scrolled
+ * @param initialHeightOffset the initial value for TopAppBarState.heightOffset. The initial offset height offset should be between zero and initialHeightOffsetLimit.
+ * @param initialContentOffset the initial value for TopAppBarState.contentOffset
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
@@ -63,10 +63,10 @@ internal fun SparkBadge(
  *
  * ![Badge image](https://developer.android.com/images/reference/androidx/compose/material3/badge.png)
  *
- * @param modifier - the Modifier to be applied to this badge
- * @param containerColor - the color used for the background of this badge
- * @param contentColor - the preferred color for content inside this badge. Defaults to either the matching content color for containerColor, or to the current LocalContentColor if containerColor is not a color from the theme.
- * @param content - optional content to be rendered inside this badge
+ * @param modifier the Modifier to be applied to this badge
+ * @param containerColor the color used for the background of this badge
+ * @param contentColor the preferred color for content inside this badge. Defaults to either the matching content color for containerColor, or to the current LocalContentColor if containerColor is not a color from the theme.
+ * @param content optional content to be rendered inside this badge
  **/
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -69,13 +69,13 @@ internal fun SparkCard(
  *
  * ![Card image](https://developer.android.com/images/reference/androidx/compose/material3/filled-card.png)
  *
- * @param modifier - the Modifier to be applied to this card
+ * @param modifier the Modifier to be applied to this card
  * When false, this component will not respond to user input,
  * and it will appear visually disabled and disabled to accessibility services.
- * @param colors - CardColors that will be used to resolve the colors used for this card in different states.
+ * @param colors CardColors that will be used to resolve the colors used for this card in different states.
  * See [CardDefaults.cardColors]
- * @param border - the border to draw around the container of this card
- * @param content - content of the card
+ * @param border the border to draw around the container of this card
+ * @param content content of the card
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/ElevatedCard.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/ElevatedCard.kt
@@ -72,7 +72,7 @@ internal fun SparkElevatedCard(
  * @param modifier the [Modifier] to be applied to this card
  * @param colors [CardColors] that will be used to resolve the color(s) used for this card in
  * different states. See [CardDefaults.elevatedCardColors].
- * @param content - content of the card
+ * @param content content of the card
  */
 @Composable
 public fun ElevatedCard(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
@@ -63,12 +63,12 @@ internal fun SparkDismissibleDrawerSheet(
  * An DismissibleDrawerSheet is a simple dismissible drawer sheet with content inside.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
- * @param drawerShape - defines the shape of this drawer's container
- * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
- * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
- * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
- * @param windowInsets - a window insets for the sheet.
- * @param content - content inside of a dismissible navigation drawer
+ * @param drawerShape defines the shape of this drawer's container
+ * @param drawerContainerColor the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets a window insets for the sheet.
+ * @param content content inside of a dismissible navigation drawer
  */
 @ExperimentalMaterial3Api
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
@@ -61,11 +61,11 @@ internal fun SparkDismissibleNavigationDrawer(
  *
  * ![DismissibleNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
- * @param drawerContent - content inside this drawer
+ * @param drawerContent content inside this drawer
  * @param modifier the [Modifier] to be applied to this drawer
- * @param drawerState - state of the drawer
- * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
- * @param content - content of the rest of the UI
+ * @param drawerState state of the drawer
+ * @param gesturesEnabled whether or not the drawer can be interacted by gestures
+ * @param content content of the rest of the UI
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
@@ -62,12 +62,12 @@ internal fun SparkModalDrawerSheet(
  * A ModalDrawerSheet is a Content inside of a modal navigation drawer.
  *
  * @param modifier the [Modifier] to be applied to this drawer's content
- * @param drawerShape - defines the shape of this drawer's container
- * @param drawerContainerColor - the color used for the background of this drawer. Use Color.Transparent to have no color.
- * @param drawerContentColor - the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
- * @param drawerTonalElevation - when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
- * @param windowInsets - a window insets for the sheet.
- * @param content - content inside of a modal navigation drawer
+ * @param drawerShape defines the shape of this drawer's container
+ * @param drawerContainerColor the color used for the background of this drawer. Use Color.Transparent to have no color.
+ * @param drawerContentColor the preferred color for content inside this drawer. Defaults to either the matching content color for drawerContainerColor, or to the current LocalContentColor if drawerContainerColor is not a color from the theme.
+ * @param drawerTonalElevation when drawerContainerColor is ColorScheme.surface, a translucent primary color overlay is applied on top of the container. A higher tonal elevation value will result in a darker color in light theme and lighter color in dark theme. See also: Surface.
+ * @param windowInsets a window insets for the sheet.
+ * @param content content inside of a modal navigation drawer
  */
 @ExperimentalSparkApi
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
@@ -67,12 +67,12 @@ internal fun SparkModalNavigationDrawer(
  *
  * ![ModalNavigationDrawer image](https://developer.android.com/images/reference/androidx/compose/material3/navigation-drawer.png)
  *
- * @param drawerContent - content inside this drawer
+ * @param drawerContent content inside this drawer
  * @param modifier the [Modifier] to be applied to this drawer
- * @param drawerState - state of the drawer
- * @param gesturesEnabled - whether or not the drawer can be interacted by gestures
- * @param scrimColor - color of the scrim that obscures content when the drawer is open
- * @param content - content of the rest of the UI
+ * @param drawerState state of the drawer
+ * @param gesturesEnabled whether or not the drawer can be interacted by gestures
+ * @param scrimColor color of the scrim that obscures content when the drawer is open
+ * @param content content of the rest of the UI
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
@@ -95,7 +95,7 @@ import com.adevinta.spark.tools.preview.ThemeVariant
  * @param keyboardActions when the input service emits an IME action, the corresponding callback
  * is called. Note that this IME action may be different from what you specified in
  * [KeyboardOptions.imeAction]
- * @param properties - PopupProperties for further customization of this popup's behavior.
+ * @param properties PopupProperties for further customization of this popup's behavior.
  * @param interactionSource the [MutableInteractionSource] representing the stream of
  * [Interaction]s for this TextField. You can create and pass in your own remembered
  * [MutableInteractionSource] if you want to observe [Interaction]s and customize the


### PR DESCRIPTION
## 🧑‍ Changes description
<!--- Describe your changes in detail -->
Remove ` - ` in doc param as it breaks doc rendering

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
With the ` - ` it would render like this in AS:
![image](https://user-images.githubusercontent.com/11772084/222411775-125b18a0-e870-4eeb-af6d-cfaf66f5e00d.png)

whereas we want it ot look like this:
![image](https://user-images.githubusercontent.com/11772084/222411903-a3cc458e-6374-4f3c-8d00-3c12a1a50aed.png)

