### PR TITLE
fix(picker): Modify Segmented color to be more visible and make switch take full width

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/SegmentedButton.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/SegmentedButton.kt
@@ -66,7 +66,7 @@ internal fun SegmentedButton(
     selectedOption: String,
     onOptionSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
-    selectedColor: Color = SparkTheme.colors.onSupportContainer,
+    selectedColor: Color = SparkTheme.colors.onAccentContainer,
     unSelectedColor: Color = LocalContentColor.current,
 ) {
     require(options.size >= 2) { "This composable requires at least 2 options" }
@@ -135,7 +135,7 @@ internal fun SegmentedButton(
                             bottomEndPercent = endCornerShape,
                         ),
                     )
-                    .background(SparkTheme.colors.supportContainer),
+                    .background(SparkTheme.colors.accentContainer),
             )
         },
     ) { measurables, constraints ->

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
@@ -115,7 +115,10 @@ public fun ThemePicker(
                         .fillMaxWidth()
                         .height(48.dp),
                 )
-                AnimatedVisibility(visible = theme.colorMode == ColorMode.Brand) {
+                AnimatedVisibility(
+                    visible = theme.colorMode == ColorMode.Brand,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
                     var expanded by remember { mutableStateOf(false) }
                     val selectedIcon = @Composable { Icon(SparkIcons.Check, contentDescription = null) }
                     SelectTextField(
@@ -150,15 +153,16 @@ public fun ThemePicker(
                 }
                 AnimatedVisibility(visible = theme.colorMode == ColorMode.Brand) {
                     SwitchLabelled(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(ThemePickerPadding),
+                        modifier = Modifier.padding(ThemePickerPadding),
                         checked = theme.userMode == UserMode.Pro,
                         onCheckedChange = { checked ->
                             onThemeChange(theme.copy(userMode = if (checked) UserMode.Pro else UserMode.Part))
                         },
                     ) {
-                        Text(text = stringResource(id = R.string.pro))
+                        Text(
+                            text = stringResource(id = R.string.pro),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Changed color of segmented control from support to accent and made the switch text full width instead of the SwitchLabelled

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
Since the color token change the segmented button was no longer distinguishable from the main color.

## 📸 Screenshots

<!--- Put your screenshots here -->
![image](https://github.com/adevinta/spark-android/assets/11772084/448f0685-6540-4583-a452-db1f1f4f129f)

