### PR TITLE
feat: Add Legacy option to use previous DS style

### DIFF
--- a/spark/lint.xml
+++ b/spark/lint.xml
@@ -24,7 +24,7 @@
 <lint>
     <issue id="ComposeCompositionLocalUsage" severity="warning">
         <option name="allowed-composition-locals"
-            value="LocalSparkColors,LocalSparkShapes,LocalSparkTypography,LocalHighlightToken,LocalHighlightComponents,LocalIsUserPro" />
+            value="LocalSparkColors,LocalSparkShapes,LocalSparkTypography,LocalHighlightToken,LocalHighlightComponents,LocalLegacyStyle" />
     </issue>
     <!--
      This seems to be an issue with Lint itself, where it's impossible to suppress with annotations.

--- a/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
@@ -238,7 +238,7 @@ internal val LocalHighlightToken = staticCompositionLocalOf { false }
 internal val LocalHighlightComponents = staticCompositionLocalOf { false }
 
 /**
- * CompositionLocal that makes the components use the legacy style from the previous DS to make it easier for the Adevinta Platform teams.
+ * CompositionLocal that makes the components use the legacy style from the previous DS to make it easier for the Adevinta Platform teams
  * to migrate their screens to spark.
  */
 internal val LocalLegacyStyle = staticCompositionLocalOf { false }

--- a/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
@@ -69,6 +69,7 @@ public fun SparkTheme(
     typography: SparkTypography = SparkTheme.typography,
     useSparkTokensHighlighter: Boolean = false,
     useSparkComponentsHighlighter: Boolean = false,
+    useLegacyStyle: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val internalColors = if (useSparkTokensHighlighter) debugColors() else colors
@@ -104,6 +105,7 @@ public fun SparkTheme(
         LocalSparkShapes provides internalShapes,
         LocalHighlightToken provides useSparkTokensHighlighter,
         LocalHighlightComponents provides useSparkComponentsHighlighter,
+        LocalLegacyStyle provides useLegacyStyle,
     ) {
         MaterialTheme(
             colorScheme = rememberedColors.asMaterial3Colors(),
@@ -172,6 +174,7 @@ internal fun SparkTenantTheme(
     useDarkColors: Boolean = isSystemInDarkTheme(),
     useSparkTokensHighlighter: Boolean = false,
     useSparkComponentsHighlighter: Boolean = false,
+    useLegacyStyle: Boolean = false,
     isPro: Boolean = false,
     content: @Composable () -> Unit,
 ) {
@@ -186,6 +189,7 @@ internal fun SparkTenantTheme(
         typography = sparkTypography(),
         useSparkTokensHighlighter = useSparkTokensHighlighter,
         useSparkComponentsHighlighter = useSparkComponentsHighlighter,
+        useLegacyStyle = useLegacyStyle,
         content = content,
     )
 }
@@ -232,3 +236,9 @@ internal val LocalHighlightToken = staticCompositionLocalOf { false }
  * Setting it to true show an overlay on spark components.
  */
 internal val LocalHighlightComponents = staticCompositionLocalOf { false }
+
+/**
+ * CompositionLocal that makes the components use the legacy style from the previous DS to make it easier for the Adevinta Platform teams.
+ * to migrate their screens to spark.
+ */
+internal val LocalLegacyStyle = staticCompositionLocalOf { false }


### PR DESCRIPTION
## 📋 Changes description
<!--- Describe your changes in detail -->
Add new param to `SparkTheme` & new CompositionLocal `LocalLegacyStyle`

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
Since we're migrating screens with Spark on the Adevinta Platform we don't want a screen to have a component with different UI if a part of the screen is not yet migrated.

This 'll allow us to have component with a UI close enough from the previous one to avoid huge difference between components .