### PR TITLE
feat: Update front layer content surface color

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -82,6 +82,8 @@ import com.adevinta.spark.catalog.themes.UserMode
 import com.adevinta.spark.catalog.themes.themeprovider.ThemeProvider
 import com.adevinta.spark.catalog.themes.themeprovider.adevinta.AdevintaTheme
 import com.adevinta.spark.catalog.themes.themeprovider.leboncoin.LeboncoinTheme
+import com.adevinta.spark.components.surface.Surface
+import com.adevinta.spark.tokens.dim5
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.google.accompanist.testharness.TestHarness
 import kotlinx.coroutines.launch
@@ -181,24 +183,28 @@ internal fun CatalogApp(
                             state = pagerState,
                             flingBehavior = PagerDefaults.flingBehavior(state = pagerState),
                         ) {
-                            when (homeScreenValues[it]) {
-                                CatalogHomeScreen.Examples -> ComponentsScreen(
-                                    components = components,
-                                    contentPadding = innerPadding,
-                                )
-
-                                CatalogHomeScreen.Showkase -> {
-                                    BodyContent(
+                            Surface(
+                                color = SparkTheme.colors.onSurface.dim5,
+                            ) {
+                                when (homeScreenValues[it]) {
+                                    CatalogHomeScreen.Examples -> ComponentsScreen(
+                                        components = components,
                                         contentPadding = innerPadding,
-                                        groupedComponentMap = groupedComponentMap,
-                                        showkaseBrowserScreenMetadata = showkaseBrowserScreenMetadata,
+                                    )
+
+                                    CatalogHomeScreen.Showkase -> {
+                                        BodyContent(
+                                            contentPadding = innerPadding,
+                                            groupedComponentMap = groupedComponentMap,
+                                            showkaseBrowserScreenMetadata = showkaseBrowserScreenMetadata,
+                                        )
+                                    }
+
+                                    CatalogHomeScreen.Configurator -> ConfiguratorComponentsScreen(
+                                        components = components,
+                                        contentPadding = innerPadding,
                                     )
                                 }
-
-                                CatalogHomeScreen.Configurator -> ConfiguratorComponentsScreen(
-                                    components = components,
-                                    contentPadding = innerPadding,
-                                )
                             }
                         }
                     },

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/HomeScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/HomeScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
@@ -48,7 +49,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
-import com.adevinta.spark.components.card.OutlinedCard
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.tokens.Layout
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
@@ -158,12 +158,14 @@ private fun HomeScreen(
             showkaseBrowserScreenMetadata.value.isSearchActive -> {
                 showkaseBrowserScreenMetadata.clearActiveSearch()
             }
+
             navController.currentDestination?.id == navController.graph.startDestinationId -> {
                 activity.finish()
             }
         }
     }
 }
+
 internal fun getNumOfUIElements(list: List<*>): Int {
     val isComponentList = list.filterIsInstance<ShowkaseBrowserComponent>()
     return when {
@@ -171,6 +173,7 @@ internal fun getNumOfUIElements(list: List<*>): Int {
         else -> list.size
     }
 }
+
 internal fun <T> getFilteredSearchList(
     map: Map<String, List<T>>,
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
@@ -185,6 +188,7 @@ internal fun <T> getFilteredSearchList(
                 )
             }
         }
+
         else -> map
     }
 
@@ -192,6 +196,7 @@ internal fun matchSearchQuery(
     searchQuery: String,
     vararg properties: String,
 ) = properties.any { it.contains(searchQuery, ignoreCase = true) }
+
 private tailrec fun Context.findActivity(): Activity =
     when (this) {
         is Activity -> this


### PR DESCRIPTION

## 📋 Changes description
- Use onSurface.dim5 as a content colors for front layer
- update card used for Showkase part

## 🤔 Context
Before Surface color was used as a front layer content color, however such components as ButtonContrast cannot be properly seen as they also use Surface as the background color.


## 📸 Screenshots
Before: 
<img src="https://github.com/adevinta/spark-android/assets/36896406/040e611e-e9a3-45c4-9e75-a9d465d30b4a" width="250"/> <img src="https://github.com/adevinta/spark-android/assets/36896406/7e53853a-15aa-42d5-8ace-0ceaded3c467" width="250"/>

After:
<img src="https://github.com/adevinta/spark-android/assets/36896406/b930f719-9f9f-4b78-b1c0-ee00856ed892" width="250"/> <img src="https://github.com/adevinta/spark-android/assets/36896406/4e3dd17a-4979-47d1-a2c3-82b6ab39d2ab" width="250"/> <img src="https://github.com/adevinta/spark-android/assets/36896406/8ad27ac9-a12b-4f2e-9a4c-bd09c3551f74" width="250"/>

<img src="https://github.com/adevinta/spark-android/assets/36896406/077893ed-fac7-49f9-b651-7a448d1cf236" width="250"/> <img src="https://github.com/adevinta/spark-android/assets/36896406/700bc834-7094-4886-9076-83c0f6688449" width="250"/>
<img src="" width="250"/>
<img src="" width="250"/>
<img src="" width="250"/>

