### PR TITLE
feat: Add configurable example for checkboxes in CatalogApp

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -41,7 +41,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material.ripple.RippleTheme
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -87,7 +86,7 @@ import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.google.accompanist.testharness.TestHarness
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun CatalogApp(
     theme: Theme,
@@ -262,10 +261,6 @@ internal fun BodyContent(
     val showkaseBrowserScreenMetadataState by rememberSaveable {
         mutableStateOf(showkaseBrowserScreenMetadata)
     }
-    val groupedComponentMapState by rememberSaveable {
-        mutableStateOf(groupedComponentMap)
-    }
-
     NavHost(
         modifier = modifier,
         navController = navController,
@@ -275,7 +270,7 @@ internal fun BodyContent(
                 navController = navController,
                 contentPadding = contentPadding,
                 showkaseBrowserScreenMetadata = showkaseBrowserScreenMetadataState,
-                groupedComponentMap = groupedComponentMapState,
+                groupedComponentMap = groupedComponentMap,
             )
         },
     )

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/checkboxes/CheckboxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/checkboxes/CheckboxConfigurator.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.configurator.samples.checkboxes
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.R
+import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.TextField
+import com.adevinta.spark.components.toggles.Checkbox
+import com.adevinta.spark.components.toggles.CheckboxLabelled
+import com.adevinta.spark.components.toggles.ContentSide
+import com.adevinta.spark.components.toggles.SwitchLabelled
+
+public val CheckboxConfigurator: Configurator = Configurator(
+    name = "Checkbox",
+    description = "Checkbox configuration",
+    sourceUrl = "$SampleSourceUrl/CheckboxSamples.kt",
+) {
+    CheckboxSample()
+}
+
+@Preview(
+    showBackground = true,
+)
+@Composable
+private fun CheckboxSample() {
+    val scrollState = rememberScrollState()
+    val focusManager = LocalFocusManager.current
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.verticalScroll(scrollState),
+    ) {
+        var isEnabled by remember { mutableStateOf(true) }
+        var contentSide by remember { mutableStateOf(ContentSide.End) }
+        var label: String? by remember { mutableStateOf(null) }
+        var state by remember { mutableStateOf(ToggleableState.On) }
+        val onClick = {
+            state = when (state) {
+                ToggleableState.On -> ToggleableState.Off
+                ToggleableState.Off -> ToggleableState.Indeterminate
+                ToggleableState.Indeterminate -> ToggleableState.On
+            }
+        }
+        ConfigedCheckbox(
+            label = label,
+            onClick = onClick,
+            state = state,
+            isEnabled = isEnabled,
+            contentSide = contentSide,
+        )
+        SwitchLabelled(
+            checked = isEnabled,
+            onCheckedChange = {
+                isEnabled = it
+                focusManager.clearFocus()
+            },
+        ) {
+            Text(
+                text = stringResource(id = R.string.configurator_component_screen_enabled_label),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        Column {
+            Text(
+                text = stringResource(id = R.string.configurator_component_checkbox_toggleable_state_label),
+                modifier = Modifier.padding(bottom = 8.dp),
+                style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            )
+            val states = ToggleableState.values()
+            val contentSidesLabel = states.map { it.name }
+            SegmentedButton(
+                options = contentSidesLabel,
+                selectedOption = state.name,
+                onOptionSelect = {
+                    state = ToggleableState.valueOf(it)
+                    focusManager.clearFocus()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+            )
+        }
+        Column {
+            Text(
+                text = stringResource(id = R.string.configurator_component_checkbox_content_side_label),
+                modifier = Modifier.padding(bottom = 8.dp),
+                style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            )
+            val contentSides = ContentSide.values()
+            val contentSidesLabel = contentSides.map { it.name }
+            SegmentedButton(
+                options = contentSidesLabel,
+                selectedOption = contentSide.name,
+                onOptionSelect = {
+                    contentSide = ContentSide.valueOf(it)
+                    focusManager.clearFocus()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+            )
+        }
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = label.orEmpty(),
+            onValueChange = {
+                label = it
+            },
+            label = stringResource(id = R.string.configurator_component_screen_textfield_label),
+            placeholder = stringResource(id = R.string.configurator_component_checkbox_placeholder_label),
+        )
+    }
+}
+
+@Composable
+private fun ConfigedCheckbox(
+    modifier: Modifier = Modifier,
+    label: String?,
+    onClick: () -> Unit,
+    state: ToggleableState,
+    isEnabled: Boolean,
+    contentSide: ContentSide,
+) {
+    if (label.isNullOrBlank().not()) {
+        CheckboxLabelled(
+            modifier = modifier,
+            enabled = isEnabled,
+            state = state,
+            onClick = onClick,
+            contentSide = contentSide,
+        ) { Text(text = label!!) }
+    } else {
+        Checkbox(
+            modifier = modifier,
+            enabled = isEnabled,
+            state = state,
+            onClick = onClick,
+        )
+    }
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/checkbox/CheckboxExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/checkbox/CheckboxExamples.kt
@@ -57,7 +57,8 @@ public val CheckboxExamples: List<Example> = listOf(
         Row {
             Column {
                 Checkbox(
-                    enabled = true, state = checkboxState,
+                    enabled = true,
+                    state = checkboxState,
                     onClick = {
                         checkboxState = when (checkboxState) {
                             ToggleableState.On -> ToggleableState.Off
@@ -122,8 +123,12 @@ private fun LabeledCheckboxGroupVerticalExample() {
     val groupState by remember {
         derivedStateOf {
             when {
-                checkboxEmailState == ToggleableState.On && checkboxNotificationsState == ToggleableState.On -> ToggleableState.On
-                checkboxEmailState == ToggleableState.Off && checkboxNotificationsState == ToggleableState.Off -> ToggleableState.Off
+                checkboxEmailState == ToggleableState.On && checkboxNotificationsState == ToggleableState.On ->
+                    ToggleableState.On
+
+                checkboxEmailState == ToggleableState.Off && checkboxNotificationsState == ToggleableState.Off ->
+                    ToggleableState.Off
+
                 else -> ToggleableState.Indeterminate
             }
         }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/checkbox/CheckboxExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/checkbox/CheckboxExamples.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.examples.samples.checkbox
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.R
+import com.adevinta.spark.catalog.model.Example
+import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.spacer.VerticalSpacer
+import com.adevinta.spark.components.toggles.Checkbox
+import com.adevinta.spark.components.toggles.CheckboxLabelled
+import com.adevinta.spark.components.toggles.ContentSide
+
+private const val CheckboxExampleDescription = "Checkbox examples"
+private const val CheckboxExampleSourceUrl = "$SampleSourceUrl/CheckboxSamples.kt"
+public val CheckboxExamples: List<Example> = listOf(
+    Example(
+        name = "Standalone checkbox",
+        description = CheckboxExampleDescription,
+        sourceUrl = CheckboxExampleSourceUrl,
+    ) {
+        var checkboxState by remember { mutableStateOf(ToggleableState.Off) }
+        Row {
+            Column {
+                Checkbox(
+                    enabled = true, state = checkboxState,
+                    onClick = {
+                        checkboxState = when (checkboxState) {
+                            ToggleableState.On -> ToggleableState.Off
+                            ToggleableState.Off -> ToggleableState.Indeterminate
+                            ToggleableState.Indeterminate -> ToggleableState.On
+                        }
+                    },
+                )
+                Checkbox(enabled = false, state = checkboxState, onClick = {})
+            }
+        }
+    },
+    Example(
+        name = "Labeled checkbox group",
+        description = CheckboxExampleDescription,
+        sourceUrl = CheckboxExampleSourceUrl,
+    ) {
+        LabeledCheckboxGroupExample()
+    },
+    Example(
+        name = "Labeled checkbox content side",
+        description = CheckboxExampleDescription,
+        sourceUrl = CheckboxExampleSourceUrl,
+    ) {
+        LabeledCheckboxContentSideExample()
+    },
+)
+
+@Composable
+private fun LabeledCheckboxContentSideExample() {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        val label = stringResource(id = R.string.component_checkbox_content_side_example_label)
+        ContentSide.values().forEach { side ->
+            var checkboxState by remember { mutableStateOf(ToggleableState.Off) }
+            CheckboxLabelled(
+                enabled = true,
+                state = checkboxState,
+                onClick = {
+                    checkboxState = when (checkboxState) {
+                        ToggleableState.Indeterminate, ToggleableState.Off -> ToggleableState.On
+                        ToggleableState.On -> ToggleableState.Off
+                    }
+                },
+                contentSide = side,
+            ) { Text(label) }
+        }
+    }
+}
+
+@Composable
+private fun LabeledCheckboxGroupExample() {
+    Column(verticalArrangement = Arrangement.spacedBy(24.dp)) {
+        LabeledCheckboxGroupHorizontalExample()
+        LabeledCheckboxGroupVerticalExample()
+    }
+}
+
+@Composable
+private fun LabeledCheckboxGroupVerticalExample() {
+    var checkboxEmailState by remember { mutableStateOf(ToggleableState.Off) }
+    var checkboxNotificationsState by remember { mutableStateOf(ToggleableState.Off) }
+    val groupState by remember {
+        derivedStateOf {
+            when {
+                checkboxEmailState == ToggleableState.On && checkboxNotificationsState == ToggleableState.On -> ToggleableState.On
+                checkboxEmailState == ToggleableState.Off && checkboxNotificationsState == ToggleableState.Off -> ToggleableState.Off
+                else -> ToggleableState.Indeterminate
+            }
+        }
+    }
+    Column {
+        Text(
+            text = stringResource(id = R.string.component_checkbox_vertical_group_title),
+            style = SparkTheme.typography.headline2,
+        )
+        VerticalSpacer(space = 8.dp)
+        CheckboxLabelled(
+            enabled = true,
+            state = groupState,
+            onClick = {
+                when (groupState) {
+                    ToggleableState.Indeterminate, ToggleableState.Off -> {
+                        checkboxEmailState = ToggleableState.On
+                        checkboxNotificationsState = ToggleableState.On
+                    }
+
+                    ToggleableState.On -> {
+                        checkboxEmailState = ToggleableState.Off
+                        checkboxNotificationsState = ToggleableState.Off
+                    }
+                }
+            },
+        ) { Text(text = stringResource(id = R.string.component_checkbox_group_example_group_label)) }
+        Column(
+            modifier = Modifier.padding(start = 32.dp),
+        ) {
+            CheckboxLabelled(
+                enabled = true,
+                state = checkboxNotificationsState,
+                onClick = {
+                    checkboxNotificationsState = when (checkboxNotificationsState) {
+                        ToggleableState.Indeterminate, ToggleableState.Off -> ToggleableState.On
+                        ToggleableState.On -> ToggleableState.Off
+                    }
+                },
+            ) { Text(text = stringResource(id = R.string.component_checkbox_group_example_option1_label)) }
+            CheckboxLabelled(
+                enabled = true,
+                state = checkboxEmailState,
+                onClick = {
+                    checkboxEmailState = when (checkboxEmailState) {
+                        ToggleableState.Indeterminate, ToggleableState.Off -> ToggleableState.On
+                        ToggleableState.On -> ToggleableState.Off
+                    }
+                },
+            ) { Text(text = stringResource(id = R.string.component_checkbox_group_example_option2_label)) }
+        }
+    }
+}
+
+@Composable
+private fun LabeledCheckboxGroupHorizontalExample() {
+    val labels = listOf(
+        stringResource(id = R.string.component_checkbox_group_example_option1_label),
+        stringResource(id = R.string.component_checkbox_group_example_option2_label),
+    )
+    Column {
+        Text(
+            text = stringResource(id = R.string.component_checkbox_horizontal_group_title),
+            style = SparkTheme.typography.headline2,
+        )
+        VerticalSpacer(space = 8.dp)
+        Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+            labels.forEach { label ->
+                var checkboxState by remember { mutableStateOf(ToggleableState.Off) }
+                CheckboxLabelled(
+                    enabled = true,
+                    state = checkboxState,
+                    onClick = {
+                        checkboxState = when (checkboxState) {
+                            ToggleableState.Indeterminate, ToggleableState.Off -> ToggleableState.On
+                            ToggleableState.On -> ToggleableState.Off
+                        }
+                    },
+                ) { Text(label) }
+            }
+        }
+    }
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -24,8 +24,10 @@ package com.adevinta.spark.catalog.model
 import androidx.annotation.StringRes
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.configurator.samples.buttons.ButtonsConfigurator
+import com.adevinta.spark.catalog.configurator.samples.checkboxes.CheckboxConfigurator
 import com.adevinta.spark.catalog.configurator.samples.textfields.TextFieldsConfigurator
 import com.adevinta.spark.catalog.examples.samples.buttons.ButtonsExamples
+import com.adevinta.spark.catalog.examples.samples.checkbox.CheckboxExamples
 import com.adevinta.spark.catalog.util.ComponentGuidelinesUrl
 import com.adevinta.spark.catalog.util.PackageSummaryUrl
 import com.adevinta.spark.catalog.util.SparkSourceUrl
@@ -58,6 +60,18 @@ private val Buttons = Component(
     configurator = ButtonsConfigurator,
 )
 
+private val Checkboxes = Component(
+    id = nextId(),
+    name = "Checkboxes",
+    description = R.string.component_checkbox_description,
+    // No buttons icon
+    guidelinesUrl = "$ComponentGuidelinesUrl/p/76f5a8-checkbox/b/98915d",
+    docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.toggles/index.html",
+    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt",
+    examples = CheckboxExamples,
+    configurator = CheckboxConfigurator,
+)
+
 private val TextFields = Component(
     id = nextId(),
     name = "TextFields",
@@ -73,5 +87,6 @@ private val TextFields = Component(
 /** Components for the catalog, ordered alphabetically by name. */
 public val Components: List<Component> = listOf(
     Buttons,
+    Checkboxes,
     TextFields,
 )

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -42,12 +42,27 @@
     <string name="examples_component_screen_title">Components examples</string>
     <string name="examples_component_screen_description">These are the examples that that can be found in the samples in the javadoc or the README.md files. They show usages of the components in different scenarios that should represent real use cases.</string>
     <string name="component_button_description">Buttons help people initiate actions, from sending an email, to sharing a document, to liking a post.</string>
+    <!--Checkbox example-->
+    <string name="component_checkbox_description">Checkboxes are used when there are multiple items to select in a list. Users can select zero, one, or any number of items.</string>
+    <string name="component_checkbox_content_side_example_label">This is an example of a multi-line text which is very long and in which the user should read all the information.</string>
+    <string name="component_checkbox_group_example_group_label">Notifications and emails</string>
+    <string name="component_checkbox_group_example_option1_label">Notifications</string>
+    <string name="component_checkbox_group_example_option2_label">Email</string>
     <string name="component_textfield_description">The input / text-field  component allows users to write in the space provided for the content.</string>
+    <string name="component_checkbox_vertical_group_title">Checkbox grouping with vertical alignment</string>
+    <string name="component_checkbox_horizontal_group_title">Checkbox grouping with horizontal alignment</string>
     <string name="showkase_home_warning_title">⚠️ Theming don’t work on these!</string>
     <string name="showkase_home_warning_description">These are the previews that the developers have when working on components. They are not exhaustive and are only meant to give you a quick idea of what the component looks like.</string>
 
     <string name="configurator_component_screen_title">Components configurations</string>
     <string name="configurator_component_screen_description">The Configurator aim to allow you to visualize a component in every possible state available state by customizing every property for each component.</string>
+    <string name="configurator_component_screen_enabled_label">Enabled</string>
+    <string name="configurator_component_screen_textfield_label">Label</string>
+    <!--Checkbox configurator-->
+    <string name="configurator_component_checkbox_toggleable_state_label">Toggleable State</string>
+    <string name="configurator_component_checkbox_content_side_label">Content Side</string>
+    <string name="configurator_component_checkbox_placeholder_label">Checkbox label</string>
+
     <string name="component_menu_guidlines">View design guidelines</string>
     <string name="component_menu_dev_docs">View developer docs</string>
     <string name="component_menu_source">View source code</string>


### PR DESCRIPTION
## 📋 Changes description

Adds configurable example for 
- checkbox group
- standalone checkbox 
- labeled checkbox in CatalogApp

## 📸 Screenshots
<img src="https://github.com/adevinta/spark-android/assets/36896406/639301f4-00ca-479d-bdb0-35af84433636" width="250"/>
<img src="https://github.com/adevinta/spark-android/assets/36896406/a4b197e5-2e70-4c8d-93ad-2f9f27628224" width="250" />
<img src="https://github.com/adevinta/spark-android/assets/36896406/c15bc209-e424-4681-b2b0-805d504cd239" width="250" />
<img src="https://github.com/adevinta/spark-android/assets/36896406/8effd8c3-0f33-498b-8770-67b3e5affb57" width="250" />
<img src="https://github.com/adevinta/spark-android/assets/36896406/bdddcc7f-5317-4412-b9d7-c8c4ab92c769" width="250" />

## 🗒️ Other info

close #507 
