### PR TITLE
feat: Suppport all intent colors of badge

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44bb7fe0c948e4025d792c5906fbcbf4554b1e3d8c79ff9bbec294105d728966
-size 27939
+oid sha256:f0d6d1abc2df0732e194b5b47ac5d257ed42f29507c83cc396f74f548c553c51
+size 31109

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b79ae7ad1f98d34ccd82067eaa1efbf997f6a92eb1857e8c2db77043299241e9
-size 28053
+oid sha256:07d3c7b00d235cc954cef8367d6992c2bcc1aadf434420889134d12133f2af6f
+size 28054

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxnostroke_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxnostroke_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa4ffc852ececd7cd355e66739c6fa64662bee5f5ef7dbd31f2e1d4528fd6c
+size 99917

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxnostroke_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxnostroke_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73d2f174abc8b914980275e4eba8e71b479ceb7cedef2cb301ea9f763acebbac
+size 94806

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxwithstroke_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxwithstroke_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c33721ea77c018f1ffa43aa83cb36ef613aab0968a505816cf1a9047a7ca15e7
+size 119240

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxwithstroke_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxwithstroke_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:402d750bb5b62c95f9154ab031d3d5bb577e941e6232fd3557c40d25db1d58c1
+size 101489

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgenostroke_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgenostroke_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a692d217831700e4f0a532105838fc2e1a1a1a35f402505fb995271641fd257e
+size 90520

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgenostroke_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgenostroke_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fca4692d6188a597682e699a32efbf0bd6d9f5678c00dd3066b18b80dd249d36
+size 94499

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgewithstroke_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgewithstroke_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:860885253d7459bedb31cd9c6fead367be9280c89a8d703e7fede0d0d430d7d9
+size 137281

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgewithstroke_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgewithstroke_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2debd25a4bba8a71ef592a6dd1a568185a9e89930196818a5dcc0e2ea2004dae
+size 134933

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82ecbbcd84149675826dc770a5cf4aabfe71d2702e4c96350cc607c46e0dd68e
-size 4840
+oid sha256:66e3f1008a724ba3f87291f2bc515e77b08be1e30a0a21ebe85917d17718423f
+size 4837

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_illustration_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5eb16d9b25cd1b51b33d91d80df75f282e4ff403fb430870902deda1ad6e723
-size 4937
+oid sha256:2b88373b18f621e138e0f13207c73bfe18bc8d977f083373f41f7d48bbceef1a
+size 4935

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationdraweritem_navigationdraweritem_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_navigationdraweritem_navigationdraweritem_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94db128934f0164ad13c45dec513132c04d8c5edb1389e4f854f6e8f3cbf2486
-size 28587
+oid sha256:9ec1a615ed4dd8844c31d9ee76da79d5d842596c303153363684d39ca85f531c
+size 30927

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_textfields_multilinetextfield_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_textfields_multilinetextfield_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:362ee27680e400d4b8e4e845d8bd8236150c886ead506afe8f602acfbf1b1f01
-size 74621
+oid sha256:d411e19831b3d35d230ddf0ac061dd44c7e7c19eb7927d8b2a5e24b6a0b793ab
+size 74622

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_textfields_multilinetextfield_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_textfields_multilinetextfield_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:639a59fc3842e638194c0281d4a7aa2969954086827db0f16254e1a343f9998d
-size 68385
+oid sha256:bd28477fe877831e417389c8bbdeff9dbed00181e92527d24ffbf0de0fdbe80c
+size 68384

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
@@ -251,7 +251,6 @@ internal fun BadgeWithStrokeIntentPreview(
     }
 }
 
-
 @Composable
 private fun BadgeIntentPreview(intent: BadgeIntent, hasStroke: Boolean) {
     BadgeStyle.values().forEach {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
@@ -80,7 +80,7 @@ internal fun SparkBadge(
 
     Row(
         modifier = modifier
-            .ifTrue(hasStroke) { border(2.dp, SparkTheme.colors.surface, shape).padding(2.dp) }
+            .ifTrue(hasStroke) { border(2.dp, colors.onColor, shape).padding(2.dp) }
             .defaultMinSize(minWidth = size, minHeight = size)
             .background(
                 color = colors.color,
@@ -223,43 +223,52 @@ public fun Badge(
 
 @Preview(
     group = "Badge",
-    name = "Badge",
+    name = "Badge no stroke",
 )
 @Composable
-internal fun BadgePreview(
+internal fun BadgeNoStrokeIntentPreview(
     @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
 ) {
     PreviewTheme(theme) {
         BadgeIntent.values().forEach { intent ->
-            BadgeStyle.values().forEach {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Badge(badgeStyle = it, intent = intent, hasStroke = false)
-                    Badge(badgeStyle = it, intent = intent, hasStroke = false) { Text("56k") }
-                    Badge(badgeStyle = it, intent = intent, count = 3, hasStroke = false)
-                    Badge(badgeStyle = it, intent = intent, count = 99, hasStroke = false)
-                    Badge(badgeStyle = it, intent = intent, count = 200, overflowCount = 99, hasStroke = false)
-                    Badge(badgeStyle = it, intent = intent, count = 99, overflowCount = 999, hasStroke = false)
-                    Badge(badgeStyle = it, intent = intent, count = 1000, overflowCount = 999, hasStroke = false)
-                }
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(SparkTheme.colors.neutralContainer)
-                        .padding(4.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Badge(badgeStyle = it, intent = intent)
-                    Badge(badgeStyle = it, intent = intent) { Text("56k") }
-                    Badge(badgeStyle = it, intent = intent, count = 3)
-                    Badge(badgeStyle = it, intent = intent, count = 99)
-                    Badge(badgeStyle = it, intent = intent, count = 200, overflowCount = 99)
-                    Badge(badgeStyle = it, intent = intent, count = 99, overflowCount = 999)
-                    Badge(badgeStyle = it, intent = intent, count = 1000, overflowCount = 999)
-                }
-            }
+            BadgeIntentPreview(intent, hasStroke = false)
+        }
+    }
+}
+
+@Preview(
+    group = "Badge",
+    name = "Badge with stroke",
+)
+@Composable
+internal fun BadgeWithStrokeIntentPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        BadgeIntent.values().forEach { intent ->
+            BadgeIntentPreview(intent, hasStroke = true)
+        }
+    }
+}
+
+
+@Composable
+private fun BadgeIntentPreview(intent: BadgeIntent, hasStroke: Boolean) {
+    BadgeStyle.values().forEach {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(SparkTheme.colors.neutralContainer)
+                .padding(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Badge(badgeStyle = it, intent = intent, hasStroke = hasStroke)
+            Badge(badgeStyle = it, intent = intent, hasStroke = hasStroke) { Text("56k") }
+            Badge(badgeStyle = it, intent = intent, count = 3, hasStroke = hasStroke)
+            Badge(badgeStyle = it, intent = intent, count = 99, hasStroke = hasStroke)
+            Badge(badgeStyle = it, intent = intent, count = 200, overflowCount = 99, hasStroke = hasStroke)
+            Badge(badgeStyle = it, intent = intent, count = 99, overflowCount = 999, hasStroke = hasStroke)
+            Badge(badgeStyle = it, intent = intent, count = 1000, overflowCount = 999, hasStroke = hasStroke)
         }
     }
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.md
@@ -3,10 +3,10 @@
 [Badges](https://spark.adevinta.com/1186e1705/p/8711ec-badge/b/98915d) convey dynamic information, 
 such as counts or status. A badge can include labels or numbers.
 
-|       | Danger and Info                                                                                 |
-|-------|-------------------------------------------------------------------------------------------------|
-| Light | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badge_light.png) |
-| Dark  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badge_dark.png)  |
+|       | No Stroke                                                                                               | With Stroke                                                                                               |
+|-------|---------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| Light | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgenostroke_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgewithstroke_light.png) |
+| Dark  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgenostroke_dark.png)  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgewithstroke_dark.png)  |
 
 The default value of overflowCount is 99. When count is larger than 99, a `+` is displayed.
 A badge can be used as a part of [`BadgedBox`](#layout) or as a standalone when it is not attached visually to
@@ -54,9 +54,10 @@ Badge(
 )
 ```
 
-| Light                                                                                               | Dark                                                                                               |
-|-----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedbox_dark.png) |
+| Light                                                                                                         | Dark                                                                                                         |
+|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxnostroke_light.png)   | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxnostroke_dark.png)   |
+| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxwithstroke_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_badge_badgedboxwithstroke_dark.png) |
 
 ## Layout
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgeIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgeIntent.kt
@@ -29,6 +29,57 @@ import com.adevinta.spark.components.IntentColor
  * BadgeIntent is used to define the intent of the badge.
  */
 public enum class BadgeIntent {
+    /**
+     * Used for the most important information.
+     */
+    Primary {
+        @Composable
+        override fun colors() = IntentColor(
+            color = SparkTheme.colors.primary,
+            onColor = SparkTheme.colors.onPrimary,
+            containerColor = SparkTheme.colors.primaryContainer,
+            onContainerColor = SparkTheme.colors.onPrimaryContainer,
+        )
+    },
+
+    /**
+     * Used to highlight information.
+     */
+    Secondary {
+        @Composable
+        override fun colors() = IntentColor(
+            color = SparkTheme.colors.secondary,
+            onColor = SparkTheme.colors.onSecondary,
+            containerColor = SparkTheme.colors.secondaryContainer,
+            onContainerColor = SparkTheme.colors.onSecondaryContainer,
+        )
+    },
+
+    /**
+     * Used for feedbacks that are positive.
+     */
+    Success {
+        @Composable
+        override fun colors() = IntentColor(
+            color = SparkTheme.colors.success,
+            onColor = SparkTheme.colors.onSuccess,
+            containerColor = SparkTheme.colors.successContainer,
+            onContainerColor = SparkTheme.colors.onSuccessContainer,
+        )
+    },
+
+    /**
+     * Used for feedbacks that are negative.
+     */
+    Alert {
+        @Composable
+        override fun colors() = IntentColor(
+            color = SparkTheme.colors.alert,
+            onColor = SparkTheme.colors.onAlert,
+            containerColor = SparkTheme.colors.alertContainer,
+            onContainerColor = SparkTheme.colors.onAlertContainer,
+        )
+    },
 
     /**
      * Used for first level information
@@ -53,6 +104,32 @@ public enum class BadgeIntent {
             onColor = SparkTheme.colors.onInfo,
             containerColor = SparkTheme.colors.infoContainer,
             onContainerColor = SparkTheme.colors.onInfoContainer,
+        )
+    },
+
+    /**
+     * Used for feedbacks that are neutral.
+     */
+    Neutral {
+        @Composable
+        override fun colors() = IntentColor(
+            color = SparkTheme.colors.neutral,
+            onColor = SparkTheme.colors.onNeutral,
+            containerColor = SparkTheme.colors.neutralContainer,
+            onContainerColor = SparkTheme.colors.onNeutralContainer,
+        )
+    },
+
+    /**
+     * Badge on a color / image panel without on intent color.
+     */
+    Surface {
+        @Composable
+        override fun colors() = IntentColor(
+            color = SparkTheme.colors.surface,
+            onColor = SparkTheme.colors.onSurface,
+            containerColor = SparkTheme.colors.surface,
+            onContainerColor = SparkTheme.colors.onSurface,
         )
     },
     ;

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
@@ -87,7 +87,7 @@ internal fun SparkBadgedBox(
         val hasContent = badgePlaceable.width > BadgeWithNoContentSize.roundToPx()
         val offset = when {
             hasContent &&
-                    badgePlaceable.width >= MediumBadgeWithContentOffset.roundToPx() -> MediumBadgeWithContentOffset
+                badgePlaceable.width >= MediumBadgeWithContentOffset.roundToPx() -> MediumBadgeWithContentOffset
 
             hasContent -> SmallBadgeWithContentOffset
             else -> BadgeWithNoContentOffset
@@ -153,10 +153,11 @@ internal fun BadgedBoxNoStrokePreview(
         BadgeIntent.values().forEach { intent ->
             BadgeStyle.values().forEach { style ->
                 BadgedBoxIntentPreview(
-                    style, intent, hasStroke = false,
+                    style,
+                    intent,
+                    hasStroke = false,
                 )
             }
-
         }
     }
 }
@@ -173,10 +174,11 @@ internal fun BadgedBoxWithStrokePreview(
         BadgeIntent.values().forEach { intent ->
             BadgeStyle.values().forEach { style ->
                 BadgedBoxIntentPreview(
-                    style, intent, hasStroke = true,
+                    style,
+                    intent,
+                    hasStroke = true,
                 )
             }
-
         }
     }
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
@@ -87,7 +87,8 @@ internal fun SparkBadgedBox(
         val hasContent = badgePlaceable.width > BadgeWithNoContentSize.roundToPx()
         val offset = when {
             hasContent &&
-                badgePlaceable.width >= MediumBadgeWithContentOffset.roundToPx() -> MediumBadgeWithContentOffset
+                    badgePlaceable.width >= MediumBadgeWithContentOffset.roundToPx() -> MediumBadgeWithContentOffset
+
             hasContent -> SmallBadgeWithContentOffset
             else -> BadgeWithNoContentOffset
         }.roundToPx()
@@ -142,117 +143,96 @@ public fun BadgedBox(
 
 @Preview(
     group = "Badge",
-    name = "BadgedBox",
+    name = "BadgedBox No Stroke",
 )
 @Composable
-internal fun BadgedBoxPreview(
+internal fun BadgedBoxNoStrokePreview(
     @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
 ) {
     PreviewTheme(theme) {
-        BadgeStyle.values().forEach {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(32.dp),
-            ) {
-                BadgedBox(
-                    badge = {
-                        Badge(count = 1, badgeStyle = it)
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.LikeOutline,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Favorite",
-                    )
-                }
-                BadgedBox(
-                    badge = {
-                        Badge(count = 100, badgeStyle = it)
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.MessageOutline,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Notifications",
-                    )
-                }
-                BadgedBox(
-                    badge = {
-                        Badge(count = 1000, badgeStyle = it, overflowCount = 999)
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.Search,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Search",
-                    )
-                }
-                BadgedBox(
-                    badge = {
-                        Badge(badgeStyle = it)
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.AccountOutline,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Notifications",
-                    )
-                }
+        BadgeIntent.values().forEach { intent ->
+            BadgeStyle.values().forEach { style ->
+                BadgedBoxIntentPreview(
+                    style, intent, hasStroke = false,
+                )
             }
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(32.dp),
-            ) {
-                BadgedBox(
-                    badge = {
-                        Badge(count = 1, badgeStyle = it, intent = BadgeIntent.Info, hasStroke = false)
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.LikeOutline,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Favorite",
-                    )
-                }
-                BadgedBox(
-                    badge = {
-                        Badge(count = 100, badgeStyle = it, intent = BadgeIntent.Info, hasStroke = false)
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.MessageOutline,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Notifications",
-                    )
-                }
-                BadgedBox(
-                    badge = {
-                        Badge(
-                            count = 1000,
-                            badgeStyle = it,
-                            overflowCount = 999,
-                            intent = BadgeIntent.Info,
-                            hasStroke = false,
-                        )
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.Search,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Search",
-                    )
-                }
-                BadgedBox(
-                    badge = {
-                        Badge(badgeStyle = it, intent = BadgeIntent.Info, hasStroke = false)
-                    },
-                ) {
-                    Icon(
-                        SparkIcons.AccountOutline,
-                        modifier = Modifier.size(24.dp),
-                        contentDescription = "Account",
-                    )
-                }
+        }
+    }
+}
+
+@Preview(
+    group = "Badge",
+    name = "BadgedBox With Stroke",
+)
+@Composable
+internal fun BadgedBoxWithStrokePreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        BadgeIntent.values().forEach { intent ->
+            BadgeStyle.values().forEach { style ->
+                BadgedBoxIntentPreview(
+                    style, intent, hasStroke = true,
+                )
             }
+
+        }
+    }
+}
+
+@Composable
+private fun BadgedBoxIntentPreview(
+    style: BadgeStyle,
+    intent: BadgeIntent,
+    hasStroke: Boolean,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(32.dp),
+    ) {
+        BadgedBox(
+            badge = {
+                Badge(count = 1, badgeStyle = style, intent = intent, hasStroke = hasStroke)
+            },
+        ) {
+            Icon(
+                SparkIcons.LikeOutline,
+                modifier = Modifier.size(24.dp),
+                contentDescription = "Favorite",
+            )
+        }
+        BadgedBox(
+            badge = {
+                Badge(count = 100, badgeStyle = style, intent = intent, hasStroke = hasStroke)
+            },
+        ) {
+            Icon(
+                SparkIcons.MessageOutline,
+                modifier = Modifier.size(24.dp),
+                contentDescription = "Notifications",
+            )
+        }
+        BadgedBox(
+            badge = {
+                Badge(count = 1000, badgeStyle = style, intent = intent, overflowCount = 999, hasStroke = hasStroke)
+            },
+        ) {
+            Icon(
+                SparkIcons.Search,
+                modifier = Modifier.size(24.dp),
+                contentDescription = "Search",
+            )
+        }
+        BadgedBox(
+            badge = {
+                Badge(badgeStyle = style, intent = intent, hasStroke = hasStroke)
+            },
+        ) {
+            Icon(
+                SparkIcons.AccountOutline,
+                modifier = Modifier.size(24.dp),
+                contentDescription = "Notifications",
+            )
         }
     }
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipIntent.kt
@@ -121,7 +121,7 @@ public enum class ChipIntent {
     },
 
     /**
-     * Badge on a color / image panel without on intent color.
+     * Chip on a color / image panel without on intent color.
      */
     Surface {
         @Composable


### PR DESCRIPTION
## 📋 Changes description

Update `Badge`component in order to support all intent colors

## 🤔 Context

The fist version of badge had only two intents : Info and Danger. 

## 📸 Screenshots

Present in the current PR

## 🗒️ Other info

close #467 
