### PR TITLE
fix: merge descendants of Tag for UI tests

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -67,7 +68,9 @@ internal fun BaseSparkTag(
     content: @Composable RowScope.() -> Unit,
 ) {
     Surface(
-        modifier = modifier.sparkUsageOverlay(),
+        modifier = modifier
+            .semantics(mergeDescendants = true) {}
+            .sparkUsageOverlay(),
         shape = if (LocalLegacyStyle.current) SparkTheme.shapes.extraSmall else SparkTheme.shapes.full,
         color = colors.backgroundColor,
         contentColor = colors.contentColor.copy(1.0f),


### PR DESCRIPTION
## 📋 Changes description

Added a semantic on the Spark Tag to merge the descendant nodes for UI tests.

## 🤔 Context

When UI testing a `TagTinted` component, there was an issue trying to find the text inside of it. Indeed we need to merge the descendants of this composable to access the text inside.

## ✅ Checklist

<!--- Feel free to add other steps if needed -->
- [ ] Link to GitHub issues it solves. <!--- closes #1234 -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 🗒️ Other info

Validated with @soulcramer 

[Contributing](https://github.com/adevinta/spark-android/blob/main/docs/contributing.md) has more information and tips for a great pull request.
