### PR TITLE
feat: add the ability to change the launcher icon color depending on the theme mode

### DIFF
--- a/catalog/src/main/res/drawable/ic_launcher_background.xml
+++ b/catalog/src/main/res/drawable/ic_launcher_background.xml
@@ -26,166 +26,166 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#181735"
+        android:fillColor="@color/ic_launcher_background_tint"
         android:pathData="M0,0h108v108h-108z" />
     <path
         android:fillColor="#00000000"
         android:pathData="M9,0L9,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19,0L19,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M29,0L29,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M39,0L39,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M49,0L49,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M59,0L59,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M69,0L69,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M79,0L79,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M89,0L89,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M99,0L99,108"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,9L108,9"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,19L108,19"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,29L108,29"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,39L108,39"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,49L108,49"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,59L108,59"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,69L108,69"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,79L108,79"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,89L108,89"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M0,99L108,99"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19,29L89,29"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19,39L89,39"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19,49L89,49"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19,59L89,59"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19,69L89,69"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M19,79L89,79"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M29,19L29,89"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M39,19L39,89"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M49,19L49,89"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M59,19L59,89"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M69,19L69,89"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
     <path
         android:fillColor="#00000000"
         android:pathData="M79,19L79,89"
         android:strokeWidth="0.8"
-        android:strokeColor="#10FFFFFF" />
+        android:strokeColor="@color/ic_launcher_background_lines_tint" />
 </vector>

--- a/catalog/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/catalog/src/main/res/drawable/ic_launcher_foreground.xml
@@ -26,7 +26,7 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#FFF51592"
+        android:fillColor="@color/ic_launcher_foreground_upper_tint"
         android:pathData="M42.4 53.8v-16c0-4.1 4.2-6.9 8.08-5.38l23.04 9.01-7.13 2.83-17.11-6.32c-0.97-0.36-2 0.34-2 1.35v12.57L42.4 53.8Z" />
     <path android:pathData="M76 45.83c0 1.18-0.73 2.24-1.84 2.68l-8.55 3.4-24.88 10.51-1.32 0.5 19.31 7.14c0.97 0.35 2-0.35 2-1.36V56.17l4.89-1.94V70.2c0 4.1-4.21 6.9-8.08 5.38l-23.67-9.23c-1.12-0.44-1.86-1.5-1.86-2.69v-1.5c0-1.18 0.73-2.24 1.84-2.68L75.6 42.89c0.26 0.44 0.41 0.94 0.41 1.47v1.47Z">
         <aapt:attr name="android:fillColor">
@@ -36,10 +36,10 @@
                 android:gradientRadius="108"
                 android:type="radial">
                 <item
-                    android:color="#FF7E49DD"
+                    android:color="@color/ic_launcher_foreground_lower_start_gradient"
                     android:offset="0.58" />
                 <item
-                    android:color="#FF4183D7"
+                    android:color="@color/ic_launcher_foreground_lower_end_gradient"
                     android:offset="1" />
             </gradient>
         </aapt:attr>

--- a/catalog/src/main/res/values-night/colors.xml
+++ b/catalog/src/main/res/values-night/colors.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright (c) 2023 Adevinta
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+  -->
+<resources>
+    <color name="ic_launcher_background_tint">#181735</color>
+    <color name="ic_launcher_background_lines_tint">#10FFFFFF</color>
+</resources>

--- a/catalog/src/main/res/values/colors.xml
+++ b/catalog/src/main/res/values/colors.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright (c) 2023 Adevinta
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+  -->
+<resources>
+    <color name="ic_launcher_background_tint">#ffffff</color>
+    <color name="ic_launcher_background_lines_tint">#10000000</color>
+    <color name="ic_launcher_foreground_upper_tint">#FFF51592</color>
+    <color name="ic_launcher_foreground_lower_start_gradient">#FF7E49DD</color>
+    <color name="ic_launcher_foreground_lower_end_gradient">#FF4183D7</color>
+</resources>


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Create color references and use them in the adaptive icon foreground & background drawables to change the icon color on the theme mode

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
I was inspired by [this PR on NowInAndroid](https://github.com/android/nowinandroid/pull/809) as I didn't knew we could change the color of the icon depending on the theme 🤩
