### PR TITLE
Revert: "chore: prepare version 0.4.0 (#621)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,6 @@
 
 ## [Unreleased]
 
-## [0.4.0]
-_2023-08-17_
-
-### Spark
-* 🆕 Implement `Spark Tab` and `Tab Group` 
-* 💄 `Checkbox`, `Switch`, `RadioButton` now has intents support 
-* 💄 Disabled components now have use dim3
-* 💄 `Button Outline` border size is now 1dp instead of 2dp
-* 💄 `TextField` update TextField background color
-* 💄 `TextField` leading content padding is adjusted
-* 💄 `TextField` addons content color is always `onSurface` even when unfocused
-* 💄 `ButtonContrast` in Surface intent is now readable
-* 💄 `ModalFullScreenScaffold` spaces and layout has been adjusted
-* 🗑️ Small size for `Button` has been removed
-* 🐛 Replace Modifier.autofill by Autofill Composable
-
-
-### Catalog App
-* 🆕 Now have examples and a configurator for `Button`, `Checkbox`, `Switch`, `RadioButton` `TextField`
-* 💄 The launcher icon now has a light and dark variant depending on the theme mode
-* 🐛 The app state is saved on configuration change
-* 🐛 Fix the link to component documentation
-* 
-
 ## [0.3.1]
 
 _2023-07-31_
@@ -98,9 +74,7 @@ _2023-03-29_
 
 <!-- Links -->
 
-[Unreleased]: https://github.com/adevinta/spark-android/compare/0.4.0...HEAD
-
-[0.3.1]: https://github.com/adevinta/spark-android/releases/tag/0.4.0
+[Unreleased]: https://github.com/adevinta/spark-android/compare/0.3.1...HEAD
 
 [0.3.1]: https://github.com/adevinta/spark-android/releases/tag/0.3.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-version=0.5.0-SNAPSHOT
+version=0.4.0-SNAPSHOT
 group=com.adevinta.spark
 
 org.gradle.caching=true


### PR DESCRIPTION

## 📋 Changes description
This reverts commit 1d1bb899

<!--- Describe your changes in detail -->

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
I've done goofed on the release 0.4.0 by setting the release version to `0.5.0-SNAPSHOT` instead of `0.4.0`
