### PR TITLE
docs: enable Dokka multi modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,27 @@ jobs:
           html: '**/build/reports/lint-results-*.html'
           sarif: '**/build/reports/lint-results-*.sarif'
           xml: '**/build/reports/lint-results-*.xml'
+
+  dokka:
+    needs: validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: ./.github/actions/setup-gradle-properties
+
+      - name: '📋 Build Dokka'
+        uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # v2.3.3
+        with:
+          # https://github.com/Kotlin/dokka/issues/1217
+          arguments: dokkaHtmlMultiModule --no-configuration-cache
+          gradle-home-cache-cleanup: true
+      - name: '📦 Archive Dokka'
+        uses: actions/upload-artifact@v3
+        with:
+          name: dokka
+          path: 'build/dokka'

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -31,7 +31,7 @@ jobs:
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # v2.3.3
         with:
           # https://github.com/Kotlin/dokka/issues/1217
-          arguments: dokkaHtml --no-configuration-cache
+          arguments: dokkaHtmlMultiModule --no-configuration-cache
           gradle-home-cache-cleanup: true
       - uses: actions/configure-pages@v3.0.4
       - uses: actions/upload-pages-artifact@v1.0.7

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -1,9 +1,14 @@
 name: '📋 Publish Dokka to GitHub Pages'
+run-name: "📋 Publish Dokka on ${{ inputs.ref }} to GitHub Pages by @${{ github.actor }}"
 
 on:
-  push:
-    branches: ["main"]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, SHA, …'
+        required: true
+        default: 'main'
+        type: string
 
 permissions:
   contents: read
@@ -22,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        ref: ${{ inputs.ref }}
       - uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkDokkaPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkDokkaPlugin.kt
@@ -39,7 +39,7 @@ internal class SparkDokkaPlugin : Plugin<Project> {
 
             if (this === rootProject) {
                 tasks.named<DokkaMultiModuleTask>("dokkaHtmlMultiModule") {
-                    moduleName.set("✨ Spark Android")
+                    moduleName.set("✨ Spark")
                     outputDirectory.set(buildDir.resolve("dokka"))
                 }
             }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkDokkaPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkDokkaPlugin.kt
@@ -29,6 +29,7 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.DokkaTask
 
 internal class SparkDokkaPlugin : Plugin<Project> {
@@ -36,13 +37,19 @@ internal class SparkDokkaPlugin : Plugin<Project> {
         with(target) {
             apply(plugin = "org.jetbrains.dokka")
 
+            if (this === rootProject) {
+                tasks.named<DokkaMultiModuleTask>("dokkaHtmlMultiModule") {
+                    moduleName.set("✨ Spark Android")
+                    outputDirectory.set(buildDir.resolve("dokka"))
+                }
+            }
+
             tasks.withType<DokkaTask> {
                 notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
             }
 
             tasks.named<DokkaTask>("dokkaHtml").configure {
                 moduleName.set("Spark")
-                outputDirectory.set(rootProject.buildDir.resolve("dokka"))
                 dokkaSourceSets.configureEach {
                     // List of files or directories containing sample code (referenced with @sample tags)
                     // samples.from("samples/basic.kt", "samples/advanced.kt")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,4 +30,6 @@ plugins {
     alias(libs.plugins.paparazzi) apply false
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.dependencyGuard) apply false
+
+    id("com.adevinta.spark.dokka")
 }


### PR DESCRIPTION
## 📋 Changes description

Enable Dokka multi-modules feature.

https://kotlin.github.io/dokka/1.8.10/developer_guide/architecture/extension_points/core_extensions/#generation

## 🤔 Context

It will allow us to document multiple modules into a single docs site.

## 🗒️ Other info

- Dokka website will be generated and archived on each PR.
- Dokka website will not be published when pushing on main, but instead, it will be a manual workflow trigger to avoid publishing -SNAPSHOTS (non-final) docs.