### PR TITLE
fix: content was not adapting to button spaces when too big

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -53,7 +54,7 @@ import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.appbar.TopAppBar
 import com.adevinta.spark.components.buttons.ButtonFilled
-import com.adevinta.spark.components.buttons.ButtonGhost
+import com.adevinta.spark.components.buttons.ButtonOutlined
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.icons.IconButton
 import com.adevinta.spark.components.image.Illustration
@@ -64,6 +65,7 @@ import com.adevinta.spark.icons.Close
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tokens.Layout
 import com.adevinta.spark.tokens.bodyWidth
+import com.adevinta.spark.tokens.dim2
 import com.adevinta.spark.tools.preview.DevicePreviews
 
 /**
@@ -92,6 +94,7 @@ public fun ModalFullScreenScaffold(
     mainButton: @Composable (Modifier) -> Unit = {},
     supportButton: @Composable (Modifier) -> Unit = {},
     reverseButtonOrder: Boolean = false,
+    illustrationContentScale: ContentScale = ContentScale.Fit,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val size = Layout.windowSize
@@ -110,6 +113,7 @@ public fun ModalFullScreenScaffold(
                 mainButton = mainButton,
                 supportButton = supportButton,
                 reverseButtonOrder = reverseButtonOrder,
+                illustrationContentScale = illustrationContentScale,
                 content = content,
             )
         }
@@ -121,6 +125,7 @@ public fun ModalFullScreenScaffold(
                 illustration = illustration,
                 mainButton = mainButton,
                 supportButton = supportButton,
+                illustrationContentScale = illustrationContentScale,
                 content = content,
             )
         }
@@ -131,6 +136,7 @@ public fun ModalFullScreenScaffold(
             illustration = illustration,
             mainButton = mainButton,
             supportButton = supportButton,
+            illustrationContentScale = illustrationContentScale,
             content = content,
         )
     }
@@ -144,6 +150,7 @@ private fun ModalScaffold(
     @DrawableRes illustration: Int? = null,
     mainButton: @Composable (Modifier) -> Unit = {},
     supportButton: @Composable (Modifier) -> Unit = {},
+    illustrationContentScale: ContentScale = ContentScale.Fit,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Dialog(
@@ -153,7 +160,7 @@ private fun ModalScaffold(
         ),
     ) {
         Surface(
-            modifier = modifier,
+            modifier = modifier.padding(DialogWindowPadding),
             shadowElevation = 6.dp,
             shape = SparkTheme.shapes.large,
         ) {
@@ -168,10 +175,11 @@ private fun ModalScaffold(
                         drawableRes = it,
                         contentDescription = null,
                         modifier = Modifier
-                            .fillMaxWidth(.3f)
+                            .fillMaxHeight(.4f)
+                            .fillMaxWidth(.8f)
                             .align(Alignment.CenterHorizontally)
                             .padding(bottom = 24.dp),
-                        contentScale = ContentScale.Crop,
+                        contentScale = illustrationContentScale,
                     )
                 }
                 Box(modifier = Modifier.weight(1f, fill = false)) {
@@ -201,6 +209,7 @@ private fun PhonePortraitModalScaffold(
     mainButton: @Composable (Modifier) -> Unit = {},
     supportButton: @Composable (Modifier) -> Unit = {},
     reverseButtonOrder: Boolean = false,
+    illustrationContentScale: ContentScale = ContentScale.Fit,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
@@ -212,6 +221,7 @@ private fun PhonePortraitModalScaffold(
                     IconButton(onClick = onClose) {
                         Icon(
                             sparkIcon = SparkIcons.Close,
+                            tint = SparkTheme.colors.onSurface.dim2,
                             contentDescription = stringResource(id = R.string.spark_a11y_modal_fullscreen_close),
                         )
                     }
@@ -220,30 +230,31 @@ private fun PhonePortraitModalScaffold(
             )
         },
         bottomBar = {
-            if (Layout.windowSize.widthSizeClass == WindowWidthSizeClass.Compact) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = Layout.bodyMargin)
-                        .padding(bottom = 16.dp),
-
-                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom),
-                ) {
-                    val buttonModifier = Modifier.fillMaxWidth()
-                    if (reverseButtonOrder) mainButton(buttonModifier)
-                    supportButton(buttonModifier)
-                    if (!reverseButtonOrder) mainButton(buttonModifier)
-                }
-            } else {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = Layout.bodyMargin)
-                        .padding(bottom = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-                ) {
-                    supportButton(Modifier)
-                    mainButton(Modifier)
+            Surface {
+                if (Layout.windowSize.widthSizeClass == WindowWidthSizeClass.Compact) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = Layout.bodyMargin)
+                            .padding(bottom = 16.dp, top = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom),
+                    ) {
+                        val buttonModifier = Modifier.fillMaxWidth()
+                        if (reverseButtonOrder) mainButton(buttonModifier)
+                        supportButton(buttonModifier)
+                        if (!reverseButtonOrder) mainButton(buttonModifier)
+                    }
+                } else {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = Layout.bodyMargin)
+                            .padding(bottom = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                    ) {
+                        supportButton(Modifier)
+                        mainButton(Modifier)
+                    }
                 }
             }
         },
@@ -258,13 +269,21 @@ private fun PhonePortraitModalScaffold(
                     drawableRes = it,
                     contentDescription = null,
                     modifier = Modifier
-                        .fillMaxWidth(.5f)
+                        .fillMaxHeight(.4f)
+                        .fillMaxWidth(.8f)
                         .align(Alignment.CenterHorizontally)
                         .padding(top = innerPadding.calculateTopPadding()),
-                    contentScale = ContentScale.Crop,
+                    contentScale = illustrationContentScale,
                 )
             }
-            content(innerPadding)
+            content(
+                PaddingValues(
+                    start = innerPadding.calculateLeftPadding(LocalLayoutDirection.current),
+                    end = innerPadding.calculateRightPadding(LocalLayoutDirection.current),
+                    top = 24.dp,
+                    bottom = innerPadding.calculateBottomPadding(),
+                ),
+            )
         }
     }
 }
@@ -278,6 +297,7 @@ private fun PhoneLandscapeModalScaffold(
     @DrawableRes illustration: Int? = null,
     mainButton: @Composable (Modifier) -> Unit = {},
     supportButton: @Composable (Modifier) -> Unit = {},
+    illustrationContentScale: ContentScale = ContentScale.Fit,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
@@ -289,7 +309,8 @@ private fun PhoneLandscapeModalScaffold(
                     IconButton(onClick = onClose) {
                         Icon(
                             sparkIcon = SparkIcons.Close,
-                            contentDescription = null, // FIXME-scott.rayapoulle.ext (13-36-2023): Add description
+                            tint = SparkTheme.colors.onSurface.dim2,
+                            contentDescription = stringResource(id = R.string.spark_a11y_modal_fullscreen_close),
                         )
                     }
                 },
@@ -301,21 +322,20 @@ private fun PhoneLandscapeModalScaffold(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = Layout.bodyMargin),
+            verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Layout.gutter),
         ) {
             illustration?.let {
                 Box(
                     modifier = Modifier
-                        .weight(.5f)
-                        .fillMaxHeight()
-                        .padding(top = innerPadding.calculateTopPadding()),
+                        .weight(.8f),
                     contentAlignment = Alignment.Center,
                 ) {
                     Illustration(
                         drawableRes = it,
                         contentDescription = null,
-                        modifier = Modifier.fillMaxSize(.7f),
-                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxWidth(.8f),
+                        contentScale = illustrationContentScale,
                     )
                 }
             }
@@ -323,7 +343,6 @@ private fun PhoneLandscapeModalScaffold(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxHeight(),
-                horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
                 Box(modifier = Modifier.weight(1f, fill = false)) {
@@ -348,6 +367,7 @@ private val MinWidth = 280.dp
 private val MaxWidth = 560.dp
 
 private val DialogPadding = PaddingValues(all = 24.dp)
+private val DialogWindowPadding = PaddingValues(all = 32.dp)
 
 @DevicePreviews
 @Preview(
@@ -370,34 +390,31 @@ private fun ModalPreview() {
                 ButtonFilled(modifier = it, onClick = { /*TODO*/ }, text = "Main Action")
             },
             supportButton = {
-                ButtonGhost(modifier = it, onClick = { /*TODO*/ }, text = "Alternative Action")
+                ButtonOutlined(modifier = it, onClick = { /*TODO*/ }, text = "Alternative Action")
             },
+            reverseButtonOrder = true,
         ) { innerPadding ->
             Text(
                 modifier = Modifier
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
-                text = "Modal content Modal content Modal content Modal content Modal content Modal content Modal " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                        "Modal content Modal content",
+                text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
+                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -101,7 +101,7 @@ public fun ModalFullScreenScaffold(
     val isPhoneLandscape = size.heightSizeClass == WindowHeightSizeClass.Compact
     val isPhonePortraitOrFoldable =
         (size.widthSizeClass == WindowWidthSizeClass.Compact || size.widthSizeClass == WindowWidthSizeClass.Medium) &&
-                size.heightSizeClass == WindowHeightSizeClass.Medium
+            size.heightSizeClass == WindowHeightSizeClass.Medium
 
     when {
         isPhonePortraitOrFoldable -> {
@@ -399,22 +399,22 @@ private fun ModalPreview() {
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
                 text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
-                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
+                    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -31,14 +31,15 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -97,7 +98,7 @@ public fun ModalFullScreenScaffold(
     val isPhoneLandscape = size.heightSizeClass == WindowHeightSizeClass.Compact
     val isPhonePortraitOrFoldable =
         (size.widthSizeClass == WindowWidthSizeClass.Compact || size.widthSizeClass == WindowWidthSizeClass.Medium) &&
-            size.heightSizeClass == WindowHeightSizeClass.Medium
+                size.heightSizeClass == WindowHeightSizeClass.Medium
 
     when {
         isPhonePortraitOrFoldable -> {
@@ -123,6 +124,7 @@ public fun ModalFullScreenScaffold(
                 content = content,
             )
         }
+
         else -> ModalScaffold(
             modifier = modifier,
             onClose = onClose,
@@ -134,7 +136,6 @@ public fun ModalFullScreenScaffold(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun ModalScaffold(
     onClose: () -> Unit,
@@ -153,12 +154,12 @@ private fun ModalScaffold(
     ) {
         Surface(
             modifier = modifier,
-            tonalElevation = 6.dp,
+            shadowElevation = 6.dp,
             shape = SparkTheme.shapes.large,
         ) {
             Column(
                 modifier = Modifier
-                    .sizeIn(minWidth = MinWidth, maxWidth = MaxWidth)
+                    .widthIn(min = MinWidth, max = MaxWidth)
                     .padding(DialogPadding),
             ) {
                 snackbarHost()
@@ -173,7 +174,9 @@ private fun ModalScaffold(
                         contentScale = ContentScale.Crop,
                     )
                 }
-                content(PaddingValues())
+                Box(modifier = Modifier.weight(1f, fill = false)) {
+                    content(PaddingValues())
+                }
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -323,9 +326,13 @@ private fun PhoneLandscapeModalScaffold(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
-                content(innerPadding)
+                Box(modifier = Modifier.weight(1f, fill = false)) {
+                    content(innerPadding)
+                }
                 Row(
-                    modifier = Modifier.padding(bottom = 16.dp),
+                    modifier = Modifier
+                        .padding(bottom = 16.dp, top = 8.dp)
+                        .fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.End),
                 ) {
                     val buttonModifier = Modifier.weight(1f)
@@ -367,12 +374,30 @@ private fun ModalPreview() {
             },
         ) { innerPadding ->
             Text(
-                modifier = Modifier.padding(innerPadding),
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
                 text = "Modal content Modal content Modal content Modal content Modal content Modal content Modal " +
-                    "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                    "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                    "content Modal content Modal content Modal content Modal content Modal content Modal content " +
-                    "Modal content Modal content",
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "content Modal content Modal content Modal content Modal content Modal content Modal content " +
+                        "Modal content Modal content",
             )
         }
     }


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
- Make the content take a weight with fill false to reduce its size priority so that it doesn't push the buttons out of the screen
- Update close icon color to `onSurface.dim2` and add content description for a11y
- Allow passing `illustrationContentScale` to handle content scale of the illustration (the default is `ContentScale.Fit`)
- Add surface to the buttons and update padding so that it is spaced with the content
- Add padding for dialog window to avoid it touching the screen edges

<img src="https://github.com/adevinta/spark-android/assets/36896406/d69edf81-bc1d-43fb-8f60-51e190582fa3" width="250"/>
<img src="https://github.com/adevinta/spark-android/assets/36896406/b137d6ab-8c0b-4993-8056-823cb7f9b9f5" width="250"/>
<img src="https://github.com/adevinta/spark-android/assets/36896406/5a8ee5cf-1c9d-454c-9c1a-23f4abbc87b6" width="250"/>
close #599 
