### PR TITLE
fix: remove trailing slash from `Url`s

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Url.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Url.kt
@@ -31,17 +31,17 @@ public fun Context.openUrl(url: String) {
 }
 
 public const val GuidelinesUrl: String = "https://spark.adevinta.com"
-public const val ComponentGuidelinesUrl: String = "https://spark.adevinta.com/1186e1705/"
+public const val ComponentGuidelinesUrl: String = "https://spark.adevinta.com/1186e1705"
 public const val StyleGuidelinesUrl: String = "https://m3.material.io/styles"
 public const val ReleasesUrl: String = "https://github.com/adevinta/spark-android/releases"
-public const val DocsUrl: String = "https://adevinta.github.io/spark-android/"
+public const val DocsUrl: String = "https://adevinta.github.io/spark-android"
 public const val SourceUrl: String = "https://github.com/adevinta/spark-android"
 public const val SparkSourceUrl: String = "https://github.com/adevinta/spark-android/tree/main/spark/src/main"
 
 // Use the real sample url from spark once we have our first ones
 /* ktlint-disable max-line-length */
 public const val SampleSourceUrl: String = "https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/samples/src/main/java/androidx/compose/material3/samples"
-public const val PackageSummaryUrl: String = "https://adevinta.github.io/spark-android/spark/"
+public const val PackageSummaryUrl: String = "https://adevinta.github.io/spark-android/spark"
 
 /* ktlint-disable max-line-length */
 public const val IssueUrl: String = "https://github.com/adevinta/spark-android/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc"


### PR DESCRIPTION
Most of them are used inside String templating, and would introduce unexpected double slashes that could break the url.

For example:
- ✅ https://adevinta.github.io/spark-android/spark/com.adevinta.spark.components.appbar/index.html
- ❌ https://adevinta.github.io/spark-android/spark//com.adevinta.spark.components.appbar/index.html