### PR TITLE
chore: add spark-contributors-android as code owners so that they're assigned as reviewers to every PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @soulcramer @MarinaRomanova @SimonMarquis
+* @soulcramer @MarinaRomanova @SimonMarquis @spark-contributors-android
 /.github/ @soulcramer @MarinaRomanova @SimonMarquis
 /gradle/ @soulcramer @MarinaRomanova @SimonMarquis
 /build-logic/ @soulcramer @MarinaRomanova @SimonMarquis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @soulcramer @MarinaRomanova @SimonMarquis @spark-contributors-android
+* @soulcramer @MarinaRomanova @SimonMarquis @adevinta/spark-contributors-android
 /.github/ @soulcramer @MarinaRomanova @SimonMarquis
 /gradle/ @soulcramer @MarinaRomanova @SimonMarquis
 /build-logic/ @soulcramer @MarinaRomanova @SimonMarquis


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Add @spark-contributors-android as code owners

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
When 2 of the current code owners are not availables we have to manually add spark android contributors to PR to make them review it.
This aim to add them by default wdyt @SimonMarquis ?

## 🗒️ Other info

<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->
Note that the @spark-contributors-android consist of senior Polaris developers that have the rights to validate or refuse PR
