### PR TITLE
feat: Add IconButtons with all intents, shapes and sizes

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5096de5824a4aedf4e40eca0e2bc61e5262ad687bee4fd17d9f05e5e0fc29a2
-size 104849
+oid sha256:b5d2dc48ed571956777795e1b60546428a920da32f017d7a4a72fc4299bfb7c6
+size 104952

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsdashed_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e963fc0e8a6392d730f0c90f194ed80792673c8d9cd4fcf5ec0caa275aa30108
-size 100383
+oid sha256:fe7b62638b602b09bd5cd058e59a4af4dde0130f71e8c31c44bbd769904d8267
+size 100515

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ebc3d99536a0966f039f465fb7af21a1af9603d635724a710f3eb1e7a90e2a4e
-size 88399
+oid sha256:68b66c68c0ed66160c8029bedad628ef4577ed01b59d53118c7b2ae7edec3f2a
+size 88359

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsfilled_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b729adbd3bc5860b9980f24be0620772d531699443fc80fa7ee6dc88467205cc
-size 90193
+oid sha256:7a3316dbd5a2e2abef843f3cdc4837a5b15c44ccc3787921353af600f7f5855a
+size 90151

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:119379d412fa6c0fa99cc950016c2a072cd55e6d0eb75b93d41fe652a71b0a71
-size 97720
+oid sha256:be8789abfacdb70480273ad1949d8d1061b8d09fc8ac1a4abbc197dd6052e425
+size 97751

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipsoutlined_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:125c586a2f1cac68ea166fde7aa2dea630e5cb296912e41421942983b1bf5103
-size 94153
+oid sha256:11a487e2a34d48504d8b0a68a307a3e1d1b87c39768becc64556a9b79446496c
+size 94202

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e081fb3c34f7f9eaaab7fc084cb127afd73ffed0a31747b98229093955ca729
-size 90504
+oid sha256:ce189640f51f452d8c62eb15f592e78e991890c9e566ae0c383cef85bf70a8f8
+size 90484

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_chips_chipstinted_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11afbff7e06c67abffc93bd4ca01d2ae74eafde28b563d5be035cb99a5164793
-size 85448
+oid sha256:9fca919204b44e50f54fa8f670d00d221b679333334a9527e7a71f2f2a9e74dc
+size 85438

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastlarge_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastlarge_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74bf3704781def2234ad36e55cc90e2bf585c6a012361ed76007d9695e88ad3e
+size 59049

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastlarge_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastlarge_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4762f411c3658aa5110aa75be3ae7ca03033bbf70b172e56384411ef8693cf28
+size 57796

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fbcabf7bb2e243052b63ff6a7da382f5c4c6c4d02909bb923d2cbe56d2cddb9
+size 38678

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:892eda1889a1cac3f5f10be46657317b2dc808b7ee1fafe717bacf7b70f232ff
+size 37665

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastsmall_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastsmall_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e33eed4d87d7b99a4c659a21de3ded3ed265691ad22eaacf9ef32b45bf81745d
+size 38370

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastsmall_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastsmall_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba5621905b72704d43fee2f73e79be03a7b7b7ee6d3061f445a572dee1f62e5d
+size 37294

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledlarge_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledlarge_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbf9610e99842732c4fbc16ad63808c912478412bf75c302668669170c919598
+size 98761

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledlarge_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledlarge_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa4931d5e4cf81ccd05e28964a5f13b8d1933699bbcda7d38b08938ccd534381
+size 99456

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:554fb5d063a9d413a4c90acf2b2650b2be1983f45f625b784ef17b417d687251
+size 91834

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:292aefae7e5bed5627eeef76eba2f3e7e44df2a6ceeec3875a569a207d0dafe3
+size 90548

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledsmall_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledsmall_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb5ee3afa7166f8354411df04adc933fea3b243b9d728557cc5e6f3e43f9dd6b
+size 80174

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledsmall_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledsmall_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0abc1c9a86db57dc2cb33041b6cbf007e93ad54b48a8a65266f3f4a38556b32f
+size 79907

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostlarge_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostlarge_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a64aaa26cb5b091217c7d54fc00733ada1dcab559efc4edc56b5fbf5cd54a653
+size 58343

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostlarge_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostlarge_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd3742e2b46c6868f5ed5191d390112c4244a76ae33b192b0381dc81689638a4
+size 57262

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca27b0f92ac036e9c4314be3794c870d7bd41102bd936986e90369b250f38d77
+size 36968

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47188479b3ee689f071bc198932bc7976fd3b95289049b1d98bc7e9203019db6
+size 36443

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostsmall_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostsmall_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f1bed331fd468b976a2e171bde73ee1c41e1e05142a92ec3d3fe26f38768042
+size 37360

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostsmall_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostsmall_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95608e4324414bc3697022a0b7d73e8ea06fcdbf8e8b1756604519d560fb5b57
+size 36828

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedlarge_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedlarge_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac7370145e9faebd68fcf082d2bb38ca0cec9fab1b1c2cd67620414c4838812a
+size 116583

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedlarge_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedlarge_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:578ec8d1fe1933e8f0b3c44b5948a73b0c3b9833bde62521d1608ca5fa6aa876
+size 113609

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6817fa1e92278779e5e7a9272fdc0b8e2f18809a90e72ddaf64bbd160e0baa7c
+size 96867

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b92ae29aa085c65bd07d52a319101fc758601a836f29cd8c4dafb3d12ee2e047
+size 93387

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedsmall_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedsmall_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:347bef25f87fea53b7def0410596957495775ce5bf2e3b1949c7a83d748a94a9
+size 79878

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedsmall_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedsmall_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de092e590366c9678179ba26c3e2ee304d80229528e757223e368e9e1937a396
+size 77415

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttons_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttons_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac4ab33c332d723386e6051868aed828f4acfc699107915fa46b36e2221b8793
+size 33232

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttons_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttons_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d6531f0086120c9895a67d12424dbe4841143450aef095b2c4b5d7d2c1f18e9
+size 33548

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedlarge_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedlarge_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1cdd6f1b1108c01482918255ae7746803048752cb0a77d422972b9b2f522a08
+size 96566

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedlarge_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedlarge_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39f4f89445282377a33984611d25a63c05daf330e14413608d8670d6665dc021
+size 91615

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc0253bca24f500757773df65fa1dd4b215c8aaa00c66790a94f7c0d7a3ddd57
+size 76253

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0a9e7674cc64242b30fd8eaee85461ca6b3cdf803cd8927789422dfe9d8d244
+size 68960

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedsmall_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedsmall_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb5ee3afa7166f8354411df04adc933fea3b243b9d728557cc5e6f3e43f9dd6b
+size 80174

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedsmall_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedsmall_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0abc1c9a86db57dc2cb33041b6cbf007e93ad54b48a8a65266f3f4a38556b32f
+size 79907

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkboxlabelled_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkboxlabelled_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:031ae17cf1a8d7596175d9c46ac4a2d1d92a2e49bf0fe588d9a089377728da7b
-size 59692
+oid sha256:a7ebfd4276848f221bf948a60c107ab5bf1ba765b99d0222bdf16c16d75ae232
+size 65346

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkboxlabelled_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_checkboxlabelled_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:079abb7e1ce190e9ec488d97f9496c1a656435770eea27d64aaf479d8eabc8cb
-size 59164
+oid sha256:f9b37d7b62a312ea4b6385ce4b6a55c7cb60158a7bb2f0710574afe7db84d722
+size 64825

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_labelledslot.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_labelledslot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99e76b3a02257f826db25d0a060f99c1f682ef45e9c1b9a4da8459d9564e9951
-size 7553
+oid sha256:92a63574a589ce42574b0be22542c99434f58e2853139b28fce33a4add52e1d9
+size 7331

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobuttonlabelled_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobuttonlabelled_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8ebe352cd736b15f7db8e192204dedf9142dc61f913977dda6264087657775e
-size 26947
+oid sha256:74f002a378c3d2ca1bd7fca3bb14afa0e76701426f7945af9f961313f3d2598c
+size 26650

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobuttonlabelled_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_radiobuttonlabelled_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94068acf6ce60419f2aa19dcd9db91e38faa1a7ce352dc3336160c0779fd27de
-size 26471
+oid sha256:fe3d146fb1d1f7b4385df15763f16a6d8500333af1b6464268c2587ac84977c7
+size 26148

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_switchlabelled_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_switchlabelled_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ef6743c9a3aa75bd7fcbf9b8d0e7ab62539080a4385d284fb36caf573574cd6
-size 111450
+oid sha256:5de81a2204f1644e58fa1408ea16b5b6dbbc51ad25860215cec487ff0b5337b5
+size 109520

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_switchlabelled_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_toggles_switchlabelled_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f729621b17625b917e3da9eab0a65940773e09545af2c0b8691dd4dede280fe9
-size 109739
+oid sha256:8e41d126c9b9c573b13a2b73a901a69fb13fac8f293c9f9d15524e166e1ddc31
+size 108045

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
@@ -55,8 +56,8 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.appbar.TopAppBar
 import com.adevinta.spark.components.buttons.ButtonFilled
 import com.adevinta.spark.components.buttons.ButtonOutlined
-import com.adevinta.spark.components.icons.Icon
-import com.adevinta.spark.components.icons.IconButton
+import com.adevinta.spark.components.iconbuttons.IconButtonColors
+import com.adevinta.spark.components.iconbuttons.SparkIconButton
 import com.adevinta.spark.components.image.Illustration
 import com.adevinta.spark.components.scaffold.Scaffold
 import com.adevinta.spark.components.text.Text
@@ -66,6 +67,7 @@ import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tokens.Layout
 import com.adevinta.spark.tokens.bodyWidth
 import com.adevinta.spark.tokens.dim2
+import com.adevinta.spark.tokens.disabled
 import com.adevinta.spark.tools.preview.DevicePreviews
 
 /**
@@ -218,13 +220,7 @@ private fun PhonePortraitModalScaffold(
         topBar = {
             TopAppBar(
                 navigationIcon = {
-                    IconButton(onClick = onClose) {
-                        Icon(
-                            sparkIcon = SparkIcons.Close,
-                            tint = SparkTheme.colors.onSurface.dim2,
-                            contentDescription = stringResource(id = R.string.spark_a11y_modal_fullscreen_close),
-                        )
-                    }
+                    CloseIconButton(onClose = onClose)
                 },
                 title = { },
             )
@@ -306,13 +302,7 @@ private fun PhoneLandscapeModalScaffold(
         topBar = {
             TopAppBar(
                 navigationIcon = {
-                    IconButton(onClick = onClose) {
-                        Icon(
-                            sparkIcon = SparkIcons.Close,
-                            tint = SparkTheme.colors.onSurface.dim2,
-                            contentDescription = stringResource(id = R.string.spark_a11y_modal_fullscreen_close),
-                        )
-                    }
+                    CloseIconButton(onClose = onClose)
                 },
                 title = { },
             )
@@ -363,6 +353,27 @@ private fun PhoneLandscapeModalScaffold(
     }
 }
 
+@Composable
+private fun CloseIconButton(
+    onClose: () -> Unit,
+) {
+    val contentColor = SparkTheme.colors.onSurface.dim2
+    val colors = IconButtonColors(
+        containerColor = Color.Transparent,
+        contentColor = contentColor,
+        disabledContainerColor = Color.Transparent,
+        disabledContentColor = contentColor.disabled,
+    )
+    SparkIconButton(
+        icon = SparkIcons.Close,
+        onClick = onClose,
+        contentDescription = stringResource(
+            id = R.string.spark_a11y_modal_fullscreen_close,
+        ),
+        colors = colors,
+    )
+}
+
 private val MinWidth = 280.dp
 private val MaxWidth = 560.dp
 
@@ -393,6 +404,7 @@ private fun ModalPreview() {
                 ButtonOutlined(modifier = it, onClick = { /*TODO*/ }, text = "Alternative Action")
             },
             reverseButtonOrder = true,
+            illustrationContentScale = ContentScale.FillWidth,
         ) { innerPadding ->
             Text(
                 modifier = Modifier

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconToggleButtonColors
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.InternalSparkApi
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.tools.modifiers.ifTrue
+import com.adevinta.spark.tools.modifiers.minimumTouchTargetSize
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+/**
+ * Icon buttons help people take supplementary actions with a single tap. They’re used when a
+ * compact button is required, such as in a toolbar or image list.
+ *
+ * @param icon a content to be drawn inside the IconButton
+ * @param colors [IconButtonColors] that will be used to resolve the colors used for this icon
+ * button in different states.
+ * @param onClick called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param enabled controls the enabled state of this icon button. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param shape to be applied to the IconButton background. It should be one of [IconButtonShape] values
+ * @param size one of the [IconButtonSize] values that sets width and height of the IconButton
+ * @param border an optional [BorderStroke] to be applied to the IconButton
+ * @param contentDescription text used by accessibility services to describe what this icon button
+ * represents. This text should be localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this icon button. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this icon button in different states.
+ */
+@InternalSparkApi
+@Composable
+internal fun SparkIconButton(
+    icon: SparkIcon,
+    colors: IconButtonColors,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: IconButtonShape = IconButtonDefaults.DefaultShape,
+    size: IconButtonSize = IconButtonDefaults.DefaultSize,
+    border: BorderStroke? = null,
+    contentDescription: String? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val content: @Composable () -> Unit = {
+        Icon(
+            sparkIcon = icon,
+            contentDescription = contentDescription,
+            size = size.iconSize,
+        )
+    }
+    Surface(
+        onClick = onClick,
+        modifier = modifier
+            .minimumTouchTargetSize()
+            .sparkUsageOverlay(),
+        enabled = enabled,
+        shape = shape.shape,
+        color = colors.containerColor(enabled = enabled).value,
+        contentColor = colors.contentColor(enabled).value,
+        border = border,
+        interactionSource = interactionSource,
+    ) {
+        Box(
+            modifier = Modifier.size(size.height),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
+    }
+}
+
+/**
+ * <a href="https://m3.material.io/components/icon-button/overview" class="external" target="_blank">Material Design outlined icon toggle button</a>.
+ *
+ * Icon buttons help people take supplementary actions with a single tap. They’re used when a
+ * compact button is required, such as in a toolbar or image list.
+ *
+ * ![Outlined icon toggle button image](https://developer.android.com/images/reference/androidx/compose/material3/outlined-icon-toggle-button.png)
+ *
+ * [content] should typically be an [Icon] (see [androidx.compose.material.icons.Icons]). If using a
+ * custom icon, note that the typical size for the internal icon is 24 x 24 dp.
+ * This icon button has an overall minimum touch target size of 48 x 48dp, to meet accessibility
+ * guidelines.
+ *
+ * @sample androidx.compose.material3.samples.OutlinedIconToggleButtonSample
+ *
+ * @param checked whether this icon button is toggled on or off
+ * @param onCheckedChange called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param enabled controls the enabled state of this icon button. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param shape defines the shape of this icon button's container and border (when [border] is not
+ * null)
+ * @param colors [IconToggleButtonColors] that will be used to resolve the colors used for this icon
+ * button in different states. See [IconButtonDefaults.outlinedIconToggleButtonColors].
+ * @param border the border to draw around the container of this icon button. Pass `null` for no
+ * border. See [IconButtonDefaults.outlinedIconToggleButtonBorder].
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this icon button. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this icon button in different states.
+ * @param content the content of this icon button, typically an [Icon]
+ */
+@ExperimentalMaterial3Api
+@Composable
+@InternalSparkApi
+internal fun IconToggleButton(
+    icon: SparkIcon, // = IconButtonDefaults.outlinedIconToggleButtonColors(),
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    intent: IconButtonIntent = IconButtonIntent.Basic,
+    enabled: Boolean = true,
+    shape: IconButtonShape = IconButtonShape.Large,
+    size: IconButtonSize = IconButtonSize.Medium,
+    border: BorderStroke? = null,
+    contentDescription: String? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val content: @Composable () -> Unit = {
+        Icon(
+            sparkIcon = icon,
+            contentDescription = contentDescription,
+            size = size.iconSize,
+        )
+    }
+    val colors = IconButtonDefaults.filledIconButtonColors(intent.colors())
+    Surface(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier.semantics { role = Role.Checkbox },
+        enabled = enabled,
+        shape = shape.shape,
+        color = colors.contentColor(enabled = enabled).value,
+        contentColor = colors.contentColor(enabled).value,
+        // color = colors.containerColor(enabled, checked).value,
+        // contentColor = colors.contentColor(enabled, checked).value,
+        border = border,
+        interactionSource = interactionSource,
+    ) {
+        Box(
+            modifier = Modifier.size(size.height),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButtons",
+)
+@Composable
+internal fun IconButtonPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        val intent = IconButtonIntent.Basic
+        IconButtonSize.values().forEach { size ->
+            IconButtonShape.values().forEach { shape ->
+                IconButtonFilledPair(
+                    intent = intent,
+                    size = size,
+                    shape = shape,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun IconButtonPreview(
+    content: @Composable (
+        intent: IconButtonIntent,
+        shape: IconButtonShape,
+    ) -> Unit,
+) {
+    IconButtonIntent.values().forEach { intent ->
+        Row(
+            modifier = Modifier.ifTrue(intent == IconButtonIntent.Surface) {
+                background(SparkTheme.colors.neutralContainer)
+            },
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            IconButtonShape.values().forEach { shape ->
+                content(intent = intent, shape = shape)
+            }
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonContrast.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonContrast.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.icons.WheelOutline
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+/**
+ * Icon buttons help people take supplementary actions with a single tap. They’re used when a
+ * compact button is required, such as in a toolbar or image list.
+ *
+ * @param icon a content to be drawn inside the IconButton
+ * @param onClick called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param intent one of [IconButtonIntent] values that will be used to determine [IconButtonColors] to be applied
+ * @param enabled controls the enabled state of this icon button. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param shape to be applied to the IconButton background. It should be one of [IconButtonShape] values
+ * @param size one of the [IconButtonSize] values that sets width and height of the IconButton
+ * @param contentDescription text used by accessibility services to describe what this icon button
+ * represents. This text should be localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this icon button. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this icon button in different states.
+ */
+@Composable
+public fun IconButtonContrast(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    intent: IconButtonIntent = IconButtonDefaults.DefaultIntent,
+    enabled: Boolean = true,
+    shape: IconButtonShape = IconButtonDefaults.DefaultShape,
+    size: IconButtonSize = IconButtonDefaults.DefaultSize,
+    contentDescription: String? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = IconButtonDefaults.contrastIconButtonColors(intent.colors())
+    SparkIconButton(
+        icon = icon,
+        onClick = onClick,
+        modifier = modifier,
+        colors = colors,
+        enabled = enabled,
+        shape = shape,
+        size = size,
+        contentDescription = contentDescription,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Contrast Small",
+)
+@Composable
+internal fun IconButtonContrastSmallPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonContrastPair(
+                intent = intent,
+                size = IconButtonSize.Small,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Contrast Medium",
+)
+@Composable
+internal fun IconButtonContrastMediumPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonContrastPair(
+                intent = intent,
+                size = IconButtonSize.Medium,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Contrast Large",
+)
+@Composable
+internal fun IconButtonContrastLargePreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonContrastPair(
+                intent = intent,
+                size = IconButtonSize.Large,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun IconButtonContrastPair(
+    intent: IconButtonIntent,
+    size: IconButtonSize,
+    shape: IconButtonShape,
+) {
+    val icon = SparkIcons.WheelOutline
+    val contentDescription = "Localized description"
+    Row {
+        listOf(true, false).forEach { enabled ->
+            IconButtonContrast(
+                icon = icon,
+                onClick = {},
+                intent = intent,
+                enabled = enabled,
+                contentDescription = contentDescription,
+                size = size,
+                shape = shape,
+            )
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonDefaults.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.IntentColor
+import com.adevinta.spark.tokens.disabled
+
+internal object IconButtonDefaults {
+
+    /**
+     * The outlined icon button's border size
+     */
+    internal val OutlinedBorderSize = 1.dp
+
+    /**
+     * The default intent of IconButton
+     */
+    internal val DefaultIntent = IconButtonIntent.Main
+
+    /**
+     * The default size of IconButton
+     */
+    internal val DefaultSize = IconButtonSize.Medium
+
+    /**
+     * The default shape of IconButton
+     */
+    internal val DefaultShape = IconButtonShape.Large
+
+    @Composable
+    fun filledIconButtonColors(
+        intent: IntentColor,
+        containerColor: Color = intent.color,
+        contentColor: Color = intent.onColor,
+        disabledContainerColor: Color = containerColor.disabled,
+        disabledContentColor: Color = contentColor.disabled,
+    ): IconButtonColors =
+        IconButtonColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+            disabledContainerColor = disabledContainerColor,
+            disabledContentColor = disabledContentColor,
+        )
+
+    @Composable
+    fun outlinedIconButtonColors(
+        intent: IntentColor,
+        containerColor: Color = Color.Transparent,
+        contentColor: Color = intent.color,
+        disabledContainerColor: Color = Color.Transparent,
+        disabledContentColor: Color = contentColor.disabled,
+    ): IconButtonColors =
+        IconButtonColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+            disabledContainerColor = disabledContainerColor,
+            disabledContentColor = disabledContentColor,
+        )
+
+    @Composable
+    fun tintedIconButtonColors(
+        intent: IntentColor,
+        containerColor: Color = intent.containerColor,
+        contentColor: Color = intent.onContainerColor,
+        disabledContainerColor: Color = containerColor.disabled,
+        disabledContentColor: Color = contentColor.disabled,
+    ): IconButtonColors =
+        IconButtonColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+            disabledContainerColor = disabledContainerColor,
+            disabledContentColor = disabledContentColor,
+        )
+
+    @Composable
+    fun ghostIconButtonColors(
+        intent: IntentColor,
+        containerColor: Color = Color.Transparent,
+        contentColor: Color = intent.onContainerColor,
+        disabledContainerColor: Color = Color.Transparent,
+        disabledContentColor: Color = contentColor.disabled,
+    ): IconButtonColors =
+        IconButtonColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+            disabledContainerColor = disabledContainerColor,
+            disabledContentColor = disabledContentColor,
+        )
+
+    @Composable
+    fun contrastIconButtonColors(
+        intent: IntentColor,
+        containerColor: Color = SparkTheme.colors.surface,
+        contentColor: Color = intent.color,
+        disabledContainerColor: Color = containerColor.disabled,
+    ): IconButtonColors = with(if (containerColor != contentColor) contentColor else SparkTheme.colors.onSurface) {
+        IconButtonColors(
+            containerColor = containerColor,
+            contentColor = this,
+            disabledContainerColor = disabledContainerColor,
+            disabledContentColor = this.disabled,
+        )
+    }
+}
+
+/**
+ * Represents the container and content colors used in an icon button in different states.
+ *
+ * - See [IconButtonDefaults.filledIconButtonColors] and
+ * [IconButtonDefaults.filledTonalIconButtonColors] for the default colors used in a
+ * [IconButtonFilled].
+ * - See [IconButtonDefaults.outlinedIconButtonColors] for the default colors used in an
+ * [OutlinedIconButton].
+ */
+@Immutable
+// FIXME: Copy from MD. Remove once MD version is updated and constructor is no longer internal
+internal class IconButtonColors(
+    private val containerColor: Color,
+    private val contentColor: Color,
+    private val disabledContainerColor: Color,
+    private val disabledContentColor: Color,
+) {
+    /**
+     * Represents the container color for this icon button, depending on [enabled].
+     *
+     * @param enabled whether the icon button is enabled
+     */
+    @Composable
+    internal fun containerColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(if (enabled) containerColor else disabledContainerColor)
+    }
+
+    /**
+     * Represents the content color for this icon button, depending on [enabled].
+     *
+     * @param enabled whether the icon button is enabled
+     */
+    @Composable
+    internal fun contentColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(if (enabled) contentColor else disabledContentColor)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || other !is IconButtonColors) return false
+
+        if (containerColor != other.containerColor) return false
+        if (contentColor != other.contentColor) return false
+        if (disabledContainerColor != other.disabledContainerColor) return false
+        if (disabledContentColor != other.disabledContentColor) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = containerColor.hashCode()
+        result = 31 * result + contentColor.hashCode()
+        result = 31 * result + disabledContainerColor.hashCode()
+        result = 31 * result + disabledContentColor.hashCode()
+
+        return result
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonFilled.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.icons.WheelOutline
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+/**
+ * Icon buttons help people take supplementary actions with a single tap. They’re used when a
+ * compact button is required, such as in a toolbar or image list.
+ *
+ * @param icon a content to be drawn inside the IconButton
+ * @param onClick called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param intent one of [IconButtonIntent] values that will be used to determine [IconButtonColors] to be applied
+ * @param enabled controls the enabled state of this icon button. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param shape to be applied to the IconButton background. It should be one of [IconButtonShape] values
+ * @param size one of the [IconButtonSize] values that sets width and height of the IconButton
+ * @param contentDescription text used by accessibility services to describe what this icon button
+ * represents. This text should be localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this icon button. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this icon button in different states.
+ */
+@Composable
+public fun IconButtonFilled(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    intent: IconButtonIntent = IconButtonDefaults.DefaultIntent,
+    enabled: Boolean = true,
+    shape: IconButtonShape = IconButtonDefaults.DefaultShape,
+    size: IconButtonSize = IconButtonDefaults.DefaultSize,
+    contentDescription: String? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = IconButtonDefaults.filledIconButtonColors(intent.colors())
+    SparkIconButton(
+        icon = icon,
+        onClick = onClick,
+        modifier = modifier,
+        colors = colors,
+        enabled = enabled,
+        shape = shape,
+        size = size,
+        contentDescription = contentDescription,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Filled Small",
+)
+@Composable
+internal fun IconButtonFilledSmallPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonFilledPair(
+                intent = intent,
+                size = IconButtonSize.Small,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Filled Medium",
+)
+@Composable
+internal fun IconButtonFilledMediumPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonFilledPair(
+                intent = intent,
+                size = IconButtonSize.Medium,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Filled Large",
+)
+@Composable
+internal fun IconButtonFilledLargePreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonFilledPair(
+                intent = intent,
+                size = IconButtonSize.Large,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun IconButtonFilledPair(
+    intent: IconButtonIntent,
+    size: IconButtonSize,
+    shape: IconButtonShape,
+) {
+    val icon = SparkIcons.WheelOutline
+    val contentDescription = "Localized description"
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        listOf(true, false).forEach { enabled ->
+            IconButtonFilled(
+                icon = icon,
+                onClick = {},
+                intent = intent,
+                enabled = enabled,
+                contentDescription = contentDescription,
+                size = size,
+                shape = shape,
+            )
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonGhost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonGhost.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.icons.WheelOutline
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+/**
+ * Icon buttons help people take supplementary actions with a single tap. They’re used when a
+ * compact button is required, such as in a toolbar or image list.
+ *
+ * @param icon a content to be drawn inside the IconButton
+ * @param onClick called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param intent one of [IconButtonIntent] values that will be used to determine [IconButtonColors] to be applied
+ * @param enabled controls the enabled state of this icon button. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param shape to be applied to the IconButton background. It should be one of [IconButtonShape] values
+ * @param size one of the [IconButtonSize] values that sets width and height of the IconButton
+ * @param contentDescription text used by accessibility services to describe what this icon button
+ * represents. This text should be localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this icon button. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this icon button in different states.
+ */
+@Composable
+public fun IconButtonGhost(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    intent: IconButtonIntent = IconButtonDefaults.DefaultIntent,
+    enabled: Boolean = true,
+    shape: IconButtonShape = IconButtonDefaults.DefaultShape,
+    size: IconButtonSize = IconButtonDefaults.DefaultSize,
+    contentDescription: String? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = IconButtonDefaults.ghostIconButtonColors(intent.colors())
+    SparkIconButton(
+        icon = icon,
+        onClick = onClick,
+        modifier = modifier,
+        colors = colors,
+        enabled = enabled,
+        shape = shape,
+        size = size,
+        contentDescription = contentDescription,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Ghost Small",
+)
+@Composable
+internal fun IconButtonGhostSmallPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonGhostPair(
+                intent = intent,
+                size = IconButtonSize.Small,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Ghost Medium",
+)
+@Composable
+internal fun IconButtonGhostMediumPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonGhostPair(
+                intent = intent,
+                size = IconButtonSize.Medium,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Ghost Large",
+)
+@Composable
+internal fun IconButtonGhostLargePreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonGhostPair(
+                intent = intent,
+                size = IconButtonSize.Large,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun IconButtonGhostPair(
+    intent: IconButtonIntent,
+    size: IconButtonSize,
+    shape: IconButtonShape,
+) {
+    val icon = SparkIcons.WheelOutline
+    val contentDescription = "Localized description"
+    Row {
+        listOf(true, false).forEach { enabled ->
+            IconButtonGhost(
+                icon = icon,
+                onClick = {},
+                intent = intent,
+                enabled = enabled,
+                contentDescription = contentDescription,
+                size = size,
+                shape = shape,
+            )
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonIntent.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.runtime.Composable
+import com.adevinta.spark.components.IntentColor
+import com.adevinta.spark.components.IntentColors
+
+/**
+ * IconButtonIntent is used to define the intent of the icon buttons.
+ */
+public enum class IconButtonIntent {
+    /**
+     * Used to match default color of such UI controls as toggles, Slider, etc.
+     */
+    Basic {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Basic.colors()
+    },
+
+    /**
+     * Used to make button visually accentuated.
+     */
+    Accent {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Accent.colors()
+    },
+
+    /**
+     * Main buttons are used for the most important actions.
+     */
+    Main {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Main.colors()
+    },
+
+    /**
+     * Support buttons are used to highlight/accentuate actions.
+     */
+    Support {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Support.colors()
+    },
+
+    /**
+     * Actions on a color / image panel without on intent color.
+     */
+    Surface {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Surface.colors()
+    },
+
+    /**
+     * Used for confirmation actions.
+     */
+    Success {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Success.colors()
+    },
+
+    /**
+     * Used for warning actions.
+     */
+    Alert {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Alert.colors()
+    },
+
+    /**
+     * Used for risky actions.
+     */
+    Danger {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Danger.colors()
+    },
+
+    /**
+     * Used for low or irrelevant actions.
+     */
+    Neutral {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Neutral.colors()
+    },
+    ;
+
+    @Composable
+    internal abstract fun colors(): IntentColor
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonOutlined.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.icons.WheelOutline
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+/**
+ * Icon buttons help people take supplementary actions with a single tap. They’re used when a
+ * compact button is required, such as in a toolbar or image list.
+ *
+ * @param icon a content to be drawn inside the IconButton
+ * @param onClick called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param intent one of [IconButtonIntent] values that will be used to determine [IconButtonColors] to be applied
+ * @param enabled controls the enabled state of this icon button. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param shape to be applied to the IconButton background. It should be one of [IconButtonShape] values
+ * @param size one of the [IconButtonSize] values that sets width and height of the IconButton
+ * @param contentDescription text used by accessibility services to describe what this icon button
+ * represents. This text should be localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this icon button. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this icon button in different states.
+ */
+@Composable
+public fun IconButtonOutlined(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    intent: IconButtonIntent = IconButtonDefaults.DefaultIntent,
+    enabled: Boolean = true,
+    shape: IconButtonShape = IconButtonDefaults.DefaultShape,
+    size: IconButtonSize = IconButtonDefaults.DefaultSize,
+    contentDescription: String? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = IconButtonDefaults.outlinedIconButtonColors(intent = intent.colors())
+    SparkIconButton(
+        icon = icon,
+        onClick = onClick,
+        modifier = modifier,
+        colors = colors,
+        enabled = enabled,
+        shape = shape,
+        size = size,
+        border = BorderStroke(
+            width = IconButtonDefaults.OutlinedBorderSize,
+            color = colors.contentColor(enabled = enabled).value,
+        ),
+        contentDescription = contentDescription,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Outlined Small",
+)
+@Composable
+internal fun IconButtonOutlinedSmallPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonOutlinedPair(
+                intent = intent,
+                size = IconButtonSize.Small,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Outlined Medium",
+)
+@Composable
+internal fun IconButtonOutlinedMediumPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonOutlinedPair(
+                intent = intent,
+                size = IconButtonSize.Medium,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Outlined Large",
+)
+@Composable
+internal fun IconButtonOutlinedLargePreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonOutlinedPair(
+                intent = intent,
+                size = IconButtonSize.Large,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun IconButtonOutlinedPair(
+    intent: IconButtonIntent,
+    size: IconButtonSize,
+    shape: IconButtonShape,
+) {
+    val icon = SparkIcons.WheelOutline
+    val contentDescription = "Localized description"
+    Row {
+        listOf(true, false).forEach { enabled ->
+            IconButtonOutlined(
+                icon = icon,
+                onClick = {},
+                intent = intent,
+                enabled = enabled,
+                contentDescription = contentDescription,
+                size = size,
+                shape = shape,
+            )
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonShape.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonShape.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.runtime.Composable
+import com.adevinta.spark.SparkTheme
+
+public enum class IconButtonShape {
+    /**
+     * Small button with min touch size still applied
+     */
+    None {
+        override val shape: CornerBasedShape
+            @Composable
+            get() = SparkTheme.shapes.none
+    },
+
+    /**
+     * Medium button is the default button size (recommended).
+     */
+    Full {
+        override val shape: CornerBasedShape
+            @Composable
+            get() = SparkTheme.shapes.full
+    },
+
+    /**
+     * Alternative large icon button size to give more emphasis to the action
+     */
+    Large {
+        override val shape: CornerBasedShape
+            @Composable
+            get() = SparkTheme.shapes.large
+    },
+    ;
+
+    internal abstract val shape: CornerBasedShape
+        @Composable get
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonSize.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonSize.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.components.icons.IconSize
+
+public enum class IconButtonSize {
+    /**
+     * Small button with min touch size still applied
+     */
+    Small {
+        override val height: Dp = 32.dp
+        override val iconSize: IconSize = IconSize.Small
+    },
+
+    /**
+     * Medium button is the default button size (recommended).
+     */
+    Medium {
+        override val height: Dp = 44.dp
+        override val iconSize: IconSize = IconSize.Small
+    },
+
+    /**
+     * Alternative large icon button size to give more emphasis to the action
+     */
+    Large {
+        override val height: Dp = 56.dp
+        override val iconSize: IconSize = IconSize.Medium
+    },
+    ;
+
+    internal abstract val height: Dp
+    internal abstract val iconSize: IconSize
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTinted.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.iconbuttons
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adevinta.spark.PreviewTheme
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.icons.WheelOutline
+import com.adevinta.spark.tools.preview.ThemeProvider
+import com.adevinta.spark.tools.preview.ThemeVariant
+
+/**
+ * Icon buttons help people take supplementary actions with a single tap. They’re used when a
+ * compact button is required, such as in a toolbar or image list.
+ *
+ * @param icon a content to be drawn inside the IconButton
+ * @param onClick called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param intent one of [IconButtonIntent] values that will be used to determine [IconButtonColors] to be applied
+ * @param enabled controls the enabled state of this icon button. When `false`, this component will
+ * not respond to user input, and it will appear visually disabled and disabled to accessibility
+ * services.
+ * @param shape to be applied to the IconButton background. It should be one of [IconButtonShape] values
+ * @param size one of the [IconButtonSize] values that sets width and height of the IconButton
+ * @param contentDescription text used by accessibility services to describe what this icon button
+ * represents. This text should be localized, such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
+ * for this icon button. You can create and pass in your own `remember`ed instance to observe
+ * [Interaction]s and customize the appearance / behavior of this icon button in different states.
+ */
+@Composable
+public fun IconButtonTinted(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    intent: IconButtonIntent = IconButtonDefaults.DefaultIntent,
+    enabled: Boolean = true,
+    shape: IconButtonShape = IconButtonDefaults.DefaultShape,
+    size: IconButtonSize = IconButtonDefaults.DefaultSize,
+    contentDescription: String? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = IconButtonDefaults.tintedIconButtonColors(intent.colors())
+    SparkIconButton(
+        icon = icon,
+        onClick = onClick,
+        modifier = modifier,
+        colors = colors,
+        enabled = enabled,
+        shape = shape,
+        size = size,
+        contentDescription = contentDescription,
+        interactionSource = interactionSource,
+    )
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Tinted Small",
+)
+@Composable
+internal fun IconButtonTintedSmallPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonFilledPair(
+                intent = intent,
+                size = IconButtonSize.Small,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Tinted Medium",
+)
+@Composable
+internal fun IconButtonTintedMediumPreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonTintedPair(
+                intent = intent,
+                size = IconButtonSize.Medium,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Preview(
+    group = "IconButtons",
+    name = "IconButton Tinted Large",
+)
+@Composable
+internal fun IconButtonTintedLargePreview(
+    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
+) {
+    PreviewTheme(theme) {
+        IconButtonPreview { intent, shape ->
+            IconButtonTintedPair(
+                intent = intent,
+                size = IconButtonSize.Large,
+                shape = shape,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun IconButtonTintedPair(
+    intent: IconButtonIntent,
+    size: IconButtonSize,
+    shape: IconButtonShape,
+) {
+    val icon = SparkIcons.WheelOutline
+    val contentDescription = "Localized description"
+    Row {
+        listOf(true, false).forEach { enabled ->
+            IconButtonTinted(
+                icon = icon,
+                onClick = {},
+                intent = intent,
+                enabled = enabled,
+                contentDescription = contentDescription,
+                size = size,
+                shape = shape,
+            )
+        }
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtons.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtons.md
@@ -1,0 +1,143 @@
+# Package com.adevinta.spark.components.buttons
+
+[IconButtons](https://spark.adevinta.com/1186e1705/p/2352e9-icon-button/b/32e1a2) take supplementary
+actions with a single tap. They’re used when a compact button is required, such as in a toolbar or
+image list.
+
+### Styles
+
+Icon buttons come in various styles:
+
+- Filled
+- Tinted
+- Outlined
+- Contrast
+- Ghost
+
+|       | Filled                                                                                                                 | Outlined                                                                                                                 | Tinted                                                                                                                 | Ghost                                                                                                                 | Contrast                                                                                                                 |
+|-------|------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| Light | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_light.png) |
+| Dark  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_dark.png)  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_dark.png)  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_dark.png)  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_dark.png)  | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_dark.png)  |
+
+### Sizes
+
+Icon buttons come in 3 sizes [IconButtonSize](IconButtonSize.kt):
+
+- small - 32.dp (however, the minimum touch size is applied and is 44.dp)
+- medium - 44.dp (default)
+- large - 56.dp
+
+The content icon is 16.dp for `IconButtonSize.Small` and `IconButtonSize.Medium`, and 24.dp
+for `IconButtonSize.Large`
+![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttons_light.png)
+
+### Shapes
+Icon buttons come in 3 shapes [IconButtonShape](IconButtonShape.kt) :
+- None 
+- Full (default)
+- Large
+
+The buttons have an loading state that can be used to indicate that the button is loading some
+data and show/hide an indeterminate circular progress indicator on the start of the button.
+
+![](../../images/loading-button.gif)
+
+### Intents
+
+Icon Buttons support all intents:
+- Basic (default)
+- Accent
+- Main
+- Support
+- Success
+- Alert
+- Danger
+- Info
+- Neutral
+- Surface
+
+#### IconButtonFilled
+
+Filled icon buttons are the standard for most use cases. The filled styling places the most
+emphasis and should be used for important actions.
+
+```kotlin
+fun IconButtonFilled(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+)
+```
+
+| Light                                                                                                                  | Dark                                                                                                                  |
+|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonfilledmedium_dark.png) |
+
+#### IconButtonOutlined
+
+Outlined icon buttons are used for support actions. The outlined styling places less emphasis on these
+actions that are important but not the main ones.
+
+Be aware that it's not advised to use it on top of images since it will be hard to see.
+
+```kotlin
+fun IconButtonOutlined(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+)
+```
+
+| Light                                                                                                                    | Dark                                                                                                                    |
+|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonoutlinedmedium_dark.png) |
+
+#### IconButtonTinted
+
+Tinted icon buttons are medium-emphasis buttons that is an alternative middle ground between
+default filled icon buttons and outlined icon buttons. They can be used in contexts where lower-priority
+icon button requires slightly more emphasis than an outline would give.
+
+```kotlin
+fun IconButtonTinted(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+)
+```
+
+| Light                                                                                                                  | Dark                                                                                                                  |
+|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttontintedmedium_dark.png) |
+
+#### IconButtonGhost
+
+Ghost icon buttons are used for the lowest priority actions, especially when presenting multiple options.
+
+Ghost icon buttons can be placed on a variety of backgrounds. Until the button is interacted with, its
+container isn’t visible.
+This button style is often used inside other components like snackbars, dialogs, and cards.
+
+```kotlin
+fun IconButtonGhost(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+)
+```
+
+| Light                                                                                                                 | Dark                                                                                                                 |
+|-----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttonghostmedium_dark.png) |
+
+#### IconButtonContrast
+
+Contrast icon buttons are used for the high to mid priority actions when the background is dark like on
+an image or a video.
+
+```kotlin
+fun IconButtonContrast(
+    icon: SparkIcon,
+    onClick: () -> Unit,
+)
+```
+
+| Light                                                                                                                    | Dark                                                                                                                    |
+|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_light.png) | ![](../../images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_iconbuttons_iconbuttoncontrastmedium_dark.png) |

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
@@ -29,20 +29,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.OutlinedIconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adevinta.spark.ExperimentalSparkApi
-import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
-import com.adevinta.spark.icons.SparkIcons
-import com.adevinta.spark.icons.WheelOutline
-import com.adevinta.spark.tools.preview.ThemeProvider
-import com.adevinta.spark.tools.preview.ThemeVariant
 import androidx.compose.material3.FilledIconButton as MaterialFilledIconButton
 import androidx.compose.material3.FilledTonalIconButton as MaterialFilledTonalIconButton
 import androidx.compose.material3.IconButton as MaterialIconButton
@@ -74,6 +66,13 @@ import androidx.compose.material3.OutlinedIconButton as MaterialOutlinedIconButt
  * @param content the content of this icon button, typically an [Icon]
  */
 @Composable
+@Deprecated(
+    "Use styled icon button like from iconbuttons package",
+    replaceWith = ReplaceWith(
+        "IconButtonFilled(icon = icon, onClick = onClick)",
+        imports = arrayOf("com.adevinta.spark.components.iconbuttons.IconButtonFilled"),
+    ),
+)
 public fun IconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -118,6 +117,13 @@ public fun IconButton(
  * [Interaction]s and customize the appearance / behavior of this icon button in different states.
  * @param content the content of this icon button, typically an [Icon]
  */
+@Deprecated(
+    "Use styled icon button like from iconbuttons package",
+    replaceWith = ReplaceWith(
+        "IconButtonFilled(icon = icon, onClick = onClick)",
+        imports = arrayOf("com.adevinta.spark.components.iconbuttons.IconButtonFilled"),
+    ),
+)
 @ExperimentalSparkApi
 @Composable
 public fun FilledIconButton(
@@ -171,6 +177,13 @@ public fun FilledIconButton(
  * [Interaction]s and customize the appearance / behavior of this icon button in different states.
  * @param content the content of this icon button, typically an [Icon]
  */
+@Deprecated(
+    "Use styled icon button from iconbuttons package",
+    replaceWith = ReplaceWith(
+        "IconButtonTinted(icon = icon, onClick = onClick)",
+        imports = arrayOf("com.adevinta.spark.components.iconbuttons.IconButtonTinted"),
+    ),
+)
 @ExperimentalSparkApi
 @Composable
 public fun FilledTonalIconButton(
@@ -230,6 +243,13 @@ public fun FilledTonalIconButton(
  * [Interaction]s and customize the appearance / behavior of this icon button in different states.
  * @param content the content of this icon button, typically an [Icon]
  */
+@Deprecated(
+    "Use styled icon button from iconbuttons package",
+    replaceWith = ReplaceWith(
+        "IconButtonOutlined(icon = icon, onClick = onClick)",
+        imports = arrayOf("com.adevinta.spark.components.iconbuttons.IconButtonOutlined"),
+    ),
+)
 @ExperimentalSparkApi
 @Composable
 public fun OutlinedIconButton(
@@ -252,38 +272,4 @@ public fun OutlinedIconButton(
         interactionSource = interactionSource,
         content = content,
     )
-}
-
-@Preview(
-    group = "Icons",
-    name = "IconButtons",
-)
-@Composable
-internal fun IconButtonPreview(
-    @PreviewParameter(ThemeProvider::class) theme: ThemeVariant,
-) {
-    PreviewTheme(theme) {
-        val icon = SparkIcons.WheelOutline
-        val contentDescription = "Localized description"
-
-        Text("IconButton")
-        IconButton(onClick = { /* doSomething() */ }) {
-            Icon(icon, contentDescription = contentDescription)
-        }
-
-        Text("FilledIconButton")
-        FilledIconButton(onClick = { /* doSomething() */ }) {
-            Icon(icon, contentDescription = contentDescription)
-        }
-
-        Text("FilledTonalIconButton")
-        FilledTonalIconButton(onClick = { /* doSomething() */ }) {
-            Icon(icon, contentDescription = contentDescription)
-        }
-
-        Text("OutlinedIconButton")
-        OutlinedIconButton(onClick = { /* doSomething() */ }) {
-            Icon(icon, contentDescription = contentDescription)
-        }
-    }
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/TouchTarget.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/TouchTarget.kt
@@ -61,7 +61,7 @@ private class MinimumTouchTargetModifier : ModifierNodeElement<MinimumTouchTarge
 @OptIn(ExperimentalComposeUiApi::class)
 private class MinimumTouchTargetModifierNode : Modifier.Node(), LayoutModifierNode {
 
-    private val minimumTouchTargetSize = DpSize(48.dp, 48.dp)
+    private val minimumTouchTargetSize = DpSize(44.dp, 44.dp)
     override fun MeasureScope.measure(
         measurable: Measurable,
         constraints: Constraints,


### PR DESCRIPTION
## 📋 Changes description

- Add new iconbutton package containing styled icon buttons:
	- IconButtonFilled
	- IconButtonOutlined
	- IconButtonTinted
	- IconButtonGhost
	- IconButtonContrast
- with all sizes, intents and shape
- deprecate old IconButtons from `icons` package. 
- Replace IconButton used in `ModalFullScreen` component

## 📸 Screenshots

Present in the current PR

## 🗒️ Other info

close #573 
close #574 
