### PR TITLE
fix: downgrade JVM targets and compatibility modes to 11

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -25,14 +25,18 @@ plugins {
     `kotlin-dsl`
     alias(libs.plugins.spotless)
 }
-
-kotlin {
-    jvmToolchain(17)
-    explicitApi()
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 tasks.withType<KotlinCompile> {
     compilerOptions.allWarningsAsErrors.set(true)
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
+}
+
+kotlin {
+    explicitApi()
 }
 
 repositories {

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidApplicationPlugin.kt
@@ -21,11 +21,9 @@
  */
 package com.adevinta.spark
 
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
 
 internal class SparkAndroidApplicationPlugin : Plugin<Project> {
@@ -34,7 +32,7 @@ internal class SparkAndroidApplicationPlugin : Plugin<Project> {
             apply(plugin = "com.android.application")
             apply(plugin = "com.adevinta.spark.android")
 
-            configure<BaseAppModuleExtension> {
+            androidApplication {
                 defaultConfig {
                     targetSdk = spark().versions.targetSdk.toString().toInt()
                 }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidComposePlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidComposePlugin.kt
@@ -30,8 +30,9 @@ internal class SparkAndroidComposePlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = "org.jetbrains.kotlin.android")
+            apply(plugin = "com.adevinta.spark.android")
 
-            configureAndroidExtension {
+            android {
                 buildFeatures.compose = true
                 composeOptions {
                     kotlinCompilerExtensionVersion = spark().versions.`androidx-compose-compiler`.toString()

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidLibraryPlugin.kt
@@ -21,20 +21,19 @@
  */
 package com.adevinta.spark
 
-import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
 
 internal class SparkAndroidLibraryPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = "com.android.library")
             apply(plugin = "com.adevinta.spark.android")
-
-            configure<LibraryExtension> {
+            android {
                 resourcePrefix = "spark_"
+            }
+            androidLibrary {
                 defaultConfig {
                     consumerProguardFile("consumer-rules.pro")
                     aarMetadata.minCompileSdk = spark().versions.minCompileSdk.toString().toInt()

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidLintPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidLintPlugin.kt
@@ -34,7 +34,6 @@ internal class SparkAndroidLintPlugin : Plugin<Project> {
             apply(plugin = "com.android.lint")
 
             configureKotlin<KotlinJvmProjectExtension>()
-            configureKotlinCompiler()
 
             configure<Lint> {
                 warningsAsErrors = true

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkAndroidPlugin.kt
@@ -21,7 +21,6 @@
  */
 package com.adevinta.spark
 
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -34,15 +33,10 @@ public class SparkAndroidPlugin : Plugin<Project> {
             apply(plugin = "org.jetbrains.kotlin.android")
 
             configureKotlin<KotlinAndroidProjectExtension>()
-            configureKotlinCompiler()
 
-            configureAndroidExtension {
+            configureAndroid {
                 compileSdk = spark().versions.compileSdk.toString().toInt()
                 defaultConfig.minSdk = spark().versions.minCompileSdk.toString().toInt()
-                compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_17
-                    targetCompatibility = JavaVersion.VERSION_17
-                }
                 packaging {
                     resources {
                         excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkKotlinJvmPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkKotlinJvmPlugin.kt
@@ -32,7 +32,6 @@ internal class SparkKotlinJvmPlugin : Plugin<Project> {
             apply(plugin = "org.jetbrains.kotlin.jvm")
 
             configureKotlin<KotlinJvmProjectExtension>()
-            configureKotlinCompiler()
 
             addKotlinBom()
             SparkUnitTests.configureSubproject(this)


### PR DESCRIPTION
## 📋 Changes description

And remove JDK 17 toolchain enforcement.

## 🤔 Context

This would force consumers to upgrade their own targets:

```
Cannot inline bytecode built with JVM target 17 into bytecode that is being built with JVM target 11. Please specify proper '-jvm-target' option
```