### PR TITLE
chore: Remove Marina as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @soulcramer @MarinaRomanova @SimonMarquis @kazaky @adevinta/spark-contributors-android
-/.github/ @soulcramer @MarinaRomanova @SimonMarquis @kazaky
-/gradle/ @soulcramer @MarinaRomanova @SimonMarquis @kazaky
-/build-logic/ @soulcramer @MarinaRomanova @SimonMarquis @kazaky
+* @soulcramer @SimonMarquis @kazaky @adevinta/spark-contributors-android
+/.github/ @soulcramer @SimonMarquis @kazaky
+/gradle/ @soulcramer @SimonMarquis @kazaky
+/build-logic/ @soulcramer @SimonMarquis @kazaky


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Remove marina from the code owner file to avoid sending a ping on every PR

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
Since Marina is no longer a member of the org she shouldn't be considered a code owner anymore

