### PR TITLE
fix: Rename all refs from Polaris to Adevinta in CatalogApp

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -80,8 +80,8 @@ import com.adevinta.spark.catalog.themes.ThemeMode
 import com.adevinta.spark.catalog.themes.ThemePicker
 import com.adevinta.spark.catalog.themes.UserMode
 import com.adevinta.spark.catalog.themes.themeprovider.ThemeProvider
-import com.adevinta.spark.catalog.themes.themeprovider.leboncoin.LeboncoinTheme
 import com.adevinta.spark.catalog.themes.themeprovider.adevinta.AdevintaTheme
+import com.adevinta.spark.catalog.themes.themeprovider.leboncoin.LeboncoinTheme
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.google.accompanist.testharness.TestHarness
 import kotlinx.coroutines.launch

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -81,7 +81,7 @@ import com.adevinta.spark.catalog.themes.ThemePicker
 import com.adevinta.spark.catalog.themes.UserMode
 import com.adevinta.spark.catalog.themes.themeprovider.ThemeProvider
 import com.adevinta.spark.catalog.themes.themeprovider.leboncoin.LeboncoinTheme
-import com.adevinta.spark.catalog.themes.themeprovider.polaris.PolarisTheme
+import com.adevinta.spark.catalog.themes.themeprovider.adevinta.AdevintaTheme
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.google.accompanist.testharness.TestHarness
 import kotlinx.coroutines.launch
@@ -96,7 +96,7 @@ internal fun CatalogApp(
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
 ) {
     val themeProvider: ThemeProvider = when (theme.brandMode) {
-        BrandMode.Polaris -> PolarisTheme
+        BrandMode.Adevinta -> AdevintaTheme
         BrandMode.Leboncoin -> LeboncoinTheme
         BrandMode.LeboncoinLegacy -> LeboncoinTheme
     }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/Theme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/Theme.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.saveable.Saver
 public data class Theme(
     val themeMode: ThemeMode = ThemeMode.System,
     val colorMode: ColorMode = ColorMode.Baseline,
-    val brandMode: BrandMode = BrandMode.Polaris,
+    val brandMode: BrandMode = BrandMode.Adevinta,
     val userMode: UserMode = UserMode.Part,
     val fontScale: Float = 1.0f,
     val fontScaleMode: FontScaleMode = FontScaleMode.System,
@@ -90,7 +90,7 @@ public enum class ThemeMode {
 public enum class BrandMode(public val label: String) {
     LeboncoinLegacy("Leboncoin (Legacy)"),
     Leboncoin("Leboncoin (New Ui)"),
-    Polaris("Polaris"),
+    Adevinta("Adevinta"),
 }
 
 public enum class UserMode {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/adevinta/AdevintaTheme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/adevinta/AdevintaTheme.kt
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.adevinta.spark.catalog.themes.themeprovider.polaris
+package com.adevinta.spark.catalog.themes.themeprovider.adevinta
 
 import androidx.compose.runtime.Composable
 import com.adevinta.spark.catalog.themes.themeprovider.ThemeProvider
@@ -31,7 +31,7 @@ import com.adevinta.spark.tokens.lightSparkColors
 import com.adevinta.spark.tokens.sparkShapes
 import com.adevinta.spark.tokens.sparkTypography
 
-public object PolarisTheme : ThemeProvider {
+public object AdevintaTheme : ThemeProvider {
     @Composable
     override fun colors(useDarkColors: Boolean, isPro: Boolean, isLegacy: Boolean): SparkColors {
         return when {


### PR DESCRIPTION
## Screenshots
<img src="https://github.com/adevinta/spark-android/assets/36896406/4902b990-1177-4b3b-b395-59bd51914e0b" width="300"/>
