### PR TITLE
fix(colors): some colors were not updated on theme change

### DIFF
--- a/spark-screenshot-testing/build.gradle.kts
+++ b/spark-screenshot-testing/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.material3)
 
     implementation(libs.airbnb.showkase)
     ksp(libs.airbnb.showkase.processor)

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tokens/ColorsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tokens/ColorsScreenshot.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.tokens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.surface.Surface
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.sparkSnapshot
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.ThemeVariant.Light
+import com.android.ide.common.rendering.api.SessionParams
+import org.junit.Rule
+import org.junit.Test
+
+internal class ColorsScreenshot {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        maxPercentDifference = .01, // We can have in some cases 2/3 pixels being different for no apparent reasons :(
+        theme = "android:Theme.MaterialComponent.Light.NoActionBar",
+        renderingMode = SessionParams.RenderingMode.SHRINK,
+        deviceConfig = DeviceConfig.PIXEL_C.copy(
+            softButtons = false,
+            locale = "fr-rFR",
+        ),
+        showSystemUi = true,
+    )
+
+    @Test
+    fun adevintaColors() {
+        ThemeVariant.values().forEach {
+            paparazzi.sparkSnapshot(name = it.name) {
+                SparkTheme(
+                    colors = if (it == Light) lightSparkColors() else darkSparkColors(),
+                ) {
+                    Surface {
+                        Colors()
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun verifyColorsDoChangeOnThemeChange() {
+        ThemeVariant.values().forEach {
+            paparazzi.snapshot(name = it.name) {
+                var debugColors by remember {
+                    mutableStateOf(if (it == Light) lightSparkColors() else darkSparkColors())
+                }
+                SparkTheme(
+                    colors = debugColors,
+                ) {
+                    Surface {
+                        Colors()
+                        LaunchedEffect(key1 = Unit) {
+                            debugColors = debugColors()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun Colors() {
+        Row {
+            Column {
+                Row {
+                    ColorItem(SparkTheme.colors.main, "main")
+                    ColorItem(SparkTheme.colors.mainContainer, "main Container")
+                    ColorItem(SparkTheme.colors.mainVariant, "main Variant")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.support, "support")
+                    ColorItem(SparkTheme.colors.supportContainer, "support Container")
+                    ColorItem(SparkTheme.colors.supportVariant, "support Variant")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.accent, "accent")
+                    ColorItem(SparkTheme.colors.accentContainer, "accent Container")
+                    ColorItem(SparkTheme.colors.accentVariant, "accent Variant")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.basic, "basic")
+                    ColorItem(SparkTheme.colors.basicContainer, "basic Container")
+                }
+            }
+            Column {
+                Row {
+                    ColorItem(SparkTheme.colors.success, "success")
+                    ColorItem(SparkTheme.colors.successContainer, "success Container")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.alert, "alert")
+                    ColorItem(SparkTheme.colors.alertContainer, "alert Container")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.error, "error")
+                    ColorItem(SparkTheme.colors.errorContainer, "error Container")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.info, "info")
+                    ColorItem(SparkTheme.colors.infoContainer, "info Container")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.neutral, "neutral")
+                    ColorItem(SparkTheme.colors.neutralContainer, "neutral Container")
+                }
+            }
+            Column {
+                Row {
+                    ColorItem(SparkTheme.colors.background, "background")
+                    ColorItem(SparkTheme.colors.backgroundVariant, "backgroundVariant")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.surface, "surface")
+                    ColorItem(SparkTheme.colors.surfaceInverse, "surface inverse")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.outline, "outline")
+                    ColorItem(SparkTheme.colors.outlineHigh, "outline High")
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ColorItem(color: Color, colorName: String) {
+        CompositionLocalProvider(
+            LocalContentColor provides contentColorFor(backgroundColor = color),
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .size(104.dp)
+                    .clip(SparkTheme.shapes.extraLarge)
+                    .border(BorderStroke(2.dp, SparkTheme.colors.onBackground), SparkTheme.shapes.extraLarge)
+                    .background(color),
+                propagateMinConstraints = true,
+            ) {
+                Box(
+                    modifier = Modifier.padding(8.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = colorName,
+                        style = SparkTheme.typography.body2,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_adevintaColors_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_adevintaColors_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:960be5bfc171c463b42a34f98be2dc9ef0f853a9219080710247eacff5b4c901
+size 118989

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_adevintaColors_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_adevintaColors_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e54d265fb20792d2a0d2132c65babe861e94f396099eb50a6af1674c8dcd3a2d
+size 120574

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46d5724feec91a8c6be70cf05da4a199ccbf19c565bc275b3329611dbbb9f93
+size 111557

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46d5724feec91a8c6be70cf05da4a199ccbf19c565bc275b3329611dbbb9f93
+size 111557

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -45,7 +45,6 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.takeOrElse
@@ -56,6 +55,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.tokens.PaletteTokens.Apple100
 import com.adevinta.spark.tokens.PaletteTokens.Apple400
 import com.adevinta.spark.tokens.PaletteTokens.Apple500
@@ -1164,8 +1164,8 @@ public fun SparkColors.contentColorFor(backgroundColor: Color): Color = when (ba
     surfaceVariant -> onSurfaceVariant
     surfaceInverse -> onSurfaceInverse
     inverseSurface -> inverseOnSurface
-    valid -> onValid
-    validContainer -> onValidContainer
+    success -> onSuccess
+    successContainer -> onSuccessContainer
     alert -> onAlert
     alertContainer -> onAlertContainer
     error -> onError
@@ -1267,10 +1267,14 @@ internal fun SparkColors.updateColorsFrom(other: SparkColors) {
     onMain = other.onMain
     mainContainer = other.mainContainer
     onMainContainer = other.onMainContainer
+    mainVariant = other.mainVariant
+    onMainVariant = other.onMainVariant
     support = other.support
     onSupport = other.onSupport
     supportContainer = other.supportContainer
     onSupportContainer = other.onSupportContainer
+    supportVariant = other.supportVariant
+    onSupportVariant = other.onSupportVariant
     tertiary = other.tertiary
     onTertiary = other.onTertiary
     tertiaryContainer = other.tertiaryContainer
@@ -1290,10 +1294,10 @@ internal fun SparkColors.updateColorsFrom(other: SparkColors) {
     outlineHigh = other.outlineHigh
     outlineVariant = other.outlineVariant
     scrim = other.scrim
-    valid = other.valid
-    onValid = other.onValid
-    validContainer = other.validContainer
-    onValidContainer = other.onValidContainer
+    success = other.success
+    onSuccess = other.onSuccess
+    successContainer = other.successContainer
+    onSuccessContainer = other.onSuccessContainer
     alert = other.alert
     onAlert = other.onAlert
     alertContainer = other.alertContainer
@@ -1438,16 +1442,13 @@ private fun ColorPreview(
                     ColorItem(SparkTheme.colors.supportVariant, "support Variant")
                 }
                 Row {
-                    ColorItem(SparkTheme.colors.background, "background")
-                    ColorItem(SparkTheme.colors.backgroundVariant, "backgroundVariant")
+                    ColorItem(SparkTheme.colors.accent, "accent")
+                    ColorItem(SparkTheme.colors.accentContainer, "accent Container")
+                    ColorItem(SparkTheme.colors.accentVariant, "accent Variant")
                 }
                 Row {
-                    ColorItem(SparkTheme.colors.surface, "surface")
-                    ColorItem(SparkTheme.colors.surfaceInverse, "surface inverse")
-                }
-                Row {
-                    ColorItem(SparkTheme.colors.outline, "outline")
-                    ColorItem(SparkTheme.colors.outlineHigh, "outline High")
+                    ColorItem(SparkTheme.colors.basic, "basic")
+                    ColorItem(SparkTheme.colors.basicContainer, "basic Container")
                 }
             }
             Column {
@@ -1472,6 +1473,20 @@ private fun ColorPreview(
                     ColorItem(SparkTheme.colors.neutralContainer, "neutral Container")
                 }
             }
+            Column {
+                Row {
+                    ColorItem(SparkTheme.colors.background, "background")
+                    ColorItem(SparkTheme.colors.backgroundVariant, "backgroundVariant")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.surface, "surface")
+                    ColorItem(SparkTheme.colors.surfaceInverse, "surface inverse")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.outline, "outline")
+                    ColorItem(SparkTheme.colors.outlineHigh, "outline High")
+                }
+            }
         }
     }
 }
@@ -1481,14 +1496,13 @@ private fun ColorItem(color: Color, colorName: String) {
     CompositionLocalProvider(
         LocalContentColor provides contentColorFor(backgroundColor = color),
     ) {
-        Box(
+        Surface(
             modifier = Modifier
                 .padding(8.dp)
-                .size(104.dp)
-                .clip(SparkTheme.shapes.extraLarge)
-                .border(BorderStroke(2.dp, SparkTheme.colors.onBackground), SparkTheme.shapes.extraLarge)
-                .background(color),
-            propagateMinConstraints = true,
+                .size(104.dp),
+            shape = SparkTheme.shapes.extraLarge,
+            border = BorderStroke(2.dp, SparkTheme.colors.onBackground),
+            color = color,
         ) {
             Box(
                 modifier = Modifier.padding(8.dp),


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Add the missing tokens in `updateColorFrom` and use `success` instead of `valid`.
Add a screenshot test to avoid future regressions

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
When updating the colors for LBC and KA I noticed in the catalog app that some colors were not updated and this was caused by forgotten tokens in the function that allow us to modify colors.

## 📸 Screenshots

<!--- Put your screenshots here -->

<table>
<tr>
 <td>
 <td>Before
 <td>After
<tr>
 <td>Base
 <td><img src="https://user-images.githubusercontent.com/11772084/262957039-aa767262-2fc3-4c9a-8de9-72b0856d622e.png"/>
 <td><img src="https://github.com/adevinta/spark-android/assets/11772084/58021e96-17fa-40d3-b035-72490dd499fa"/>
<tr>
 <td>Modified
 <td><img src="https://user-images.githubusercontent.com/11772084/262957180-eb65a15f-302c-4ac5-82b5-66cb7ab68b34.png"/>
 <td><img src="https://github.com/adevinta/spark-android/assets/11772084/a4cabe73-66f9-449a-9555-725e643615a2"/>
</table>



## 🗒️ Other info
Close #665 