### PR TITLE
doc: Remove duplicated doc in components README.md

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
@@ -11,23 +11,6 @@ A badge is a visual indicator for numeric values such as tallies and scores.
 
 ### Styles
 
-|       | Danger and Info                                                                                                                                                  |
-|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Light | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badge_light.png) |
-| Dark  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badge_dark.png)  |
-
-```kotlin
-@Composable
-fun Badge(
-    count: Int,
-    modifier: Modifier = Modifier,
-    badgeStyle: BadgeStyle = BadgeStyle.Medium,
-    intent: BadgeIntent = BadgeIntent.Danger,
-    overflowCount: Int = BADGE_MAX_COUNT,
-    hasBorder: Boolean = true,
-)
-```
-
 The default value of overflowCount is 99. When count is larger than 99, a `+` is displayed.
 A badge can be used as a part of `BadgedBox` or as a standalone when it is not attached visually to
 a specific relative element.
@@ -51,50 +34,9 @@ Badge(
 The badges can have a count with and overflow specified. If no overflow count is passed,
 the default of 99 is used.
 
-```kotlin
-@Composable
-public fun Badge(
-    count: Int,
-    modifier: Modifier = Modifier,
-    badgeStyle: BadgeStyle = BadgeStyle.Medium,
-    intent: BadgeIntent = BadgeIntent.Danger,
-    overflowCount: Int = BADGE_MAX_COUNT,
-    hasBorder: Boolean = true,
-)
-```
-
-| Parameters                                   | Descriptions                                             |
-|----------------------------------------------|----------------------------------------------------------|
-| `count: Int`                                 | The count to use inside the label                        |
-| `modifier: Modifier = Modifier`              | The Modifier to be applied to this badge                 |                                                                                                                     |
-| `badgeStyle: BadgeStyle = BadgeStyle.Medium` | The style of the badge which defines its size            |
-| `intent: BadgeIntent = BadgeIntent.Danger`   | The [BadgeIntent](BadgeIntent.kt) color to use           |
-| `overflowCount: Int = BADGE_MAX_COUNT`       | Defines the max count starting from which + is displayed |
-| `hasBorder: Boolean = true`                  | hWhether a border should be drawn                        |
-
 Instead of the count badge can accept an optional `@Composable` content.
 If no content is passed, an empty badge is drawn.
-
-```kotlin
-@Composable
-public fun Badge(
-    modifier: Modifier = Modifier,
-    badgeStyle: BadgeStyle = BadgeStyle.MEDIUM,
-    intent: BadgeIntent = BadgeIntent.Danger,
-    hasStroke: Boolean = true,
-    contentDescription: String? = null,
-    content: (@Composable () -> Unit)? = null,
-)
-```
-
-| Parameters                                   | Descriptions                                         |
-|----------------------------------------------|------------------------------------------------------|
-| `modifier: Modifier = Modifier`              | The `Modifier` to be applied to this badge           |                                                                                                                     |
-| `badgeStyle: BadgeStyle = BadgeStyle.Medium` | Style of the badge which defines its size            |
-| `intent: BadgeIntent = BadgeIntent.Danger`   | the [BadgeIntent](BadgeIntent.kt) color to use       |
-| `hasStroke: Boolean = true`                  | Whether a border should be drawn                     |
-| `contentDescription: String? = null`         | A content description to use instead of default      |
-| `content: (@Composable () -> Unit)? = null`  | An optional content to be rendered inside this badge |                                                                        |
+|
 
 ### Style
 
@@ -124,18 +66,3 @@ Badge(
 ## Layout
 
 BadgedBox can be used to position the badge at the top right corner of another component.
-
-```kotlin
-@Composable
-public fun BadgedBox(
-    badge: @Composable BoxScope.() -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable BoxScope.() -> Unit,
-)
-```
-
-| Parameters                                 | Descriptions                                              |
-|--------------------------------------------|-----------------------------------------------------------|
-| `badge: @Composable BoxScope.() -> Unit`   | The badge to be displayed - typically a [Badge](Badge.kt) |
-| `modifier: Modifier = Modifier`            | The `Modifier` to be applied to this BadgedBox            |
-| `content: @Composable RowScope.() -> Unit` | The anchor to which this badge will be positioned         |

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Buttons.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Buttons.md
@@ -18,22 +18,6 @@ on [spark.adevinta.com](https://spark.adevinta.com/1186e1705/p/34b742-button/b/3
 
 ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttonsizes_light.png)
 
-```kotlin
-@Composable
-fun ButtonFilled(
-    onClick: () -> Unit,
-    text: String,
-    modifier: Modifier = Modifier,
-    size: ButtonSize = ButtonSize.Medium,
-    intent: ButtonIntent = ButtonIntent.Primary,
-    enabled: Boolean = true,
-    icon: SparkIcon? = null,
-    iconSide: IconSide = IconSide.START,
-    isLoading: Boolean = false,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-)
-```
-
 The minimal usage of the component is the text and the click action.
 
 ```kotlin
@@ -47,18 +31,6 @@ The buttons have an loading state that can be used to indicate that the button i
 data and show/hide an indeterminate circular progress indicator on the start of the button.
 
 ![](../../../../../../../../../art/components/button/loading-button.gif)
-
-| Parameters                                                                              | Descriptions                                                                                                                                                                                                                                                    |
-|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `onClick: () -> Unit`                                                                   | The callback to be called when the user click on the button                                                                                                                                                                                                     |
-| `text: String or AnnotatedString`                                                       | The text to be displayed in the button                                                                                                                                                                                                                          | Modifier to be applied to the button                                                                                                                       |
-| `size: ButtonSize = ButtonSize.Medium`                                                  | The size of the button                                                                                                                                                                                                                                          |
-| `intent: ButtonIntent = ButtonIntent.Primary`                                           | The intent color for the button.                                                                                                                                                                                                                                |
-| `enabled: Boolean = true`                                                               | True Controls the enabled state of the button. When `false`, this button will not be clickable                                                                                                                                                                  |
-| `icon: (@Composable () -> Unit)? = null`                                                | The optional icon to be displayed at the start or the end of the button container.                                                                                                                                                                              |
-| `iconSide: IconSide = IconSide.LEFT`                                                    | If an icon is added, you can configure the side at the start or end of the button                                                                                                                                                                               |
-| `isLoading: Boolean = false`                                                            | show or hide a CircularProgressIndicator at the start that push the content to indicate a loading state                                                                                                                                                         |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the **MutableInteractionSource** representing the stream of **Interaction**s for this button. You can create and pass in your own `remember`ed instance to observe **Interaction**s and customize the appearance / behavior of this button in different states. |
 
 ### All Styles
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.md
@@ -17,56 +17,8 @@ trigger actions, make selections, or filter content.
 | Light | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chips_part_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chips_pro_light.png) |
 | Dark  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chips_part_dark.png)  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chips_pro_dark.png)  |
 
-```kotlin
-@Composable
-fun Chip(
-    style: ChipStyles,
-    intent: ChipIntent,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    content: @Composable RowScope.() -> Unit,
-)
-```
+Most commonly chip contains an optional `leadingIcon` and the text.
 
-| Parameters                                                                              | Descriptions                                                                                                             |
-|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `style: ChipStyles`                                                                     | One of [ChipStyles](ChipStyles.kt) that defines chips background and border color                                        |
-| `intent: ChipIntent`                                                                    | The [ChipIntent](ChipIntent.kt) colors that will be used for the content and background of this chip in different states |
-| `onClick: () -> Unit`                                                                   | Called when this chip is clicked                                                                                         |
-| `modifier: Modifier = Modifier`                                                         | The `Modifier` to be applied to this badge                                                                               |                                                                                                                     |
-| `enabled: Boolean = true`                                                               | Controls the enabled state of this chip                                                                                  |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the `MutableInteractionSource` representing the stream of `Interaction`s                                                 |
-| `content: @Composable RowScope.() -> Unit`                                              | Composable to set as the chip's custom content                                                                           |
-
-Most commonly chip contains an optional `leadingIcon` and the text:
-
-```kotlin
-fun Chip(
-    style: ChipStyles,
-    intent: ChipIntent,
-    onClick: () -> Unit,
-    text: String?,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    leadingIcon: SparkIcon? = null,
-    contentDescription: String? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-)
-```
-
-| Parameters                                                                              | Descriptions                                                                                                             |
-|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `style: ChipStyles`                                                                     | One of [ChipStyles](ChipStyles.kt) that defines chips background and border                                              |
-| `intent: ChipIntent`                                                                    | The [ChipIntent](ChipIntent.kt) colors that will be used for the content and background of this chip in different states |
-| `onClick: () -> Unit`                                                                   | Called when this chip is clicked                                                                                         |
-| `text: String?`                                                                         | Label for this chip, set `null` if no label is needed                                                                    |
-| `modifier: Modifier = Modifier`                                                         | The `Modifier` to be applied to this badge                                                                               |                                                                                                                     |
-| `enabled: Boolean = true`                                                               | Controls the enabled state of this chip                                                                                  |
-| `leadingIcon: SparkIcon? = null`                                                        | Optional icon at the start of the chip, preceding the `text`                                                             |
-| `contentDescription: String? = null`                                                    | Text used by accessibility services to describe what this icon represents                                                |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | The `MutableInteractionSource` representing the stream of `Interaction`s                                                 |
 
 ### Style
 
@@ -101,14 +53,18 @@ Part:
 | Dashed   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_part_light.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_part_dark.png)   |
 
 Pro:
-| Style    | Light                                                                                                                                                                         | Dark                                                                                                                                                                         |
+| Style | Light | Dark |
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Outlined | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_pro_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_pro_dark.png) |
-| Filled   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_pro_light.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_pro_dark.png)   |
-| Tinted   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_pro_light.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_pro_dark.png)   |
-| Dashed   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_pro_light.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_pro_dark.png)   |
+|
+Outlined | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_pro_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_pro_dark.png) |
+|
+Filled | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_pro_light.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_pro_dark.png)   |
+|
+Tinted | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_pro_light.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_pro_dark.png)   |
+|
+Dashed | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_pro_light.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_pro_dark.png)   |
 
-To draw a chip with an optional leading icon and text:
+To draw a chip with an optional leading icon and text.
 ```kotlin
 fun ChipOutlined(
     text: String,
@@ -120,16 +76,6 @@ fun ChipOutlined(
     onClick: () -> Unit = {},
 )
 ```
-
-| Parameters                                                                              | Descriptions                                                                                                             |
-|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `intent: ChipIntent`                                                                    | The [ChipIntent](ChipIntent.kt) colors that will be used for the content and background of this chip in different states |
-| `onClick: () -> Unit`                                                                   | Called when this chip is clicked                                                                                         |
-| `text: String?`                                                                         | Label for this chip, set `null` if no label is needed                                                                    |
-| `modifier: Modifier = Modifier`                                                         | The `Modifier` to be applied to this badge                                                                               |                                                                                                                     |
-| `enabled: Boolean = true`                                                               | Controls the enabled state of this chip                                                                                  |
-| `leadingIcon: SparkIcon? = null`                                                        | Optional icon at the start of the chip, preceding the `text`                                                             |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | The `MutableInteractionSource` representing the stream of `Interaction`s                                                 |
 
 To draw a chip that only contains an icon:
 
@@ -145,17 +91,6 @@ fun ChipOutlined(
 )
 ```
 
-| Parameters                                                                              | Descriptions                                                                                                             |
-|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `icon: SparkIcon`                                                                       | icon to draw inside the chip's content                                                                                   |
-| `intent: ChipIntent`                                                                    | The [ChipIntent](ChipIntent.kt) colors that will be used for the content and background of this chip in different states |
-| `onClick: () -> Unit`                                                                   | Called when this chip is clicked                                                                                         |
-| `modifier: Modifier = Modifier`                                                         | The `Modifier` to be applied to this badge                                                                               |                                                                                                                     |
-| `enabled: Boolean = true`                                                               | Controls the enabled state of this chip                                                                                  |
-| `leadingIcon: SparkIcon? = null`                                                        | Optional icon at the start of the chip, preceding the `text`                                                             |
-| `contentDescription: String? = null`                                                    | Text used by accessibility services to describe what this icon represents                                                |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | The `MutableInteractionSource` representing the stream of `Interaction`s                                                 |
-
 To pass a custom content:
 
 ```kotlin
@@ -168,16 +103,6 @@ fun ChipOutlined(
     content: @Composable RowScope.() -> Unit,
 )
 ```
-
-| Parameters                                                                              | Descriptions                                                                                                             |
-|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `intent: ChipIntent`                                                                    | The [ChipIntent](ChipIntent.kt) colors that will be used for the content and background of this chip in different states |
-| `modifier: Modifier = Modifier`                                                         | The `Modifier` to be applied to this badge                                                                               |
-| `enabled: Boolean = true`                                                               | Controls the enabled state of this chip                                                                                  |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | The `MutableInteractionSource` representing the stream of `Interaction`s                                                 |
-| `onClick: () -> Unit`                                                                   | Called when this chip is clicked                                                                                         |
-| `content: @Composable RowScope.() -> Unit`                                              | A Composable to set as the chip's custom content                                                                         |
-
 
 ### Handling selection
 Chips in Spark don’t control the selected style when grouped.

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icon.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icon.md
@@ -15,24 +15,6 @@ This component is the wrapper of the icons that you can find in Spark Foundation
 | Light | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_light.png) |
 | Dark  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_icon_icon_dark.png)  |
 
-```kotlin
-@Composable
-public fun Icon(
-    sparkIcon: SparkIcon,
-    contentDescription: String?,
-    modifier: Modifier = Modifier,
-    tint: IconTints = IconDefaults.color,
-    size: IconSize = IconDefaults.size,
-)
-```
-
-| Parameters                             | Descriptions                                                                                                                       |
-|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| `sparkIcon: SparkIcon`                 | [SparkIcon](../../../../../../../../../spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcon.kt) to draw inside this Icon |
-| `contentDescription: String?`          | Text used by accessibility services to describe what this icon represents                                                          |
-| `modifier: Modifier = Modifier`        | An optional `Modifier` to be applied to this icon                                                                                  |                                                                                                                     |
-| `tint: IconTints = IconDefaults.color` | One of the [IconTint](IconTints.kt)s to be applied to `sparkIcon`. If no tint is provided, then a default is used                  |
-| `size: IconSize = IconDefaults.size`   | One of [IconSize](IconDefaults.kt)s to be applied as size of the icon                                                              |
 
 Icon component that draws `sparkIcon` using `tint`, defaulting to `LocalContentColor`. For a
 clickable icon, see [IconButton](IconButton.kt).
@@ -41,64 +23,7 @@ Instead of [SparkIcon](../../../../../../../../../spark-icons/src/main/kotlin/co
 - [ImageVector]
 - [ImageBitmap]
 - [Painter]
-
-```kotlin
-@Composable
-public fun Icon(
-    imageVector: ImageVector,
-    contentDescription: String?,
-    modifier: Modifier = Modifier,
-    tint: IconTints = IconDefaults.color,
-    size: IconSize = IconDefaults.size,
-)
-```
-
-| Parameters                             | Descriptions                                                                                                    |
-|----------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| `imageVector: ImageVector`             | `ImageVector` to draw inside this Icon                                                                          |
-| `contentDescription: String?`          | Text used by accessibility services to describe what this icon represents                                       |
-| `modifier: Modifier = Modifier`        | optional `Modifier` to be applied to this icon                                                                  |                                                                                                                     |
-| `tint: IconTints = IconDefaults.color` | One of [IconTint](IconTints.kt)s to be applied to `imageVector`. If no tint is provided, then a default is used |
-| `size: IconSize = IconDefaults.size`   | One of [IconSize](IconDefaults.kt)  to be applied as size of the icon                                           |
-
-```kotlin
-@Composable
-public fun Icon(
-    bitmap: ImageBitmap,
-    contentDescription: String?,
-    modifier: Modifier = Modifier,
-    tint: IconTints = IconDefaults.color,
-    size: IconSize = IconDefaults.size,
-)
-```
-
-| Parameters                             | Descriptions                                                                                              |
-|----------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| `bitmap: ImageBitmap`                  | `ImageBitmap` to draw inside this Icon                                                                    |
-| `contentDescription: String?`          | text used by accessibility services to describe what this icon represents                                 |
-| `modifier: Modifier = Modifier`        | optional `Modifier` to be applied to this icon                                                            |                                                                                                                     |
-| `tint: IconTints = IconDefaults.color` | a tint [IconTint](IconTints.kt) to be applied to `bitmap`. If no tint is provided, then a default is used |
-| `size: IconSize = IconDefaults.size`   | size one of [IconSize](IconDefaults.kt) to be applied as size of the icon                                 |
-
-```kotlin
-@Composable
-public fun Icon(
-    painter: Painter,
-    contentDescription: String?,
-    modifier: Modifier = Modifier,
-    tint: IconTints = IconDefaults.color,
-    size: IconSize = IconDefaults.size,
-)
-```
-
-| Parameters                             | Descriptions                                                                                               |
-|----------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `painter: Painter`                     | `Painter` to draw inside this Icon                                                                         |
-| `contentDescription: String?`          | text used by accessibility services to describe what this icon represents                                  |
-| `modifier: Modifier = Modifier`        | optional `Modifier` to be applied to this icon                                                             |                                                                                                                     |
-| `tint: IconTints = IconDefaults.color` | a tint [IconTint](IconTints.kt) to be applied to `painter`. If no tint is provided, then a default is used |
-| `size: IconSize = IconDefaults.size`   | size one of [IconSize](IconDefaults.kt) to be applied as size of the icon                                  |
-
+-
 
 ### Style
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/Spinner.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/Spinner.md
@@ -18,25 +18,6 @@ Spinners provide a visual clue that an action is processing awaiting a course of
 | Dark  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_spinner_spinnermedium_part_dark.png)  | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_spinner_spinnermedium_pro_dark.png)  |
 |       | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_spinner_spinnersmall_part_dark.png)   | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_spinner_spinnersmall_pro_dark.png)   |
 
-```kotlin
-@Composable
-fun Spinner(
-    intent: SpinnerIntent,
-    modifier: Modifier = Modifier,
-    size: SpinnerSize = SpinnerDefaults.CircularSize,
-    isBackgroundVisible: Boolean = false,
-)
-```
-
-| Parameters                                         | Descriptions                                                                          |
-|----------------------------------------------------|---------------------------------------------------------------------------------------|
-| `intent: SpinnerIntent`                            | One of [SpinnerIntent](SpinnerIntent.kt) colors that will be used to draw the spinner |
-| `modifier: Modifier = Modifier`                    | Modifier to be applied to this badge                                                  |                                                                                                                     |
-| `size: SpinnerSize = SpinnerDefaults.CircularSize` | one of the [SpinnerSize](SpinnerDefaults.kt) that defines the size of the component   |
-| `isBackgroundVisible: Boolean = false`             | whether a background should be drawn                                                  |
-
-### Style
-
 A visible background may be added to display a background behind the spinner.
 
 All intents from Spark are available for this component ([SpinnerIntent](SpinnerIntent.kt)).

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.md
@@ -13,17 +13,6 @@ on [zeroheight.com/25c15666f/](https://zeroheight.com/25c15666f/p/72b9ad-checkbo
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkbox_part_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkbox_part_dark.png) |
 
-```kotlin
-@Composable
-fun Checkbox(
-    state: Boolean,
-    onCheckedChange: (() -> Unit)?,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-)
-```
-
 Checkboxes allows users to select one or more items from a set. Checkboxes can turn an option on or
 off.
 
@@ -43,14 +32,6 @@ Checkbox(
 )
 ```
 
-| Parameters                                                                              | Descriptions                                                                                                                                                                                                                                                                                       |
-|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `checked: Boolean`                                                                      | whether Checkbox is checked or unchecked                                                                                                                                                                                                                                                           |
-| `onClick: (() -> Unit)?`                                                                | callback to be invoked when checkbox is being clicked, therefore the change of checked state in requested. If null, then this is passive and relies entirely on a higher-level component to control the "checked" state.                                                                           |
-| `modifier: Modifier = Modifier`                                                         | A Modifier for this Checkbox                                                                                                                                                                                                                                                                       |
-| `enabled: Boolean = true`                                                               | whether the component is enabled or grayed out                                                                                                                                                                                                                                                     |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the [MutableInteractionSource] representing the stream of [Interaction]s for this Checkbox. You can create and pass in your own remembered [MutableInteractionSource] if you want to observe [Interaction]s and customize the appearance / behavior of this TextField in different [Interaction]s. |
-
 ---
 
 ### CheckBoxLabelled
@@ -58,19 +39,6 @@ Checkbox(
 | Light                                                                                                                                                                              | Dark                                                                                                                                                                              |
 |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkboxlabelled_part_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkboxlabelled_part_dark.png) |
-
-```kotlin
-@Composable
-fun CheckboxLabelled(
-    state: ToggleableState,
-    onClick: (() -> Unit)?,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    contentSide: ContentSide = ContentSide.End,
-    content: @Composable RowScope.() -> Unit,
-)
-```
 
 The Checkbox allows users to select one or more items from a set. Checkboxes can turn an option on
 or off.
@@ -88,16 +56,6 @@ CheckboxLabelled(
     onClick = {},
 ) { Text("CheckBox On") }
 ```
-
-| Parameters                                                                              | Descriptions                                                                                                                                                                                                                                                                                       |
-|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `checked: Boolean`                                                                      | whether Checkbox is checked or unchecked                                                                                                                                                                                                                                                           |
-| `onClick: (() -> Unit)?`                                                                | callback to be invoked when checkbox is being clicked, therefore the change of checked state in requested. If null, then this is passive and relies entirely on a higher-level component to control the "checked" state.                                                                           |
-| `modifier: Modifier = Modifier`                                                         | A Modifier for this text field                                                                                                                                                                                                                                                                     |
-| `enabled: Boolean = true`                                                               | whether the component is enabled or grayed out                                                                                                                                                                                                                                                     |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the [MutableInteractionSource] representing the stream of [Interaction]s for this Checkbox. You can create and pass in your own remembered [MutableInteractionSource] if you want to observe [Interaction]s and customize the appearance / behavior of this TextField in different [Interaction]s. |
-| `contentSide: ContentSide = ContentSide.End`                                            | The side where we want to show the label, default to [ContentSide.End].                                                                                                                                                                                                                            |
-| `content: @Composable RowScope.() -> Unit`                                              | The content displayed after the checkbox, usually a Text composable shown at the end.                                                                                                                                                                                                              |                                                                                                                                                                                                                                                                                                    |
 
 ## Layout
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.md
@@ -13,17 +13,6 @@ on [spark.adevinta.com](https://spark.adevinta.com/1186e1705/p/98058f-radio-butt
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobutton_part_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobutton_part_dark.png) |
 
-```kotlin
-@Composable
-fun RadioButton(
-    selected: Boolean,
-    onClick: (() -> Unit)?,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-)
-```
-
 The primary radio button allow users to select one option from a set.
 
 - Use radio buttons to select a single option from a list
@@ -45,14 +34,6 @@ RadioButton(
 )
 ```
 
-| Parameters                                                                              | Descriptions                                                                                                                                                                                                                                                                                            |
-|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `selected: Boolean`                                                                     | whether this radio button is selected or not                                                                                                                                                                                                                                                            |
-| `onClick: (() -> Unit)?`                                                                | callback to be invoked when the RadioButton is clicked. If null, then this RadioButton will not handle input events, and only act as a visual indicator of selected state                                                                                                                               |
-| `modifier: Modifier = Modifier`                                                         | A Modifier for this RadioButton                                                                                                                                                                                                                                                                         |
-| `enabled: Boolean = true`                                                               | whether the component is enabled or grayed out                                                                                                                                                                                                                                                          |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the [MutableInteractionSource] representing the stream of [Interaction]s for this RadioButton. You can create and pass in your own remembered [MutableInteractionSource] if you want to observe [Interaction]s and customize the appearance / behavior of this RadioButton in different [Interaction]s. |
-
 ---
 
 ### CheckBoxLabelled
@@ -60,19 +41,6 @@ RadioButton(
 | Light                                                                                                                                                                                 | Dark                                                                                                                                                                                 |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobuttonlabelled_part_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobuttonlabelled_part_dark.png) |
-
-```kotlin
-@Composable
-public fun RadioButtonLabelled(
-    selected: Boolean,
-    onClick: (() -> Unit)?,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    contentSide: ContentSide = ContentSide.End,
-    content: @Composable RowScope.() -> Unit,
-)
-```
 
 The primary radio button allow users to select one option from a set.
 
@@ -94,16 +62,6 @@ RadioButtonLabelled(
     }
 ) { Text("RadioButton On") }
 ```
-
-| Parameters                                                                              | Descriptions                                                                                                                                                                                                                                                                                            |
-|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `selected: Boolean`                                                                     | whether this radio button is selected or not                                                                                                                                                                                                                                                            |
-| `onClick: (() -> Unit)?`                                                                | callback to be invoked when the RadioButton is clicked. If null, then this RadioButton will not handle input events, and only act as a visual indicator of selected state                                                                                                                               |
-| `modifier: Modifier = Modifier`                                                         | A Modifier for this text field                                                                                                                                                                                                                                                                          |
-| `enabled: Boolean = true`                                                               | whether the component is enabled or grayed out                                                                                                                                                                                                                                                          |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the [MutableInteractionSource] representing the stream of [Interaction]s for this RadioButton. You can create and pass in your own remembered [MutableInteractionSource] if you want to observe [Interaction]s and customize the appearance / behavior of this RadioButton in different [Interaction]s. |
-| `contentSide: ContentSide = ContentSide.End`                                            | The side where we want to show the label, default to [ContentSide.End].                                                                                                                                                                                                                                 |
-| `content: @Composable RowScope.() -> Unit`                                              | The content displayed after the radio button, usually a Text composable shown at the end.                                                                                                                                                                                                               |                                                                                                                                                                                                                                                                                                    |
 
 ## Layout
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.md
@@ -24,28 +24,6 @@ It is also used to control binary options (On/Off or True/False).
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_switch_part_light.png) | ![](../../../../../../../../../spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_switch_part_dark.png) |
 
-```kotlin
-@Composable
-public fun Switch(
-    checked: Boolean,
-    onCheckedChange: ((Boolean) -> Unit)?,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    icons: SwitchIcons? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-)
-```
-
-| Parameters                                                                              | Descriptions                                                                                                                                                                                                                                                                                            |
-|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `checked: Boolean`                                                                      | whether or not this component is checked                                                                                                                                                                                                                                                                |
-| `onCheckedChange: (() -> Unit)?`                                                        | callback to be invoked when Switch is being clicked, therefore the change of checked state is requested. If null, then this is passive and relies entirely on a higher-level component to control the "checked" state.                                                                                  |
-| `modifier: Modifier = Modifier`                                                         | Modifier to be applied to the switch layout                                                                                                                                                                                                                                                             |
-| `enabled: Boolean = true`                                                               | whether the component is enabled or grayed out                                                                                                                                                                                                                                                          |
-| `icons: SwitchIcons? = null,`                                                           | represents the pair of icons to use for check/unchecked states, you can use [SwitchDefaults.icons](SwitchDefaults.kt) if you want to use the default ones.                                                                                                                                              |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the `MutableInteractionSource` representing the stream of `Interaction`s for this RadioButton. You can create and pass in your own remembered `MutableInteractionSource` if you want to observe `Interaction`s and customize the appearance / behavior of this RadioButton in different `Interaction`s. |
-
-
 ### SwitchLabelled
 
 |      | Light                                                                                                                                                                            | Dark                                                                                                                                                                            |
@@ -69,30 +47,6 @@ SwitchLabelled(
     }
 ) { Text(text = "Switch On") }
 ```
-
-```kotlin
-@Composable
-public fun SwitchLabelled(
-    checked: Boolean,
-    onCheckedChange: ((Boolean) -> Unit)?,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    icons: SwitchIcons? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    contentSide: ContentSide = ContentSide.Start,
-    content: @Composable RowScope.() -> Unit,
-)
-```
-
-| Parameters                                                                              | Descriptions                                                                                                                                                                                                                                                                                            |
-|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `checked: Boolean`                                                                      | whether or not this component is checked                                                                                                                                                                                                                                                                |
-| `onCheckedChange: (() -> Unit)?`                                                        | callback to be invoked when Switch is being clicked, therefore the change of checked state is requested. If null, then this is passive and relies entirely on a higher-level component to control the "checked" state.                                                                                  |
-| `modifier: Modifier = Modifier`                                                         | Modifier to be applied to the switch layout                                                                                                                                                                                                                                                             |
-| `enabled: Boolean = true`                                                               | whether the component is enabled or grayed out                                                                                                                                                                                                                                                          |
-| `icons: SwitchIcons? = null,`                                                           | represents the pair of icons to use for check/unchecked states, you can use [SwitchDefaults.icons](SwitchDefaults.kt) if you want to use the default ones.                                                                                                                                              |
-| `interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | the `MutableInteractionSource` representing the stream of `Interaction`s for this RadioButton. You can create and pass in your own remembered `MutableInteractionSource` if you want to observe `Interaction`s and customize the appearance / behavior of this RadioButton in different `Interaction`s. |
-| `content: @Composable RowScope.() -> Unit`                                              | The content displayed before the switch, usually a Text composable shown at the start                                                                                                                                                                                                                   |
 
 ## Layout
 - The Switch respects the minimum touch size.


### PR DESCRIPTION
## 📋 Changes description
<!--- Describe your changes in detail -->
Remove the code block that show the signature of the component and the table with the parameter and their associated documentation

## 🤔 Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
since we plan to use Dokka to fully host our doc these part were a duplicate of what Dokka already offers so we're removing it

Close #424 