### PR TITLE
fix(snackbar): apply the SparkTheme.shapes.small shape on snackbars

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
@@ -93,7 +93,7 @@ public fun SparkSnackbar(
         modifier = modifier
             .padding(16.dp)
             .sparkUsageOverlay(),
-        shape = SparkTheme.shapes.extraSmall,
+        shape = SparkTheme.shapes.small,
         actionOnNewLine = actionOnNewLine,
         containerColor = colors.baseColor,
         contentColor = contentColor,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.LocalLegacyStyle
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.buttons.BaseSparkButton
@@ -93,7 +94,7 @@ public fun SparkSnackbar(
         modifier = modifier
             .padding(16.dp)
             .sparkUsageOverlay(),
-        shape = SparkTheme.shapes.small,
+        shape = if (LocalLegacyStyle.current) SparkTheme.shapes.extraSmall else SparkTheme.shapes.small,
         actionOnNewLine = actionOnNewLine,
         containerColor = colors.baseColor,
         contentColor = contentColor,


### PR DESCRIPTION
## 📋 Changes description

Apply a SparkTheme.shapes.small shape of 8 dp on the Snackbar

## ✅ Checklist

- [Closes issue 514](closes issue https://github.com/adevinta/spark-android/issues/514)

## 📸 Screenshots
![Screenshot_20230707_183207_Leboncoin dev](https://github.com/adevinta/spark-android/assets/31015348/1ca31402-d844-4a5f-be39-f709fd7442e5)
![Screenshot_20230707_183213_Leboncoin dev](https://github.com/adevinta/spark-android/assets/31015348/c4a045e3-d807-409d-9f0f-5ff317681bf1)


