### PR TITLE
fix: update catalog app to show `ExtraLarge` icons

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -152,7 +152,7 @@ public fun IconsScreen(
                     Icon(
                         sparkIcon = SparkIcon.DrawableRes(drawableRes),
                         contentDescription = null,
-                        size = IconSize.Large,
+                        size = IconSize.ExtraLarge,
                     )
                     Text(
                         text = iconName,


### PR DESCRIPTION
| Before | After |
|---|---|
| ![2023-08-24-13 41 10](https://github.com/adevinta/spark-android/assets/1921278/8e8714ee-a1e3-42e4-b253-b31edb5c4803) | ![2023-08-24-13 42 22](https://github.com/adevinta/spark-android/assets/1921278/f64793c6-9269-4c25-814c-e50469876c0b) |
