### PR TITLE
ci: add support for automated paparazzi update

### DIFF
--- a/.github/actions/paparazzi-golden-images/action.yml
+++ b/.github/actions/paparazzi-golden-images/action.yml
@@ -1,0 +1,44 @@
+name: '📸 Paparazzi golden images'
+description: 'Update Paparazzi golden images and commit the result'
+
+inputs:
+  github-token:
+    description: 'GitHub token'
+    required: true
+  ref:
+    description: 'Branch, tag, SHA, …'
+    required: true
+    default: '${{ github.event.repository.default_branch }}'
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        lfs: true
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - uses: ./.github/actions/setup-gradle-properties
+    - uses: gradle/wrapper-validation-action@8d49e559aae34d3e0eb16cde532684bc9702762b # v1.0.6
+    - uses: actionsdesk/lfs-warning@e5f9a4c21f4bee104db7c0f23954dde59e5df909 # v3.2
+    - uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629 # v2.4.2
+      with:
+        arguments: recordPaparazziRelease
+        gradle-home-cache-cleanup: true
+    - run: |
+        if ! git diff --quiet --exit-code -- **/src/test/snapshots/**/*.png ;
+        then
+          git config user.name 'spark-ui-bot'
+          git config user.email 'spark-ui-bot@users.noreply.github.com'
+          git commit **/src/test/snapshots/**/*.png -m "📸 Update Paparazzi golden images"
+          git show
+          git push
+          echo "::notice::UPDATED"
+        else
+          echo "::notice::UP-TO-DATE"
+        fi
+      shell: bash

--- a/.github/actions/paparazzi-report/action.yml
+++ b/.github/actions/paparazzi-report/action.yml
@@ -17,7 +17,7 @@ runs:
           echo "🚨 UI regression detected! Checkout the [paparazzi-delta](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) artifact." ; \
           echo -e "If these changes are expected, you can either:" ; \
           echo -e "- manually run the \`gradlew recordPaparazziRelease\` and commit the new golden images" ; \
-          echo -e "- or ask \`@adevinta/spark-ui-bot paparazzi golden images\` in this PR (🚧 work in progress 🚧)" ; \
+          echo -e "- or ask \`@spark-ui-bot paparazzi golden images\` in this PR" ; \
         ) | gh pr comment "$PR_NUMBER" --body-file -
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/workflows/chat-bot-commands.yml
+++ b/.github/workflows/chat-bot-commands.yml
@@ -1,0 +1,29 @@
+name: '🧰 Chat Bot Commands'
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  check-comment:
+    name: Check comment
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '@spark-ui-bot')
+    env:
+      ACTOR: ${{ github.actor }}
+      NUMBER: ${{ github.event.issue.number }}
+      COMMENT: ${{ github.event.comment.body }}
+    steps:
+      - uses: actions/checkout@v3
+      - if: github.event.issue.pull_request
+        run: gh pr checkout $NUMBER
+
+      - name: Paparazzi golden images
+        if: github.event.issue.pull_request && contains(github.event.comment.body, 'paparazzi golden images')
+        uses: ./.github/actions/paparazzi-golden-images
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## 📋 Changes description

Enable new chat-bot automations with trigger comments.

- `@spark-ui-bot paparazzi golden images` will run `gradlew recordPaparazziRelease` and commit any update if necessary.