### PR TITLE
ci: remove `paths-ignore` on md and docs files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,9 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
   merge_group:
     types: [ checks_requested ]
     branches: ["main"]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
As it breaks expected checks to be executed.
Also, modifing md files need to re-build and validate dokka which is part of this workflow.