### PR TITLE
fix: Update UpNavigationIcon size to small

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_appbar_topappbar_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_appbar_topappbar_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0508c6296f1eb2b8866f5d0264b4623d96c16343aebbee1e9d0ca640a5e22e76
-size 56817
+oid sha256:d0f5ba20f6169b7243ba760a56f60f0cede637a4e3b8dc4b856d70c74bc6af40
+size 50096

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_appbar_topappbar_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_appbar_topappbar_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb67deccd7127d1403f609c61ef622204155bfe1437b8a0b9759c155a46871c4
-size 51132
+oid sha256:db8486e9acc8c8e0d408b2b6845093fe53265d8ec381a390e9b6731f0357b918
+size 45506

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.navigation.UpNavigationIcon
 import com.adevinta.spark.icons.BurgerMenu
 import com.adevinta.spark.icons.CameraFill
 import com.adevinta.spark.icons.SparkIcons
@@ -281,6 +282,13 @@ internal fun PreviewTopAppBar(
         themeVariant = theme,
         padding = PaddingValues(0.dp),
     ) {
+        TopAppBar(
+            title = { Text("Up TopAppBar") },
+            navigationIcon = {
+                UpNavigationIcon(onClick = { /* doSomething() */ })
+            }
+        )
+
         TopAppBar(
             title = { Text("Simple TopAppBar") },
             navigationIcon = {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
@@ -286,7 +286,7 @@ internal fun PreviewTopAppBar(
             title = { Text("Up TopAppBar") },
             navigationIcon = {
                 UpNavigationIcon(onClick = { /* doSomething() */ })
-            }
+            },
         )
 
         TopAppBar(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/UpNavigationIcon.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/UpNavigationIcon.kt
@@ -43,7 +43,7 @@ public fun UpNavigationIcon(
         onClick = onClick,
     ) {
         Icon(
-            size = IconSize.Small,
+            size = IconSize.Medium,
             sparkIcon = SparkIcons.ArrowLeft,
             contentDescription = contentDescription,
         )


### PR DESCRIPTION
📋 Changes description
The Up navigation icon got shrinked since the icons got updated for v0.2.0.

✅ Checklist
Introduced with new Icons from 0.2.0 milestone
Related to Remove Small size for button  #453
I have reviewed the submitted code.
I have tested on a phone device/emulator.

📸 Screenshots
Done after adding a preview