### PR TITLE
chore: downgrade AGP to stable 8.0.0

### DIFF
--- a/build-logic/src/main/kotlin/com/adevinta/spark/ProjectExtensions.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/ProjectExtensions.kt
@@ -44,7 +44,7 @@ internal val Project.isAndroid: Boolean get() = pluginManager.hasPlugin("com.and
 internal val Project.isJavaPlatform: Boolean get() = pluginManager.hasPlugin("org.gradle.java-platform")
 
 internal fun Project.configureAndroidExtension(
-    configure: CommonExtension<*, *, *, *, *>.() -> Unit,
+    configure: CommonExtension<*, *, *, *>.() -> Unit,
 ) = when {
     isAndroidApplication -> configure<ApplicationExtension>(configure)
     isAndroidLibrary -> configure<LibraryExtension>(configure)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 accompanist = "0.28.0"
-android-gradlePlugin = "8.1.0-alpha11"
+android-gradlePlugin = "8.0.0"
 androidx-appCompat = "1.5.1"
 androidx-compose-bom = "2023.01.00"
 androidx-compose-compiler = "1.4.5"


### PR DESCRIPTION
Now that we have a stable 8.x version.