### PR TITLE
fix: Add fixes for finalizing the v0.1.0

### DIFF
--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PreviewScreenshotTests.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PreviewScreenshotTests.kt
@@ -73,6 +73,7 @@ internal class PreviewScreenshotTests {
                 } catch (t: Throwable) {
                     // TODO-@soulcramer (22-48-2023): Should we display the throwable message here too?
                     failure = true
+                    throw t
                 }
             }
         }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/BottomAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/BottomAppBar.kt
@@ -49,8 +49,9 @@ import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.icons.IconButton
 import com.adevinta.spark.tokens.contentColorFor
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.BottomAppBar as MaterialBottomAppBar
 
 /**
@@ -154,7 +155,7 @@ public fun BottomAppBar(
 )
 @Composable
 internal fun BottomAppBarPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -229,11 +229,12 @@ public object SparkButtonDefaults {
      */
     @Composable
     internal fun outlinedBorder(color: Color): BorderStroke = BorderStroke(
-        width = OutlinedBorderSize,
+        width = if (LocalLegacyStyle.current) LegacyOutlinedBorderSize else OutlinedBorderSize,
         color = color,
     )
 
     private val OutlinedBorderSize = 2.0.dp
+    private val LegacyOutlinedBorderSize = 1.0.dp
 }
 
 @Preview

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/FloatingActionButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/FloatingActionButton.kt
@@ -47,8 +47,9 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.icons.SparkIcon
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.ExtendedFloatingActionButton as MaterialExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton as MaterialFloatingActionButton
 import androidx.compose.material3.LargeFloatingActionButton as MaterialLargeFloatingActionButton
@@ -355,7 +356,7 @@ public fun ExtendedFloatingActionButton(
 )
 @Composable
 internal fun DropdownMenuPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/AssistChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/AssistChip.kt
@@ -46,8 +46,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.icons.Icon
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.AssistChip as MaterialAssistChip
 import androidx.compose.material3.ElevatedAssistChip as MaterialElevatedAssistChip
 
@@ -162,6 +163,7 @@ public fun AssistChip(
  * for this chip. You can create and pass in your own `remember`ed instance to observe
  * [Interaction]s and customize the appearance / behavior of this chip in different states.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 public fun ElevatedAssistChip(
     onClick: () -> Unit,
@@ -197,7 +199,7 @@ public fun ElevatedAssistChip(
     name = "AssistChip",
 )
 internal fun AssistChipPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/FilterChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/FilterChip.kt
@@ -50,8 +50,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.icons.Icon
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.ElevatedFilterChip as MaterialElevatedFilterChip
 import androidx.compose.material3.FilterChip as MaterialFilterChip
 
@@ -219,7 +220,7 @@ public fun ElevatedFilterChip(
     name = "FilterChip",
 )
 internal fun FilterPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/InputChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/InputChip.kt
@@ -56,8 +56,9 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.icons.Icon
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.InputChip as MaterialInputChip
 
 /**
@@ -150,7 +151,7 @@ public fun InputChip(
     name = "InputChip",
 )
 internal fun InputChipPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/SuggestionChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/SuggestionChip.kt
@@ -42,8 +42,9 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adevinta.spark.PreviewTheme
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.SuggestionChip as MaterialSuggestionChip
 
 
@@ -120,7 +121,7 @@ public fun SuggestionChip(
     name = "SuggestionChip",
 )
 internal fun SuggestionChipPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
@@ -41,8 +41,9 @@ import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.SparkIcon
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.FilledIconButton as MaterialFilledIconButton
 import androidx.compose.material3.FilledTonalIconButton as MaterialFilledTonalIconButton
 import androidx.compose.material3.IconButton as MaterialIconButton
@@ -271,7 +272,7 @@ public fun OutlinedIconButton(
 )
 @Composable
 internal fun IconButtonPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
@@ -42,8 +42,9 @@ import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.tokens.contentColorFor
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.FilledIconToggleButton as MaterialFilledIconToggleButton
 import androidx.compose.material3.FilledTonalIconToggleButton as MaterialFilledTonalIconToggleButton
 import androidx.compose.material3.IconToggleButton as MaterialIconToggleButton
@@ -279,7 +280,7 @@ public fun OutlinedIconToggleButton(
 )
 @Composable
 internal fun IconToggleButtonPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -57,8 +57,9 @@ import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.divider.Divider
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.icons.IconButton
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.DropdownMenu as MaterialDropdownMenu
 import androidx.compose.material3.DropdownMenuItem as MaterialDropdownMenuItem
 
@@ -176,7 +177,7 @@ public fun DropdownMenuItem(
 )
 @Composable
 internal fun DropdownMenuPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
@@ -41,8 +41,9 @@ import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 
 /**
  * Component that displays rating of an user with stars in the following form:
@@ -159,7 +160,7 @@ public fun RatingFull(
     name = "RatingFull",
 )
 internal fun RatingFullPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {
@@ -175,7 +176,7 @@ internal fun RatingFullPreview(
     name = "RatingCompressed",
 )
 internal fun RatingCompressedPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {
@@ -191,7 +192,7 @@ internal fun RatingCompressedPreview(
     name = "RatingNaked",
 )
 internal fun RatingNakedPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
@@ -43,8 +43,9 @@ import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.tokens.EmphasizeMedium
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import java.lang.String.format
 import java.util.Locale
 
@@ -138,7 +139,7 @@ internal fun firstLocale(): Locale {
     name = "RatingSmall",
 )
 internal fun RatingSmallPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     val frenchLocale = Locale("fr", "rFR")

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
@@ -38,8 +38,9 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.tokens.DisabledAlpha
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 
 /**
  * RatingStar is the atomic element of rating components
@@ -73,7 +74,7 @@ private val StarSize = 12.dp
 @Composable
 @Preview
 private fun RatingStarPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
@@ -29,7 +29,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.consumedWindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
@@ -57,8 +57,9 @@ import com.adevinta.spark.components.appbar.TopAppBar
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.icons.IconButton
 import com.adevinta.spark.tokens.contentColorFor
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.Scaffold as MaterialScaffold
 
 /**
@@ -134,7 +135,7 @@ public fun Scaffold(
 )
 @Composable
 private fun ScaffoldPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(
@@ -174,7 +175,7 @@ private fun ScaffoldPreview(
             content = { innerPadding ->
                 LazyColumn(
                     // consume insets as scaffold doesn't do it by default
-                    modifier = Modifier.consumedWindowInsets(innerPadding),
+                    modifier = Modifier.consumeWindowInsets(innerPadding),
                     contentPadding = innerPadding,
                 ) {
                     items(count = 100) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.consumedWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
@@ -175,7 +176,7 @@ private fun ScaffoldPreview(
             content = { innerPadding ->
                 LazyColumn(
                     // consume insets as scaffold doesn't do it by default
-                    modifier = Modifier.consumeWindowInsets(innerPadding),
+                    modifier = Modifier.consumedWindowInsets(innerPadding),
                     contentPadding = innerPadding,
                 ) {
                     items(count = 100) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagFilled.kt
@@ -23,6 +23,7 @@
 @file:Suppress("DEPRECATION")
 package com.adevinta.spark.components.tags
 
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -82,6 +83,28 @@ public fun TagFilled(
         modifier = modifier,
         leadingIcon = leadingIcon,
         tint = tint,
+    )
+}
+
+@Deprecated(
+    "Use TagFilled instead without `content` parameter",
+    ReplaceWith("TagFilled(text, modifier, intent, leadingIcon, tint)"),
+    level = DeprecationLevel.ERROR,
+)
+@Composable
+public fun TagFilled(
+    modifier: Modifier = Modifier,
+    colors: TagColors = TagDefaults.filledColors(TagIntent.Primary),
+    leadingIcon: SparkIcon? = null,
+    tint: Color? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    BaseSparkTag(
+        colors = colors,
+        modifier = modifier,
+        leadingIcon = leadingIcon,
+        tint = tint,
+        content = content,
     )
 }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
@@ -38,8 +38,9 @@ import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.tools.modifiers.minimumTouchTargetSize
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 
 @Composable
 @InternalSparkApi
@@ -158,7 +159,7 @@ public fun CheckboxLabelled(
 )
 @Composable
 internal fun AllStatesCheckboxPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {
@@ -179,7 +180,7 @@ internal fun AllStatesCheckboxPreview(
 )
 @Composable
 internal fun AllStatesCheckBoxLabelledPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
@@ -38,8 +38,9 @@ import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.tools.modifiers.minimumTouchTargetSize
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 
 
 @Composable
@@ -161,7 +162,7 @@ public fun RadioButtonLabelled(
 )
 @Composable
 internal fun AllStatesRadioButtonPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {
@@ -180,7 +181,7 @@ internal fun AllStatesRadioButtonPreview(
 )
 @Composable
 internal fun AllStatesRadioButtonLabelledPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
@@ -44,8 +44,9 @@ import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.tools.modifiers.minimumTouchTargetSize
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
-import com.adevinta.spark.tools.preview.SparkPreviewParam
-import com.adevinta.spark.tools.preview.SparkPreviewParamProvider
+import com.adevinta.spark.tools.preview.SparkPreviewProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.UserType
 import androidx.compose.material3.Switch as MaterialSwitch
 
 @Composable
@@ -169,7 +170,7 @@ public fun SwitchLabelled(
 )
 @Composable
 internal fun AllStatesSwitchPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {
@@ -189,7 +190,7 @@ internal fun AllStatesSwitchPreview(
 )
 @Composable
 internal fun AllStatesSwitchLabelledPreview(
-    @PreviewParameter(SparkPreviewParamProvider::class) param: SparkPreviewParam,
+    @PreviewParameter(SparkPreviewProvider::class) param: Pair<ThemeVariant, UserType>,
 ) {
     val (theme, userType) = param
     PreviewTheme(theme, userType) {

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreviewProvider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreviewProvider.kt
@@ -33,14 +33,14 @@ public class SparkPreviewProvider : PreviewParameterProvider<Pair<ThemeVariant, 
 
 public class SparkPreviewParamProvider : CollectionPreviewParameterProvider<SparkPreviewParam>(
     listOf(
-        SparkPreviewParam(ThemeVariant.Light, UserType.Part, false),
-        SparkPreviewParam(ThemeVariant.Light, UserType.Pro, false),
-        SparkPreviewParam(ThemeVariant.Dark, UserType.Part, false),
-        SparkPreviewParam(ThemeVariant.Dark, UserType.Pro, false),
-        SparkPreviewParam(ThemeVariant.Light, UserType.Part, true),
-        SparkPreviewParam(ThemeVariant.Light, UserType.Pro, true),
-        SparkPreviewParam(ThemeVariant.Dark, UserType.Part, true),
-        SparkPreviewParam(ThemeVariant.Dark, UserType.Pro, true),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Part, isLegacy = false),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Pro, isLegacy = false),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Part, isLegacy = false),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Pro, isLegacy = false),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Part, isLegacy = true),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Pro, isLegacy = true),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Part, isLegacy = true),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Pro, isLegacy = true),
     ),
 )
 

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreviewProvider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreviewProvider.kt
@@ -33,16 +33,21 @@ public class SparkPreviewProvider : PreviewParameterProvider<Pair<ThemeVariant, 
 
 public class SparkPreviewParamProvider : CollectionPreviewParameterProvider<SparkPreviewParam>(
     listOf(
-        SparkPreviewParam(ThemeVariant.Light, UserType.Part),
-        SparkPreviewParam(ThemeVariant.Light, UserType.Pro),
-        SparkPreviewParam(ThemeVariant.Dark, UserType.Part),
-        SparkPreviewParam(ThemeVariant.Dark, UserType.Pro),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Part, false),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Pro, false),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Part, false),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Pro, false),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Part, true),
+        SparkPreviewParam(ThemeVariant.Light, UserType.Pro, true),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Part, true),
+        SparkPreviewParam(ThemeVariant.Dark, UserType.Pro, true),
     ),
 )
 
 public data class SparkPreviewParam(
     val theme: ThemeVariant,
     val userType: UserType,
+    val isLegacy: Boolean,
 )
 
 /**


### PR DESCRIPTION
## 📋 Changes description
<!--- Describe your changes in detail -->

- Add legacy button outline.
- Add legacy support for `SparkPreviewParam`.
- Add deprecated `TagFilled` to support previous usages of `TagFilled` with `@Ignore("InternalSparkApi")`

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
I realized that these changes were missing to either test easily the integration or would make breaking changes if not introduced.

## 🗒️ Other info
<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->

related to #328 
