### PR TITLE
feat: Add Icons demo to CatalogApp

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -67,6 +67,7 @@ import com.adevinta.spark.catalog.backdrop.BackdropValue
 import com.adevinta.spark.catalog.backdrop.rememberBackdropScaffoldState
 import com.adevinta.spark.catalog.configurator.ConfiguratorComponentsScreen
 import com.adevinta.spark.catalog.examples.ComponentsScreen
+import com.adevinta.spark.catalog.icons.IconDemoScreen
 import com.adevinta.spark.catalog.model.Component
 import com.adevinta.spark.catalog.showkase.ShowkaseBrowserScreenMetadata
 import com.adevinta.spark.catalog.showkase.navGraph
@@ -199,6 +200,10 @@ internal fun CatalogApp(
                                     components = components,
                                     contentPadding = innerPadding,
                                 )
+
+                                CatalogHomeScreen.Icons -> IconDemoScreen(
+                                    contentPadding = innerPadding,
+                                )
                             }
                         }
                     },
@@ -281,5 +286,5 @@ private val SheetScrimColor = Color.Black.copy(alpha = 0.4f)
 internal const val HomeRoute = "home"
 
 public enum class CatalogHomeScreen {
-    Examples, Showkase, Configurator
+    Examples, Showkase, Configurator, Icons
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
@@ -57,12 +57,9 @@ public fun IconDemoScreen(
                 ),
             ) { navBackStackEntry ->
                 val arguments = requireNotNull(navBackStackEntry.arguments) { "No arguments" }
-                val iconId = arguments.getInt(IconIdArgName)
-                val icon = SparkIcon.DrawableRes(iconId)
-                val name = requireNotNull(arguments.getString(IconNameArgName)) { "No name provided for the Icon" }
                 IconExampleScreen(
-                    icon = icon,
-                    name = name,
+                    icon = SparkIcon.DrawableRes(arguments.getInt(IconIdArgName)),
+                    name = requireNotNull(arguments.getString(IconNameArgName)) { "No name provided for the Icon" },
                 )
             }
         },

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.catalog.icons
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.adevinta.spark.icons.SparkIcon
+
+@Composable
+public fun IconDemoScreen(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues,
+) {
+    val navController = rememberNavController()
+
+    NavHost(
+        modifier = modifier,
+        navController = navController,
+        startDestination = IconsList,
+        builder = {
+            composable(route = IconsList) {
+                IconsScreen(
+                    navController = navController,
+                    contentPadding = contentPadding,
+                )
+            }
+            composable(
+                route = "$IconDemoRoute/" +
+                        "{$IconIdArgName}/{$IconNameArgName}",
+                arguments = listOf(
+                    navArgument(IconIdArgName) { type = NavType.IntType },
+                    navArgument(IconNameArgName) { type = NavType.StringType },
+                ),
+            ) { navBackStackEntry ->
+                val arguments = requireNotNull(navBackStackEntry.arguments) { "No arguments" }
+                val iconId = arguments.getInt(IconIdArgName)
+                val icon = SparkIcon.DrawableRes(iconId)
+                val name = requireNotNull(arguments.getString(IconNameArgName)) { "No name provided for the Icon" }
+                IconExampleScreen(
+                    icon = icon,
+                    name = name,
+                )
+            }
+        },
+    )
+}
+
+internal const val IconsList = "icons"
+internal const val IconDemoRoute = "iconDemo"
+internal const val IconIdArgName = "iconId"
+internal const val IconNameArgName = "iconName"

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.adevinta.spark.catalog.icons
 
 import androidx.compose.foundation.layout.PaddingValues
@@ -52,7 +51,7 @@ public fun IconDemoScreen(
             }
             composable(
                 route = "$IconDemoRoute/" +
-                        "{$IconIdArgName}/{$IconNameArgName}",
+                    "{$IconIdArgName}/{$IconNameArgName}",
                 arguments = listOf(
                     navArgument(IconIdArgName) { type = NavType.IntType },
                     navArgument(IconNameArgName) { type = NavType.StringType },

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
@@ -50,8 +50,7 @@ public fun IconDemoScreen(
                 )
             }
             composable(
-                route = "$IconDemoRoute/" +
-                    "{$IconIdArgName}/{$IconNameArgName}",
+                route = "$IconDemoRoute/{$IconIdArgName}/{$IconNameArgName}",
                 arguments = listOf(
                     navArgument(IconIdArgName) { type = NavType.IntType },
                     navArgument(IconNameArgName) { type = NavType.StringType },

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconExampleScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconExampleScreen.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.catalog.icons
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.components.buttons.ButtonFilled
+import com.adevinta.spark.components.chips.ChipFilled
+import com.adevinta.spark.components.iconbuttons.IconButtonFilled
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.tab.Tab
+import com.adevinta.spark.components.tab.TabGroup
+import com.adevinta.spark.components.tags.TagFilled
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.toggles.SwitchIcons
+import com.adevinta.spark.components.toggles.SwitchLabelled
+import com.adevinta.spark.icons.Close
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.icons.SparkIcons
+
+@Composable
+internal fun IconExampleScreen(icon: SparkIcon, name: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically),
+    ) {
+        IconButtonFilled(icon = icon, contentDescription = name, onClick = {})
+        ButtonFilled(onClick = {}, text = name, icon = icon)
+        TagFilled(text = name, leadingIcon = icon)
+        ChipFilled {
+            Text(text = name)
+            Icon(sparkIcon = icon, contentDescription = name)
+        }
+        var checked by remember {
+            mutableStateOf(true)
+        }
+        SwitchLabelled(
+            checked = checked,
+            onCheckedChange = { checked = it },
+            icons = SwitchIcons(checked = icon, unchecked = SparkIcons.Close),
+        ) {
+            Text(text = name)
+        }
+
+        val tabs = mutableListOf(
+            Pair("Home", null),
+            Pair(name, icon),
+        )
+        var selectedIndex by remember { mutableStateOf(1) }
+        TabGroup(
+            selectedTabIndex = selectedIndex,
+        ) {
+            tabs.forEachIndexed { index, pair ->
+                Tab(
+                    selected = selectedIndex == index,
+                    onClick = { selectedIndex = index },
+                    icon = pair.second,
+                    text = pair.first,
+                )
+            }
+        }
+    }
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconExampleScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconExampleScreen.kt
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.adevinta.spark.catalog.icons
 
 import androidx.compose.foundation.layout.Arrangement

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.catalog.icons
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.R
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.icons.IconSize
+import com.adevinta.spark.components.spacer.VerticalSpacer
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.TextField
+import com.adevinta.spark.icons.DeleteFill
+import com.adevinta.spark.icons.Search
+import com.adevinta.spark.icons.SparkIcon
+import com.adevinta.spark.icons.SparkIcons
+import java.util.Locale
+import com.adevinta.spark.icons.R as IconR
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
+@Composable
+public fun IconsScreen(
+    contentPadding: PaddingValues,
+    modifier: Modifier = Modifier,
+    navController: NavController,
+) {
+    val context = LocalContext.current
+    val focusManager = LocalFocusManager.current
+    val icons by remember {
+        mutableStateOf(getAllIconsRes(context))
+    }
+    var query: String by rememberSaveable { mutableStateOf("") }
+    val filteredIcons by remember {
+        derivedStateOf {
+            if (query.isEmpty()) icons else icons.filter { it.second.contains(query, ignoreCase = true) }
+        }
+    }
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        TextField(
+            value = query,
+            onValueChange = { query = it },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = stringResource(id = R.string.icons_screen_seraah_helper),
+            leadingContent = {
+                Icon(sparkIcon = SparkIcons.Search, contentDescription = null)
+            },
+            trailingContent = {
+                Icon(
+                    modifier = Modifier.clickable { query = "" },
+                    sparkIcon = SparkIcons.DeleteFill,
+                    contentDescription = "Clear",
+                )
+            },
+        )
+        VerticalSpacer(space = 16.dp)
+        LazyVerticalGrid(
+            modifier = modifier
+                .consumeWindowInsets(contentPadding)
+                .fillMaxSize()
+                .clickable(
+                    // no ripple effect is needed as this onClick is just to clear the focus of the search field
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ) {
+                    focusManager.clearFocus()
+                },
+
+            contentPadding = contentPadding,
+            columns = GridCells.Adaptive(minSize = 60.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            items(filteredIcons.size) { index ->
+                val iconWithNamePair = filteredIcons[index]
+                Column(
+                    modifier = Modifier
+                        .clip(SparkTheme.shapes.small)
+                        .combinedClickable(
+                            onLongClick = { copyToClipboard(context, iconWithNamePair.second) },
+                            onClick = {
+                                val route = "$IconDemoRoute/${iconWithNamePair.first}/${iconWithNamePair.second}"
+                                navController.navigate(
+                                    route = route,
+                                )
+                            },
+                        )
+                        .padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Icon(
+                        sparkIcon = SparkIcon.DrawableRes(iconWithNamePair.first),
+                        contentDescription = null,
+                        size = IconSize.Large,
+                    )
+                    Text(
+                        text = iconWithNamePair.second,
+                        style = SparkTheme.typography.caption,
+                    )
+                }
+            }
+        }
+    }
+}
+
+
+/**
+ * @return a [List] of [Pair]s of drawable res Int and String, representing formatted name of the resource
+ */
+private fun getAllIconsRes(context: Context) = IconR.drawable::class.java.declaredFields.map {
+    val icon = it.getInt(null)
+    icon to context.resources.getResourceEntryName(icon).removePrefix("spark_icons_").toPascalCase()
+}
+
+private fun String.toPascalCase(): String = split("_").joinToString(separator = "") { str ->
+    str.replaceFirstChar {
+        if (it.isLowerCase()) it.titlecase(
+            Locale.ROOT,
+        ) else it.toString()
+    }
+}
+
+private fun copyToClipboard(context: Context, text: String) {
+    val clipboardManager =
+        context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText("password", text)
+    clipboardManager.setPrimaryClip(clip)
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -167,9 +167,7 @@ private fun getAllIconsRes(context: Context) = IconR.drawable::class.java.declar
 private fun String.toPascalCase(): String = split("_").joinToString(separator = "") { str ->
     str.replaceFirstChar {
         if (it.isLowerCase()) {
-            it.titlecase(
-                Locale.ROOT,
-            )
+            it.titlecase(Locale.ROOT)
         } else {
             it.toString()
         }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.adevinta.spark.catalog.icons
 
 import android.content.ClipData
@@ -158,7 +157,6 @@ public fun IconsScreen(
     }
 }
 
-
 /**
  * @return a [List] of [Pair]s of drawable res Int and String, representing formatted name of the resource
  */
@@ -169,9 +167,13 @@ private fun getAllIconsRes(context: Context) = IconR.drawable::class.java.declar
 
 private fun String.toPascalCase(): String = split("_").joinToString(separator = "") { str ->
     str.replaceFirstChar {
-        if (it.isLowerCase()) it.titlecase(
-            Locale.ROOT,
-        ) else it.toString()
+        if (it.isLowerCase()) {
+            it.titlecase(
+                Locale.ROOT,
+            )
+        } else {
+            it.toString()
+        }
     }
 }
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -94,7 +94,7 @@ public fun IconsScreen(
             value = query,
             onValueChange = { query = it },
             modifier = Modifier.fillMaxWidth(),
-            placeholder = stringResource(id = R.string.icons_screen_seraah_helper),
+            placeholder = stringResource(id = R.string.icons_screen_search_helper),
             leadingContent = {
                 Icon(sparkIcon = SparkIcons.Search, contentDescription = null)
             },

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -167,11 +167,11 @@ private fun getAllIconsRes(context: Context) = IconR.drawable::class.java.declar
     val prefix = "spark_icons_"
     val icon = field.getInt(null)
     val name = context.resources.getResourceEntryName(icon)
-    if (name.contains(prefix)) {
-        NamedIcon(drawableRes = icon, name = name.removePrefix(prefix).toPascalCase())
-    } else {
-        null
-    }
+    if (!name.startsWith(prefix)) return@mapNotNull null
+    NamedIcon(
+        drawableRes = icon,
+        name = name.removePrefix(prefix).toPascalCase(),
+    )
 }
 
 private fun String.toPascalCase(): String = split("_").joinToString(separator = "") { str ->

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -132,9 +132,8 @@ public fun IconsScreen(
                         .combinedClickable(
                             onLongClick = { copyToClipboard(context, iconWithNamePair.second) },
                             onClick = {
-                                val route = "$IconDemoRoute/${iconWithNamePair.first}/${iconWithNamePair.second}"
                                 navController.navigate(
-                                    route = route,
+                                    route = "$IconDemoRoute/${iconWithNamePair.first}/${iconWithNamePair.second}",
                                 )
                             },
                         )

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -76,5 +76,5 @@
     <string name="component_menu_source">View source code</string>
     <string name="component_menu_issue">Report an issue</string>
 
-    <string name="icons_screen_seraah_helper">"Search Spark Icon"</string>
+    <string name="icons_screen_search_helper">"Search Spark Icon"</string>
     </resources>

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -76,5 +76,5 @@
     <string name="component_menu_source">View source code</string>
     <string name="component_menu_issue">Report an issue</string>
 
-    <string name="icons_screen_search_helper">"Search Spark Icon"</string>
+    <string name="icons_screen_search_helper">Search Spark Icon</string>
     </resources>

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -75,4 +75,6 @@
     <string name="component_menu_dev_docs">View developer docs</string>
     <string name="component_menu_source">View source code</string>
     <string name="component_menu_issue">Report an issue</string>
+
+    <string name="icons_screen_seraah_helper">"Search Spark Icon"</string>
     </resources>


### PR DESCRIPTION
## 📋 Changes description

Add new tab to CatalogApp to display all available `SparkIcons`. It also includes examples of usages of selected icon inside :  
- Button
- Icon Button
- Tag
- Chip
- Switch
- Tab

Long click on an icon copy its name to the clipboard.

## 📸 Screenshots

<img src= "https://github.com/adevinta/spark-android/assets/36896406/d01dca0f-3212-4a72-b260-c6501ad273de" width="300" />
<img src= "https://github.com/adevinta/spark-android/assets/36896406/d52a1bd8-3a3f-4e16-b707-f3feb0f3467b" width="300" />
<img src= "https://github.com/adevinta/spark-android/assets/36896406/56b6f18c-3387-4a5c-ad56-adb73f5695c9" width="300" />
<img src= "https://github.com/adevinta/spark-android/assets/36896406/3d17ea07-1af6-4cd9-bba0-afc234e9920d" width="300" />

[Icons Demo.webm](https://github.com/adevinta/spark-android/assets/36896406/37e57b35-5f5b-48d5-8fe2-ecc81d582a49)

## 🗒️ Other info

close #635 
