### PR TITLE
feat: Adapt Icon to respect Spark specs

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1256f1e6d477985e79d65d351c0b15af9fc7e8371234d7893a15806afe41b1c6
+size 56600

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4102046d7e6a242e4a6fb4c5a818046eceee02a389c68db64c1b2ad4dc962d1e
+size 58102

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
@@ -11,10 +11,10 @@ A badge is a visual indicator for numeric values such as tallies and scores.
 
 ### Styles
 
-|       | Danger and Info                                                                                                                                                         |
-|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Light | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badge_light.png)        |
-| Dark  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_badge_badge_dark.png) |
+|       | Danger and Info                                                                                                                                                  |
+|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Light | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badge_light.png) |
+| Dark  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badge_dark.png)  |
 
 ```kotlin
 @Composable
@@ -117,9 +117,9 @@ Badge(
 )
 ```
 
-| Light                                                                                                                                                              | Dark                                                                                                                                                                      |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images//com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge__badge_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images//com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttonfilled_dark.png) |
+| Light                                                                                                                                                                 | Dark                                                                                                                                                                 |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images//com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images//com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_dark.png) |
 
 ## Layout
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icon.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icon.md
@@ -1,0 +1,122 @@
+# Icon components
+
+## Icon design specs
+
+You can find the design specs on [spark.adevinta.com](https://spark.adevinta.com/1186e1705/p/11373f-icon/b/80bf01).
+
+## Usage
+
+This component is the wrapper of the icons that you can find in Spark Foundations.
+
+### Styles
+
+|       | Colors and sizes                                                                                                                                               |
+|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Light | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_light.png) |
+| Dark  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_dark.png)  |
+
+```kotlin
+@Composable
+public fun Icon(
+    sparkIcon: SparkIcon,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: IconTints = IconDefaults.color,
+    size: IconSize = IconDefaults.size,
+)
+```
+
+| Parameters                             | Descriptions                                                                      |
+|----------------------------------------|-----------------------------------------------------------------------------------|
+| `sparkIcon: SparkIcon`                 | [SparkIcon] to draw inside this Icon                                              |
+| `contentDescription: String?`          | text used by accessibility services to describe what this icon represents         |
+| `modifier: Modifier = Modifier`        | optional modifier [Modifier] to be applied to this icon                           |                                                                                                                     |
+| `tint: IconTints = IconDefaults.color` | tint to be applied to [sparkIcon]. If no tint is provided, then a default is used |
+| `size: IconSize = IconDefaults.size`   | one of [IconSize] to be applied as size of the icon                               |
+
+Icon component that draws [sparkIcon] using [tint], defaulting to [LocalContentColor]. For a
+clickable icon, see [IconButton].
+
+Instead of [SparkIcon] you can pass:
+- [ImageVector]
+- [ImageBitmap]
+- [Painter]
+
+```kotlin
+@Composable
+public fun Icon(
+    imageVector: ImageVector,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: IconTints = IconDefaults.color,
+    size: IconSize = IconDefaults.size,
+)
+```
+
+| Parameters                             | Descriptions                                                                        |
+|----------------------------------------|-------------------------------------------------------------------------------------|
+| `imageVector: ImageVector`             | [ImageVector] to draw inside this Icon                                              |
+| `contentDescription: String?`          | text used by accessibility services to describe what this icon represents           |
+| `modifier: Modifier = Modifier`        | optional modifier [Modifier] to be applied to this icon                             |                                                                                                                     |
+| `tint: IconTints = IconDefaults.color` | tint to be applied to [imageVector]. If no tint is provided, then a default is used |
+| `size: IconSize = IconDefaults.size`   | size one of [IconSize] to be applied as size of the icon                            |
+
+```kotlin
+@Composable
+public fun Icon(
+    bitmap: ImageBitmap,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: IconTints = IconDefaults.color,
+    size: IconSize = IconDefaults.size,
+)
+```
+
+| Parameters                             | Descriptions                                                                   |
+|----------------------------------------|--------------------------------------------------------------------------------|
+| `bitmap: ImageBitmap`                  | [ImageBitmap] to draw inside this Icon                                         |
+| `contentDescription: String?`          | text used by accessibility services to describe what this icon represents      |
+| `modifier: Modifier = Modifier`        | optional modifier [Modifier] to be applied to this icon                        |                                                                                                                     |
+| `tint: IconTints = IconDefaults.color` | tint to be applied to [bitmap]. If no tint is provided, then a default is used |
+| `size: IconSize = IconDefaults.size`   | size one of [IconSize] to be applied as size of the icon                       |
+
+```kotlin
+@Composable
+public fun Icon(
+    painter: Painter,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: IconTints = IconDefaults.color,
+    size: IconSize = IconDefaults.size,
+)
+```
+
+| Parameters                             | Descriptions                                                                    |
+|----------------------------------------|---------------------------------------------------------------------------------|
+| `painter: Painter`                     | [Painter] to draw inside this Icon                                              |
+| `contentDescription: String?`          | text used by accessibility services to describe what this icon represents       |
+| `modifier: Modifier = Modifier`        | optional modifier [Modifier] to be applied to this icon                         |                                                                                                                     |
+| `tint: IconTints = IconDefaults.color` | tint to be applied to [painter]. If no tint is provided, then a default is used |
+| `size: IconSize = IconDefaults.size`   | size one of [IconSize] to be applied as size of the icon                        |
+
+
+### Style
+
+All icons accept 7 intents as tints:
+- Primary
+- Secondary
+- Surface
+- Success
+- Alert
+- Danger
+- Neutral
+
+as well as 
+- `IconTints.Current` that uses [LocalContentColor] and is a default tint 
+- `IconTints.Unspecified` that applies no tint.
+
+All icons can have the following sizes:
+- Small (16.dp)
+- Medium (24.dp) - default size
+- Large (32.dp)
+- ExtraLarge (40.dp)

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconDefaults.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.icons
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+public object IconDefaults {
+    public val size: IconSize = IconSize.Medium
+    public val color: IconTints = IconTints.Current
+}
+
+public enum class IconSize(public val size: Dp) {
+    Small(16.dp),
+    Medium(24.dp),
+    Large(32.dp),
+    ExtraLarge(40.dp)
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconTints.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconTints.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.components.icons
+
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.adevinta.spark.SparkTheme
+
+public enum class IconTints {
+    /**
+     * Used for the most important information.
+     */
+    Primary {
+        @Composable
+        override fun color() = SparkTheme.colors.primary
+    },
+
+    /**
+     * Used to highlight/accentuate.
+     */
+    Secondary {
+        @Composable
+        override fun color() = SparkTheme.colors.secondary
+    },
+
+    /**
+     * Icon on a color / image panel without on intent color.
+     */
+    Surface {
+        @Composable
+        override fun color() = SparkTheme.colors.surface
+    },
+
+    /**
+     * Used for confirmation.
+     */
+    Success {
+        @Composable
+        override fun color() = SparkTheme.colors.success
+    },
+
+    /**
+     * Used for warning.
+     */
+    Alert {
+        @Composable
+        override fun color() = SparkTheme.colors.alert
+    },
+
+    /**
+     * Used to alert.
+     */
+    Danger {
+        @Composable
+        override fun color() = SparkTheme.colors.error
+    },
+
+    /**
+     * Used for low importance information.
+     */
+    Neutral {
+        @Composable
+        override fun color() = SparkTheme.colors.neutral
+    },
+
+    /**
+     * Used for low importance information.
+     */
+    Current {
+        @Composable
+        override fun color() = LocalContentColor.current
+    },
+
+    /**
+     * Used for low importance information.
+     */
+    Unspecified {
+        @Composable
+        override fun color() = Color.Unspecified
+    };
+
+    @Composable
+    internal abstract fun color(): Color
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
@@ -23,6 +23,10 @@
 package com.adevinta.spark.components.icons
 
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
@@ -33,12 +37,20 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.IconDrawableRes
 import com.adevinta.spark.icons.IconVector
 import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.modifiers.ifTrue
 import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import androidx.compose.material3.Icon as MaterialIcon
+
 
 /**
  * Icon component that draws [sparkIcon] using [tint], defaulting to [LocalContentColor]. For a
@@ -50,21 +62,25 @@ import androidx.compose.material3.Icon as MaterialIcon
  * and does not represent a meaningful action that a user can take. This text should be
  * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
  * @param modifier optional [Modifier] for this Icon
- * @param tint tint to be applied to [sparkIcon]. If [Color.Unspecified] is provided, then no
- *  tint is applied
+ * @param tint to be applied to [sparkIcon]. If no tint is provided, then a default is used.
+ * @param size one of [IconSize] to be applied as size of the icon.
+ * If no size is provided the default [IconSize.Medium] is used.
  */
 @Composable
 public fun Icon(
     sparkIcon: SparkIcon,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    tint: Color = LocalContentColor.current,
+    tint: IconTints = IconDefaults.color,
+    size: IconSize = IconDefaults.size,
 ) {
     MaterialIcon(
         painter = rememberSparkIconPainter(sparkIcon),
         contentDescription = contentDescription,
-        modifier = modifier.sparkUsageOverlay(),
-        tint = tint,
+        modifier = modifier
+            .sparkUsageOverlay()
+            .size(size.size),
+        tint = tint.color(),
     )
 }
 
@@ -72,29 +88,31 @@ public fun Icon(
  * Icon component that draws [imageVector] using [tint], defaulting to [LocalContentColor]. For a
  * clickable icon, see [IconButton].
  *
- * To learn more about icons, see [Material Design icons](https://m3.material.io/styles/icons/overview)
- *
  * @param imageVector [ImageVector] to draw inside this icon
  * @param contentDescription text used by accessibility services to describe what this icon
- * represents. This should always be provided unless this icon is used for decorative purposes, and
- * does not represent a meaningful action that a user can take. This text should be localized, such
- * as by using [androidx.compose.ui.res.stringResource] or similar
- * @param modifier the [Modifier] to be applied to this icon
- * @param tint tint to be applied to [imageVector]. If [Color.Unspecified] is provided, then no tint
- * is applied.
+ * represents. This should always be provided unless this icon is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier optional [Modifier] for this Icon
+ * @param tint to be applied to [imageVector]. If no intent is provided, then a default is used.
+ * @param iconSize one of [IconSize] to be applied as size of the icon.
+ * If no size is provided the default [IconSize.Medium] is used.
  */
 @Composable
 public fun Icon(
     imageVector: ImageVector,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    tint: Color = LocalContentColor.current,
+    tint: IconTints = IconDefaults.color,
+    iconSize: IconSize = IconDefaults.size,
 ) {
     MaterialIcon(
         imageVector = imageVector,
         contentDescription = contentDescription,
-        modifier = modifier.sparkUsageOverlay(),
-        tint = tint,
+        modifier = modifier
+            .sparkUsageOverlay()
+            .size(iconSize.size),
+        tint = tint.color(),
     )
 }
 
@@ -102,56 +120,88 @@ public fun Icon(
  * Icon component that draws [bitmap] using [tint], defaulting to [LocalContentColor]. For a
  * clickable icon, see [IconButton].
  *
- * To learn more about icons, see [Material Design icons](https://m3.material.io/styles/icons/overview)
- *
  * @param bitmap [ImageBitmap] to draw inside this icon
  * @param contentDescription text used by accessibility services to describe what this icon
- * represents. This should always be provided unless this icon is used for decorative purposes, and
- * does not represent a meaningful action that a user can take. This text should be localized, such
- * as by using [androidx.compose.ui.res.stringResource] or similar
- * @param modifier the [Modifier] to be applied to this icon
- * @param tint tint to be applied to [bitmap]. If [Color.Unspecified] is provided, then no tint is
- * applied.
+ * represents. This should always be provided unless this icon is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier optional [Modifier] for this Icon
+ * @param tint to be applied to [bitmap]. If no intent is provided, then a default is used
+ * @param iconSize one of [IconSize] to be applied as size of the icon.
+ * If no size is provided the default [IconSize.Medium] is used.
  */
 @Composable
 public fun Icon(
     bitmap: ImageBitmap,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    tint: Color = LocalContentColor.current,
+    tint: IconTints = IconDefaults.color,
+    iconSize: IconSize = IconDefaults.size,
 ) {
     MaterialIcon(
         bitmap = bitmap,
         contentDescription = contentDescription,
-        modifier = modifier.sparkUsageOverlay(),
-        tint = tint,
+        modifier = modifier
+            .sparkUsageOverlay()
+            .size(iconSize.size),
+        tint = tint.color(),
     )
 }
 
 /**
- * Icon component that draws a [painter] using [tint], defaulting to [LocalContentColor]. For a
+ * Icon component that draws [painter] using [tint], defaulting to [LocalContentColor]. For a
  * clickable icon, see [IconButton].
- *
- * To learn more about icons, see [Material Design icons](https://m3.material.io/styles/icons/overview)
  *
  * @param painter [Painter] to draw inside this icon
  * @param contentDescription text used by accessibility services to describe what this icon
- * represents. This should always be provided unless this icon is used for decorative purposes, and
- * does not represent a meaningful action that a user can take. This text should be localized, such
- * as by using [androidx.compose.ui.res.stringResource] or similar
- * @param modifier the [Modifier] to be applied to this icon
- * @param tint tint to be applied to [painter]. If [Color.Unspecified] is provided, then no tint is
- * applied.
+ * represents. This should always be provided unless this icon is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier optional [Modifier] for this Icon
+ * @param tint to be applied to [painter]. If no intent is provided, then a default is used
+ * @param iconSize one of [IconSize] to be applied as size of the icon.
+ * If no size is provided the default [IconSize.Medium] is used.
  */
 @Composable
 public fun Icon(
     painter: Painter,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    tint: Color = LocalContentColor.current,
+    tint: IconTints = IconDefaults.color,
+    iconSize: IconSize = IconDefaults.size,
 ) {
     MaterialIcon(
         painter = painter,
+        contentDescription = contentDescription,
+        modifier = modifier
+            .sparkUsageOverlay()
+            .size(iconSize.size),
+        tint = tint.color(),
+    )
+}
+
+/**
+ * Icon component that draws [sparkIcon] using [tint], defaulting to [LocalContentColor].
+ * An internal function used for other Spark components internally.
+ *
+ * @param sparkIcon [SparkIcon] to draw inside this Icon
+ * @param contentDescription text used by accessibility services to describe what this icon
+ * represents. This should always be provided unless this icon is used for decorative purposes,
+ * and does not represent a meaningful action that a user can take. This text should be
+ * localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier optional [Modifier] for this Icon
+ * @param tint tint to be applied to [sparkIcon]. If [Color.Unspecified] is provided, then no
+ *  tint is applied
+ */
+@Composable
+internal fun Icon(
+    sparkIcon: SparkIcon,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current,
+) {
+    MaterialIcon(
+        painter = rememberSparkIconPainter(sparkIcon),
         contentDescription = contentDescription,
         modifier = modifier.sparkUsageOverlay(),
         tint = tint,
@@ -170,5 +220,39 @@ public fun rememberSparkIconPainter(sparkIcon: SparkIcon): Painter {
         }
 
         else -> error("Can't found Painter for sparkIcon $sparkIcon")
+    }
+}
+
+
+@Preview(
+    group = "Icon",
+    name = "Icon",
+)
+@Composable
+internal fun IconPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconSize.values().map { it to IconTints.values() }.forEach { (size, tints) ->
+            LazyRow {
+                items(
+                    tints.count(),
+                    itemContent = { index ->
+                        Box(
+                            modifier = Modifier.ifTrue(tints[index] == IconTints.Surface) {
+                                background(SparkTheme.colors.neutralContainer)
+                            },
+                        ) {
+                            Icon(
+                                sparkIcon = SparkIcon.Toggles.Check.Simple,
+                                tint = tints[index],
+                                contentDescription = "Done",
+                                size = size,
+                            )
+                        }
+                    },
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
## 📋 Changes description
- Update Icons component to respect Spark specs (with preset sizes and tints).

## 📸 Screenshots
Generated by paparazzi in this PR files

close #344 
