### PR TITLE
fix: wrong icon replacement

### DIFF
--- a/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcon.kt
+++ b/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcon.kt
@@ -498,9 +498,9 @@ public sealed class SparkIcon {
 
         @Deprecated(
             message = "Use SparkIcons instead.",
-            replaceWith = ReplaceWith("SparkIcons.Clothes", "com.adevinta.spark.icons"),
+            replaceWith = ReplaceWith("SparkIcons.CategoriesClothesOutline", "com.adevinta.spark.icons"),
         )
-        public val Clothes: DrawableRes = SparkIcons.Clothes
+        public val Clothes: DrawableRes = SparkIcons.CategoriesClothesOutline
 
         @Deprecated(
             message = "Use SparkIcons instead.",


### PR DESCRIPTION
## 📋 Changes description

| CategoriesClothesOutline | Clothes |
|---|---|
| <img src="https://raw.githubusercontent.com/adevinta/spark-tokens/538143e5165ea42bf946b4cbbd2391620d74ae96/assets/spark/icons/CategoriesClothesOutline.svg">  |  <img src="https://raw.githubusercontent.com/adevinta/spark-tokens/538143e5165ea42bf946b4cbbd2391620d74ae96/assets/spark/icons/Clothes.svg"> |

