### PR TITLE
fix: ModalFullScreenScaffold has now a spacing between button in portrait and add reverse order

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -78,6 +78,7 @@ import com.adevinta.spark.tools.preview.DevicePreviews
  * @param illustration whether the modal display a close icon, and its corresponding action
  * @param mainButton the main actions for this modal (should be a [ButtonFilled])
  * @param supportButton the support or alternative actions for this modal (should any other button than [ButtonFilled])
+ * @param reverseButtonOrder inverse the order of the buttons, so the mainButton button is shown at the top in portrait mode
  * @param content the center custom Composable for modal content
  */
 @ExperimentalSparkApi
@@ -89,6 +90,7 @@ public fun ModalFullScreenScaffold(
     @DrawableRes illustration: Int? = null,
     mainButton: @Composable (Modifier) -> Unit = {},
     supportButton: @Composable (Modifier) -> Unit = {},
+    reverseButtonOrder: Boolean = false,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val size = Layout.windowSize
@@ -106,6 +108,7 @@ public fun ModalFullScreenScaffold(
                 illustration = illustration,
                 mainButton = mainButton,
                 supportButton = supportButton,
+                reverseButtonOrder = reverseButtonOrder,
                 content = content,
             )
         }
@@ -194,6 +197,7 @@ private fun PhonePortraitModalScaffold(
     @DrawableRes illustration: Int? = null,
     mainButton: @Composable (Modifier) -> Unit = {},
     supportButton: @Composable (Modifier) -> Unit = {},
+    reverseButtonOrder: Boolean = false,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
@@ -219,10 +223,13 @@ private fun PhonePortraitModalScaffold(
                         .fillMaxWidth()
                         .padding(horizontal = Layout.bodyMargin)
                         .padding(bottom = 16.dp),
+
+                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom),
                 ) {
                     val buttonModifier = Modifier.fillMaxWidth()
+                    if (reverseButtonOrder) mainButton(buttonModifier)
                     supportButton(buttonModifier)
-                    mainButton(buttonModifier)
+                    if (!reverseButtonOrder) mainButton(buttonModifier)
                 }
             } else {
                 Row(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -78,7 +78,7 @@ import com.adevinta.spark.tools.preview.DevicePreviews
  * @param illustration whether the modal display a close icon, and its corresponding action
  * @param mainButton the main actions for this modal (should be a [ButtonFilled])
  * @param supportButton the support or alternative actions for this modal (should any other button than [ButtonFilled])
- * @param reverseButtonOrder inverse the order of the buttons, so the mainButton button is shown at the top in portrait mode
+ * @param reverseButtonOrder inverse the order of the buttons, so the [mainButton] button is shown at the top in portrait mode
  * @param content the center custom Composable for modal content
  */
 @ExperimentalSparkApi


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Add spacing to buttons and add a new `reverseButtonOrder` param to, like its name indiquate, reverse the order between the support and main button.

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
As mentioned [here](https://adevinta.slack.com/archives/C04QQEU3Y2H/p1689755220968659) a spacing was missing between buttons in portrait mode

## 📸 Screenshots

<!--- Put your screenshots here -->

<table>
<tr>
 <td> Before 
 <td> After
<tr>
 <td> <img src="https://github.com/adevinta/spark-android/assets/11772084/cf7c32d7-0dd1-4bdb-9be1-82ce31549f57"/>
 <td> <img src="https://github.com/adevinta/spark-android/assets/11772084/130214f5-a7d8-4859-b18a-8c970f75300a"/>
</table>

## 🗒️ Other info

Close #546 
