### PR TITLE
chore: merge hotfix 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ## [Unreleased]
 
+
+## [0.4.2]
+
+_2023-08-24_
+
+* 🐛 Some color tokens were not updated on theme change
+
 ## [0.4.1]
+
 _2023-08-17_
 
 ### Spark
@@ -97,7 +105,9 @@ _2023-03-29_
 
 <!-- Links -->
 
-[Unreleased]: https://github.com/adevinta/spark-android/compare/0.4.1...HEAD
+[Unreleased]: https://github.com/adevinta/spark-android/compare/0.4.2...HEAD
+
+[0.4.2]: https://github.com/adevinta/spark-android/releases/tag/0.4.2
 
 [0.4.1]: https://github.com/adevinta/spark-android/releases/tag/0.4.1
 

--- a/spark-screenshot-testing/build.gradle.kts
+++ b/spark-screenshot-testing/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.material3)
 
     implementation(libs.airbnb.showkase)
     ksp(libs.airbnb.showkase.processor)

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
@@ -66,3 +66,6 @@ internal fun Paparazzi.sparkSnapshot(
 internal fun patchedEnvironment() = with(detectEnvironment()) {
     copy(compileSdkVersion = 33, platformDir = platformDir.replace("34", "33"))
 }
+
+internal const val MaxPercentDifference: Double = 0.01
+internal const val PaparazziTheme: String = "android:Theme.MaterialComponent.Light.NoActionBar"

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PreviewScreenshotTests.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PreviewScreenshotTests.kt
@@ -44,8 +44,8 @@ internal class PreviewScreenshotTests {
 
     @get:Rule
     val paparazzi = Paparazzi(
-        maxPercentDifference = .01, // We can have in some cases 2/3 pixels being different for no apparent reasons :(
-        theme = "android:Theme.MaterialComponent.Light.NoActionBar",
+        maxPercentDifference = MaxPercentDifference,
+        theme = PaparazziTheme,
         renderingMode = SessionParams.RenderingMode.SHRINK,
         showSystemUi = false,
         environment = patchedEnvironment(),

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldScreenshot.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.Paparazzi
+import com.adevinta.spark.MaxPercentDifference
+import com.adevinta.spark.PaparazziTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.textfields.TextFieldState
@@ -55,8 +57,8 @@ internal class TextFieldScreenshot {
 
     @get:Rule
     val paparazzi = Paparazzi(
-        maxPercentDifference = .01, // We can have in some cases 2/3 pixels being different for no apparent reasons :(
-        theme = "android:Theme.MaterialComponent.Light.NoActionBar",
+        maxPercentDifference = MaxPercentDifference,
+        theme = PaparazziTheme,
         renderingMode = SessionParams.RenderingMode.SHRINK,
         showSystemUi = false,
         environment = patchedEnvironment(),

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tokens/ColorsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tokens/ColorsScreenshot.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.tokens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.adevinta.spark.MaxPercentDifference
+import com.adevinta.spark.PaparazziTheme
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.surface.Surface
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.sparkSnapshot
+import com.adevinta.spark.tools.preview.ThemeVariant
+import com.adevinta.spark.tools.preview.ThemeVariant.Light
+import com.android.ide.common.rendering.api.SessionParams
+import org.junit.Rule
+import org.junit.Test
+import kotlin.reflect.KProperty0
+
+internal class ColorsScreenshot {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        maxPercentDifference = MaxPercentDifference,
+        theme = PaparazziTheme,
+        renderingMode = SessionParams.RenderingMode.SHRINK,
+        deviceConfig = DeviceConfig.PIXEL_C.copy(
+            softButtons = false,
+            locale = "fr-rFR",
+        ),
+        showSystemUi = true,
+    )
+
+    private val colors
+        @Composable
+        get() = with(SparkTheme.colors) {
+            listOf(
+                listOf(
+                    listOf(::main, ::mainContainer, ::mainVariant),
+                    listOf(::support, ::supportContainer, ::supportVariant),
+                    listOf(::accent, ::accentContainer, ::accentVariant),
+                    listOf(::basic, ::basicContainer),
+                ),
+                listOf(
+                    listOf(::success, ::successContainer),
+                    listOf(::alert, ::alertContainer),
+                    listOf(::error, ::errorContainer),
+                    listOf(::info, ::infoContainer),
+                    listOf(::neutral, ::neutralContainer),
+                ),
+                listOf(
+                    listOf(::background, ::backgroundVariant),
+                    listOf(::surface, ::surfaceInverse),
+                    listOf(::outline, ::outlineHigh),
+                ),
+            )
+        }
+
+    @Test
+    fun themesColors() {
+        ThemeVariant.values().forEach {
+            paparazzi.sparkSnapshot(name = it.name) {
+                SparkTheme(
+                    colors = if (it == Light) lightSparkColors() else darkSparkColors(),
+                ) {
+                    Surface {
+                        Colors()
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun verifyColorsDoChangeOnThemeChange() {
+        ThemeVariant.values().forEach {
+            paparazzi.snapshot(name = it.name) {
+                var debugColors by remember {
+                    mutableStateOf(if (it == Light) lightSparkColors() else darkSparkColors())
+                }
+                SparkTheme(
+                    colors = debugColors,
+                ) {
+                    Surface {
+                        Colors()
+                        LaunchedEffect(key1 = Unit) {
+                            debugColors = debugColors()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun Colors() {
+        Row {
+            colors.forEach { column ->
+                Column {
+                    column.forEach { row ->
+                        Row {
+                            row.forEach { color ->
+                                ColorItem(color)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ColorItem(color: KProperty0<Color>) {
+        Surface(
+            modifier = Modifier
+                .padding(8.dp)
+                .size(104.dp),
+            color = color.get(),
+            shape = SparkTheme.shapes.extraLarge,
+            border = BorderStroke(2.dp, SparkTheme.colors.onBackground),
+        ) {
+            Box(
+                modifier = Modifier.padding(8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = color.name,
+                    style = SparkTheme.typography.body2,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_themesColors_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_themesColors_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1d7dcd35ad7b1974784bbd384704c625f2d84419951ba88d626e5001a8d6278
+size 118596

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_themesColors_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_themesColors_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db2b043942d636475a0cd69df0991555e761d2d60a36d9c2a89275f48bf62203
+size 120169

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43c6ef93ef6310c2f046adb7edb31427259a22bf8626b3fd8cb7f644a92f0ebe
+size 111504

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.tokens_ColorsScreenshot_verifyColorsDoChangeOnThemeChange_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43c6ef93ef6310c2f046adb7edb31427259a22bf8626b3fd8cb7f644a92f0ebe
+size 111504

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -45,7 +45,6 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.takeOrElse
@@ -56,6 +55,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.components.surface.Surface
 import com.adevinta.spark.tokens.PaletteTokens.Apple100
 import com.adevinta.spark.tokens.PaletteTokens.Apple400
 import com.adevinta.spark.tokens.PaletteTokens.Apple500
@@ -1164,8 +1164,8 @@ public fun SparkColors.contentColorFor(backgroundColor: Color): Color = when (ba
     surfaceVariant -> onSurfaceVariant
     surfaceInverse -> onSurfaceInverse
     inverseSurface -> inverseOnSurface
-    valid -> onValid
-    validContainer -> onValidContainer
+    success -> onSuccess
+    successContainer -> onSuccessContainer
     alert -> onAlert
     alertContainer -> onAlertContainer
     error -> onError
@@ -1267,10 +1267,14 @@ internal fun SparkColors.updateColorsFrom(other: SparkColors) {
     onMain = other.onMain
     mainContainer = other.mainContainer
     onMainContainer = other.onMainContainer
+    mainVariant = other.mainVariant
+    onMainVariant = other.onMainVariant
     support = other.support
     onSupport = other.onSupport
     supportContainer = other.supportContainer
     onSupportContainer = other.onSupportContainer
+    supportVariant = other.supportVariant
+    onSupportVariant = other.onSupportVariant
     tertiary = other.tertiary
     onTertiary = other.onTertiary
     tertiaryContainer = other.tertiaryContainer
@@ -1290,10 +1294,10 @@ internal fun SparkColors.updateColorsFrom(other: SparkColors) {
     outlineHigh = other.outlineHigh
     outlineVariant = other.outlineVariant
     scrim = other.scrim
-    valid = other.valid
-    onValid = other.onValid
-    validContainer = other.validContainer
-    onValidContainer = other.onValidContainer
+    success = other.success
+    onSuccess = other.onSuccess
+    successContainer = other.successContainer
+    onSuccessContainer = other.onSuccessContainer
     alert = other.alert
     onAlert = other.onAlert
     alertContainer = other.alertContainer
@@ -1438,16 +1442,13 @@ private fun ColorPreview(
                     ColorItem(SparkTheme.colors.supportVariant, "support Variant")
                 }
                 Row {
-                    ColorItem(SparkTheme.colors.background, "background")
-                    ColorItem(SparkTheme.colors.backgroundVariant, "backgroundVariant")
+                    ColorItem(SparkTheme.colors.accent, "accent")
+                    ColorItem(SparkTheme.colors.accentContainer, "accent Container")
+                    ColorItem(SparkTheme.colors.accentVariant, "accent Variant")
                 }
                 Row {
-                    ColorItem(SparkTheme.colors.surface, "surface")
-                    ColorItem(SparkTheme.colors.surfaceInverse, "surface inverse")
-                }
-                Row {
-                    ColorItem(SparkTheme.colors.outline, "outline")
-                    ColorItem(SparkTheme.colors.outlineHigh, "outline High")
+                    ColorItem(SparkTheme.colors.basic, "basic")
+                    ColorItem(SparkTheme.colors.basicContainer, "basic Container")
                 }
             }
             Column {
@@ -1472,6 +1473,20 @@ private fun ColorPreview(
                     ColorItem(SparkTheme.colors.neutralContainer, "neutral Container")
                 }
             }
+            Column {
+                Row {
+                    ColorItem(SparkTheme.colors.background, "background")
+                    ColorItem(SparkTheme.colors.backgroundVariant, "backgroundVariant")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.surface, "surface")
+                    ColorItem(SparkTheme.colors.surfaceInverse, "surface inverse")
+                }
+                Row {
+                    ColorItem(SparkTheme.colors.outline, "outline")
+                    ColorItem(SparkTheme.colors.outlineHigh, "outline High")
+                }
+            }
         }
     }
 }
@@ -1481,14 +1496,13 @@ private fun ColorItem(color: Color, colorName: String) {
     CompositionLocalProvider(
         LocalContentColor provides contentColorFor(backgroundColor = color),
     ) {
-        Box(
+        Surface(
             modifier = Modifier
                 .padding(8.dp)
-                .size(104.dp)
-                .clip(SparkTheme.shapes.extraLarge)
-                .border(BorderStroke(2.dp, SparkTheme.colors.onBackground), SparkTheme.shapes.extraLarge)
-                .background(color),
-            propagateMinConstraints = true,
+                .size(104.dp),
+            shape = SparkTheme.shapes.extraLarge,
+            border = BorderStroke(2.dp, SparkTheme.colors.onBackground),
+            color = color,
         ) {
             Box(
                 modifier = Modifier.padding(8.dp),


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Add the missing tokens in `updateColorFrom` and use `success` instead of `valid`.
Add a screenshot test to avoid future regressions

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
When updating the colors for LBC and KA I noticed in the catalog app that some colors were not updated and this was caused by forgotten tokens in the function that allow us to modify colors.
