### PR TITLE
fix: Handle disabled colors for ButtonOutlined

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttonoutlined_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttonoutlined_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de9a8a7a1afffdaf10ece73ce2b76c0e1a0b69f9c0306ee036c4bc71603c85e2
-size 28103
+oid sha256:76bc81a14b1cfa7768231a6c28e07d9bdb662f11bfa6dd4342c95c7649e1b80c
+size 27119

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttonoutlined_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttonoutlined_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a072951c00caaef6aac2a1ec5ba31f60dbcb3d83fefb1a7490a8582aa479084
-size 26350
+oid sha256:0e65c4aca0944a55e5e782bc6a78dc184502997b331c4cc1c6252af60f6a94e9
+size 25990

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonOutlined.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -76,8 +77,12 @@ public fun ButtonOutlined(
         targetValue = intent.colors().color,
         label = "content color",
     )
+    val disabledContentColor = contentColor.copy(alpha = SparkTheme.colors.dim3)
+        .compositeOver(SparkTheme.colors.surface)
+
     val colors = ButtonDefaults.outlinedButtonColors(
         contentColor = contentColor,
+        disabledContentColor = disabledContentColor,
     )
     SparkButton(
         onClick = onClick,
@@ -86,7 +91,7 @@ public fun ButtonOutlined(
         size = size,
         enabled = enabled,
         elevation = null,
-        border = SparkButtonDefaults.outlinedBorder(contentColor),
+        border = SparkButtonDefaults.outlinedBorder(if (enabled) contentColor else disabledContentColor),
         colors = colors,
         icon = icon,
         iconSide = iconSide,


### PR DESCRIPTION
## 📋 Changes description
- Update content color and border color of the `ButtonOutlined` when disabled. 

## 📸 Screenshots
Present in the current PR

## 🗒️ Other info
close #399 
