### PR TITLE
chore: Increase the default number of max open PRs for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,6 +18,7 @@ updates:
           - "org.jetbrains.kotlin.jvm"
           - "com.google.devtools.ksp"
           - "androidx.compose.compiler:compiler"
+    open-pull-requests-limit: 20
 registries:
   maven-google:
     type: "maven-repository"


### PR DESCRIPTION
Since we have enabled grouped updates, it's now easier to reach the default threshold of 5 open PRs for dependabot.
And at the moment, dependabot has reached this limit and won't open any more PRs: https://github.com/adevinta/spark-android/network/updates/716645372