### PR TITLE
fix: Save screen state on config change in CatalogApp

### DIFF
--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -22,6 +22,7 @@
 plugins {
     id("com.adevinta.spark.android-application")
     id("com.adevinta.spark.android-compose")
+    id("kotlin-parcelize")
 }
 
 android {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
@@ -258,6 +259,12 @@ internal fun BodyContent(
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
 ) {
     val navController = rememberNavController()
+    val showkaseBrowserScreenMetadataState by rememberSaveable {
+        mutableStateOf(showkaseBrowserScreenMetadata)
+    }
+    val groupedComponentMapState by rememberSaveable {
+        mutableStateOf(groupedComponentMap)
+    }
 
     NavHost(
         modifier = modifier,
@@ -267,8 +274,8 @@ internal fun BodyContent(
             navGraph(
                 navController = navController,
                 contentPadding = contentPadding,
-                showkaseBrowserScreenMetadata = showkaseBrowserScreenMetadata,
-                groupedComponentMap = groupedComponentMap,
+                showkaseBrowserScreenMetadata = showkaseBrowserScreenMetadataState,
+                groupedComponentMap = groupedComponentMapState,
             )
         },
     )

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/CurrentScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/CurrentScreen.kt
@@ -21,7 +21,9 @@
  */
 package com.adevinta.spark.catalog.showkase
 
+import android.os.Parcelable
 import androidx.compose.runtime.MutableState
+import kotlinx.parcelize.Parcelize
 
 internal enum class CurrentScreen {
     COMPONENT_GROUPS,
@@ -33,6 +35,7 @@ internal enum class CurrentScreen {
 
 internal fun String?.insideGroup() = this == CurrentScreen.COMPONENTS_IN_A_GROUP.name
 
+@Parcelize
 internal data class ShowkaseBrowserScreenMetadata(
     val currentGroup: String? = null,
     val currentComponentName: String? = null,
@@ -40,7 +43,7 @@ internal data class ShowkaseBrowserScreenMetadata(
     val currentComponentKey: String? = null,
     val isSearchActive: Boolean = false,
     val searchQuery: String? = null,
-)
+) : Parcelable
 
 internal fun MutableState<ShowkaseBrowserScreenMetadata>.clear() {
     update {


### PR DESCRIPTION
## 📋 Changes description

The Showkase part of CatalogApp loses its state when rotating the screen. This change saves the state across configuration changes.