### PR TITLE
fix(catalog): add proguard rules to keep the names of spark icons resources

### DIFF
--- a/catalog/proguard-rules.pro
+++ b/catalog/proguard-rules.pro
@@ -14,3 +14,8 @@
 -verbose
 
 -keep class com.adevinta.spark.tools.preview.UserProProvider { *; }
+
+# Keep all spark-icons resources explicitly in the catalog app
+-keep class com.adevinta.spark.icons.R$drawable {
+    public static <fields>;
+}


### PR DESCRIPTION
## 🤔 Context

Proguard will rename resources and remove unused (explicit) resources.
This lead to an empty page of icons in the catalog app.  