### PR TITLE
fix: Update content color for ButtonIntent.Surface for ButtonContrast

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttoncontrastintents_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttoncontrastintents_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3fde29e71d30776bf7183d4a2acd6adb12bfe08767da3077e1e82b890f70b26
-size 29265
+oid sha256:5f6e986f67536b9dbfbaff1575e2b7768f7bb577c0139e4a7fc184a5620154b0
+size 31181

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttoncontrastintents_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_buttons_buttoncontrastintents_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f33e445676d1635d0bbc27876efd6e74d09003a1c38826c859a26411b53a022
-size 24678
+oid sha256:4447a96555e762cbf0b0ac1ffc4f78adf63ab20980d863e4acd255b00aa8bfaf
+size 26506

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
@@ -77,12 +77,14 @@ public fun ButtonContrast(
     isLoading: Boolean = false,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
+    val containerColor = SparkTheme.colors.surface
+    val colors = intent.colors()
     val contentColor by animateColorAsState(
-        targetValue = intent.colors().color,
+        targetValue = if (colors.color == containerColor) colors.onColor else colors.color,
         label = "content color",
     )
-    val containerColor = SparkTheme.colors.surface
-    val colors = ButtonDefaults.buttonColors(
+
+    val buttonColors = ButtonDefaults.buttonColors(
         containerColor = containerColor,
         contentColor = contentColor,
         disabledContainerColor = containerColor.disabled,
@@ -95,7 +97,7 @@ public fun ButtonContrast(
         size = size,
         enabled = enabled,
         elevation = ButtonDefaults.buttonElevation(),
-        colors = colors,
+        colors = buttonColors,
         icon = icon,
         iconSide = iconSide,
         isLoading = isLoading,


### PR DESCRIPTION
## 🤔 Context

ButtonIntent.Surface is an exception in case of ButtonContrast. As the contaner color is surface, the content color should not be `intent.colors.color()` but rather `onColor``

## 📸 Screenshots

Present in the current PR

## 🗒️ Other info

close #611 
