### PR TITLE
fix: ModalFullScreenScaffold top padding issue when no illustration

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -276,7 +276,7 @@ private fun PhonePortraitModalScaffold(
                 PaddingValues(
                     start = innerPadding.calculateLeftPadding(LocalLayoutDirection.current),
                     end = innerPadding.calculateRightPadding(LocalLayoutDirection.current),
-                    top =  if (illustration == null) innerPadding.calculateTopPadding() else 24.dp,
+                    top = if (illustration == null) innerPadding.calculateTopPadding() else 24.dp,
                     bottom = innerPadding.calculateBottomPadding(),
                 ),
             )

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalFullScreenScaffold.kt
@@ -276,7 +276,7 @@ private fun PhonePortraitModalScaffold(
                 PaddingValues(
                     start = innerPadding.calculateLeftPadding(LocalLayoutDirection.current),
                     end = innerPadding.calculateRightPadding(LocalLayoutDirection.current),
-                    top = 24.dp,
+                    top =  if (illustration == null) innerPadding.calculateTopPadding() else 24.dp,
                     bottom = innerPadding.calculateBottomPadding(),
                 ),
             )


### PR DESCRIPTION
## 📋 Changes description

Content gets overlapped by TopAppBar in ModalFullScreenScaffold component when we set the illustration to null.

## 🤔 Context

This fix is required whenever we're using ModalFullScreenScaffold component with no illustration in order to have a proper top padding between the TopAppBar and the content. This fix handles "PhonePortrait" form factor only.

We can easily reproduce the issue using ModalFullScreenScaffold component preview itself. If we set the illustration to "null", the Text content is overlapped by the TopAppBar.

## ✅ Checklist

<!--- Feel free to add other steps if needed -->
- [x] Link to GitHub issues it solves:  closes #713
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!--- Put your screenshots here -->

## 🗒️ Other info

<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->

[Contributing](https://github.com/adevinta/spark-android/blob/main/docs/contributing.md) has more information and tips for a great pull request.
