### PR TITLE
feat: Add configurable example for Switches in CatalogApp

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.adevinta.spark.catalog.configurator.samples.checkboxes
+package com.adevinta.spark.catalog.configurator.samples.toggles
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -151,7 +151,7 @@ private fun CheckboxSample() {
         )
         Column {
             Text(
-                text = stringResource(id = R.string.configurator_component_checkbox_content_side_label),
+                text = stringResource(id = R.string.configurator_component_toggle_content_side_label),
                 modifier = Modifier.padding(bottom = 8.dp),
                 style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
             )
@@ -176,7 +176,7 @@ private fun CheckboxSample() {
                 label = it
             },
             label = stringResource(id = R.string.configurator_component_screen_textfield_label),
-            placeholder = stringResource(id = R.string.configurator_component_checkbox_placeholder_label),
+            placeholder = stringResource(id = R.string.configurator_component_toggle_placeholder_label),
         )
     }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.configurator.samples.toggles
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.R
+import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.menu.DropdownMenuItem
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.SelectTextField
+import com.adevinta.spark.components.textfields.TextField
+import com.adevinta.spark.components.toggles.ContentSide
+import com.adevinta.spark.components.toggles.Switch
+import com.adevinta.spark.components.toggles.SwitchLabelled
+import com.adevinta.spark.components.toggles.ToggleIntent
+
+public val SwitchConfigurator: Configurator = Configurator(
+    name = "Switch",
+    description = "Switch configuration",
+    sourceUrl = "$SampleSourceUrl/SwitchSamples.kt",
+) {
+    SwitchSample()
+}
+
+@Preview(
+    showBackground = true,
+)
+@Composable
+private fun SwitchSample() {
+    val scrollState = rememberScrollState()
+    val focusManager = LocalFocusManager.current
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.verticalScroll(scrollState),
+    ) {
+        var isEnabled by remember { mutableStateOf(true) }
+        var contentSide by remember { mutableStateOf(ContentSide.End) }
+        var label: String? by remember { mutableStateOf(null) }
+        var state by remember { mutableStateOf(false) }
+        var intent by remember { mutableStateOf(ToggleIntent.Main) }
+        val onClick = { checked: Boolean -> state = checked }
+        ConfigedSwitch(
+            label = label,
+            onClick = onClick,
+            checked = state,
+            isEnabled = isEnabled,
+            intent = intent,
+            contentSide = contentSide,
+        )
+        SwitchLabelled(
+            checked = isEnabled,
+            onCheckedChange = {
+                isEnabled = it
+                focusManager.clearFocus()
+            },
+        ) {
+            Text(
+                text = stringResource(id = R.string.configurator_component_screen_enabled_label),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        val intents = ToggleIntent.values()
+        var expanded by remember { mutableStateOf(false) }
+        SelectTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = intent.name,
+            onValueChange = {},
+            readOnly = true,
+            label = stringResource(id = R.string.configurator_component_screen_intent_label),
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded },
+            onDismissRequest = { expanded = false },
+            dropdownContent = {
+                intents.forEach {
+                    DropdownMenuItem(
+                        text = { Text(it.name) },
+                        onClick = {
+                            intent = it
+                            expanded = false
+                        },
+                    )
+                }
+            },
+        )
+        Column {
+            Text(
+                text = stringResource(id = R.string.configurator_component_toggle_content_side_label),
+                modifier = Modifier.padding(bottom = 8.dp),
+                style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            )
+            val contentSides = ContentSide.values()
+            val contentSidesLabel = contentSides.map { it.name }
+            SegmentedButton(
+                options = contentSidesLabel,
+                selectedOption = contentSide.name,
+                onOptionSelect = {
+                    contentSide = ContentSide.valueOf(it)
+                    focusManager.clearFocus()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+            )
+        }
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = label.orEmpty(),
+            onValueChange = {
+                label = it
+            },
+            label = stringResource(id = R.string.configurator_component_screen_textfield_label),
+            placeholder = stringResource(id = R.string.configurator_component_toggle_placeholder_label),
+        )
+    }
+}
+
+@Composable
+private fun ConfigedSwitch(
+    modifier: Modifier = Modifier,
+    label: String?,
+    onClick: (Boolean) -> Unit,
+    checked: Boolean,
+    isEnabled: Boolean,
+    contentSide: ContentSide,
+    intent: ToggleIntent,
+) {
+    if (label.isNullOrBlank().not()) {
+        SwitchLabelled(
+            modifier = modifier,
+            enabled = isEnabled,
+            checked = checked,
+            onCheckedChange = onClick,
+            contentSide = contentSide,
+            intent = intent,
+        ) { Text(text = label!!) }
+    } else {
+        Switch(
+            modifier = modifier,
+            enabled = isEnabled,
+            checked = checked,
+            onCheckedChange = onClick,
+            intent = intent,
+        )
+    }
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/CheckboxExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/CheckboxExamples.kt
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.adevinta.spark.catalog.examples.samples.checkbox
+package com.adevinta.spark.catalog.examples.samples.toggles
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/SwitchExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/SwitchExamples.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.examples.samples.toggles
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.adevinta.spark.catalog.R
+import com.adevinta.spark.catalog.model.Example
+import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.toggles.ContentSide
+import com.adevinta.spark.components.toggles.Switch
+import com.adevinta.spark.components.toggles.SwitchDefaults
+import com.adevinta.spark.components.toggles.SwitchIcons
+import com.adevinta.spark.components.toggles.SwitchLabelled
+import com.adevinta.spark.icons.AlarmOffFill
+import com.adevinta.spark.icons.AlarmOnFill
+import com.adevinta.spark.icons.SparkIcons
+
+private const val SwitchExampleDescription = "Switch examples"
+private const val SwitchExampleSourceUrl = "$SampleSourceUrl/SwitchSamples.kt"
+public val SwitchExamples: List<Example> = listOf(
+    Example(
+        name = "Standalone switch",
+        description = SwitchExampleDescription,
+        sourceUrl = SwitchExampleSourceUrl,
+    ) {
+        Column {
+            var switchState by remember { mutableStateOf(true) }
+            val onCheckedChange = { _: Boolean -> switchState = !switchState }
+            SwitchPair(
+                checked = switchState,
+                onCheckedChange = onCheckedChange,
+            )
+            SwitchPair(
+                icons = SwitchDefaults.icons,
+                checked = switchState,
+                onCheckedChange = onCheckedChange,
+            )
+            SwitchPair(
+                icons = SwitchIcons(
+                    checked = SparkIcons.AlarmOnFill,
+                    unchecked = SparkIcons.AlarmOffFill,
+                ),
+                checked = switchState,
+                onCheckedChange = onCheckedChange,
+            )
+        }
+    },
+    Example(
+        name = "Labeled switch content side End",
+        description = SwitchExampleDescription,
+        sourceUrl = SwitchExampleSourceUrl,
+    ) {
+        LabeledSwitchGroupExample(ContentSide.End)
+    },
+    Example(
+        name = "Labeled switch content side Start",
+        description = SwitchExampleDescription,
+        sourceUrl = SwitchExampleSourceUrl,
+    ) {
+        LabeledSwitchGroupExample(ContentSide.Start)
+    },
+)
+
+@Composable
+private fun LabeledSwitchGroupExample(
+    contentSide: ContentSide,
+) {
+    val labels = listOf(
+        stringResource(id = R.string.component_checkbox_group_example_option1_label),
+        stringResource(id = R.string.component_checkbox_group_example_option2_label),
+        stringResource(id = R.string.component_checkbox_content_side_example_label),
+
+        )
+
+    var childrenStates by remember {
+        mutableStateOf(List(labels.size) { false })
+    }
+    Column {
+        labels.forEachIndexed { index, label ->
+            val checked = childrenStates.getOrElse(index) { false }
+            SwitchLabelled(
+                modifier = Modifier.fillMaxWidth(),
+                enabled = true,
+                checked = checked,
+                contentSide = contentSide,
+                onCheckedChange = {
+                    childrenStates = childrenStates.mapIndexed { i, state ->
+                        if (i == index) {
+                            !state
+                        } else {
+                            state
+                        }
+                    }
+                },
+            ) {
+                Text(
+                    text = label,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+private fun ColumnScope.SwitchPair(
+    checked: Boolean,
+    icons: SwitchIcons? = null,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        enabled = true,
+        icons = icons,
+    )
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        enabled = false,
+        icons = icons,
+    )
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/SwitchExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/SwitchExamples.kt
@@ -99,7 +99,7 @@ private fun LabeledSwitchGroupExample(
         stringResource(id = R.string.component_checkbox_group_example_option2_label),
         stringResource(id = R.string.component_checkbox_content_side_example_label),
 
-        )
+    )
 
     var childrenStates by remember {
         mutableStateOf(List(labels.size) { false })
@@ -131,14 +131,12 @@ private fun LabeledSwitchGroupExample(
     }
 }
 
-
 @Composable
 private fun ColumnScope.SwitchPair(
     checked: Boolean,
     icons: SwitchIcons? = null,
     onCheckedChange: (Boolean) -> Unit,
 ) {
-
     Switch(
         checked = checked,
         onCheckedChange = onCheckedChange,

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -24,8 +24,9 @@ package com.adevinta.spark.catalog.model
 import androidx.annotation.StringRes
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.configurator.samples.buttons.ButtonsConfigurator
-import com.adevinta.spark.catalog.configurator.samples.checkboxes.CheckboxConfigurator
 import com.adevinta.spark.catalog.configurator.samples.textfields.TextFieldsConfigurator
+import com.adevinta.spark.catalog.configurator.samples.toggles.CheckboxConfigurator
+import com.adevinta.spark.catalog.configurator.samples.toggles.SwitchConfigurator
 import com.adevinta.spark.catalog.examples.samples.buttons.ButtonsExamples
 import com.adevinta.spark.catalog.examples.samples.toggles.CheckboxExamples
 import com.adevinta.spark.catalog.examples.samples.toggles.SwitchExamples
@@ -78,11 +79,11 @@ private val Switches = Component(
     name = "Switches",
     description = R.string.component_switch_description,
     // No buttons icon
-    guidelinesUrl = "$ComponentGuidelinesUrl/p/76f5a8-checkbox/b/98915d",
+    guidelinesUrl = "$ComponentGuidelinesUrl/p/58a2c6-switch/b/700a17",
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.toggles/index.html",
-    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt",
+    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/toggles/Switch.kt",
     examples = SwitchExamples,
-    configurator = CheckboxConfigurator,
+    configurator = SwitchConfigurator,
 )
 
 private val TextFields = Component(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -27,7 +27,8 @@ import com.adevinta.spark.catalog.configurator.samples.buttons.ButtonsConfigurat
 import com.adevinta.spark.catalog.configurator.samples.checkboxes.CheckboxConfigurator
 import com.adevinta.spark.catalog.configurator.samples.textfields.TextFieldsConfigurator
 import com.adevinta.spark.catalog.examples.samples.buttons.ButtonsExamples
-import com.adevinta.spark.catalog.examples.samples.checkbox.CheckboxExamples
+import com.adevinta.spark.catalog.examples.samples.toggles.CheckboxExamples
+import com.adevinta.spark.catalog.examples.samples.toggles.SwitchExamples
 import com.adevinta.spark.catalog.util.ComponentGuidelinesUrl
 import com.adevinta.spark.catalog.util.PackageSummaryUrl
 import com.adevinta.spark.catalog.util.SparkSourceUrl
@@ -72,6 +73,18 @@ private val Checkboxes = Component(
     configurator = CheckboxConfigurator,
 )
 
+private val Switches = Component(
+    id = nextId(),
+    name = "Switches",
+    description = R.string.component_switch_description,
+    // No buttons icon
+    guidelinesUrl = "$ComponentGuidelinesUrl/p/76f5a8-checkbox/b/98915d",
+    docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.toggles/index.html",
+    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt",
+    examples = SwitchExamples,
+    configurator = CheckboxConfigurator,
+)
+
 private val TextFields = Component(
     id = nextId(),
     name = "TextFields",
@@ -88,5 +101,6 @@ private val TextFields = Component(
 public val Components: List<Component> = listOf(
     Buttons,
     Checkboxes,
+    Switches,
     TextFields,
 )

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="component_checkbox_horizontal_group_title">Checkbox grouping with horizontal alignment</string>
     <string name="showkase_home_warning_title">⚠️ Theming don’t work on these!</string>
     <string name="showkase_home_warning_description">These are the previews that the developers have when working on components. They are not exhaustive and are only meant to give you a quick idea of what the component looks like.</string>
+    <!--Switch example-->
+    <string name="component_switch_description">Switch component allows the user to activate or deactivate the state of an element or concept. It is also used to control binary options (On/Off or True/False).</string>
 
     <string name="configurator_component_screen_title">Components configurations</string>
     <string name="configurator_component_screen_description">The Configurator aim to allow you to visualize a component in every possible state available state by customizing every property for each component.</string>

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -61,10 +61,10 @@
     <string name="configurator_component_screen_enabled_label">Enabled</string>
     <string name="configurator_component_screen_textfield_label">Label</string>
     <string name="configurator_component_screen_intent_label">Intent</string>
-    <!--Checkbox configurator-->
+    <!--Toggle configurator-->
     <string name="configurator_component_checkbox_toggleable_state_label">Toggleable State</string>
-    <string name="configurator_component_checkbox_content_side_label">Content Side</string>
-    <string name="configurator_component_checkbox_placeholder_label">Checkbox label</string>
+    <string name="configurator_component_toggle_content_side_label">Content Side</string>
+    <string name="configurator_component_toggle_placeholder_label">Toggle label</string>
 
     <string name="component_menu_guidlines">View design guidelines</string>
     <string name="component_menu_dev_docs">View developer docs</string>


### PR DESCRIPTION
## 📋 Changes description

Adds configurable example for 
- standalone switch 
- labeled switch in CatalogApp

## 📸 Screenshots
<img src="https://github.com/adevinta/spark-android/assets/36896406/55fbf12d-0007-4e69-84f6-854fa720defb" width="250"/>
<img src="https://github.com/adevinta/spark-android/assets/36896406/8814204c-d0c3-409f-9ddb-89c18b69eda9" width="250" />
<img src="https://github.com/adevinta/spark-android/assets/36896406/f46b28f2-a31c-48a1-8204-10eb4471dd71" width="250"/>
<img src="https://github.com/adevinta/spark-android/assets/36896406/2c04ef3f-9a8d-46a5-a076-5e2ac01f84ea" width="250" />
<img src="https://github.com/adevinta/spark-android/assets/36896406/4f6cf8ec-16ab-4f7a-b68a-0cbb3954839f" width="250"/>

## 🗒️ Other info

close #508