### PR TITLE
refactor: Change TonalTag visibility from internal to public

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
@@ -98,12 +98,12 @@ internal fun SparkTag(
 }
 
 @Immutable
-internal data class TagColors(
+public data class TagColors(
     val backgroundColor: Color,
     val contentColor: Color,
 )
 
-internal object TagDefaults {
+public object TagDefaults {
     internal val MinHeight = 20.dp
 
     /**
@@ -117,7 +117,8 @@ internal object TagDefaults {
     internal val LeadingIconSize = 16.dp
 
     @Composable
-    internal fun tonalColors(
+    @InternalSparkApi
+    public fun tonalColors(
         backgroundColor: Color = SparkTheme.colors.secondaryContainer,
     ): TagColors {
         return TagColors(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagTonal.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagTonal.kt
@@ -39,7 +39,7 @@ import com.adevinta.spark.tools.preview.UserType
 
 @InternalSparkApi
 @Composable
-internal fun TagTonal(
+public fun TagTonal(
     colors: TagColors,
     modifier: Modifier = Modifier,
     leadingIcon: SparkIcon? = null,


### PR DESCRIPTION
## 📋 Changes description
<!--- Describe your changes in detail -->
Change `TonalTag` visibility from internal to public with the `TagDefault.tonalColor()`

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
This Api is used by a consumer so we still need to let it open until we refine the TonalTag api to allow more states

## 🗒️ Other info
Related to #215 
