### PR TITLE
fix: Fix outline & ghost style icon button bug

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
@@ -46,7 +46,7 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.progress.Spinner
 import com.adevinta.spark.components.progress.SpinnerSize
-import com.adevinta.spark.components.surface.Surface
+import androidx.compose.material3.Surface
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.tools.modifiers.ifTrue

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.PlainTooltipBox
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -46,7 +47,6 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.progress.Spinner
 import com.adevinta.spark.components.progress.SpinnerSize
-import androidx.compose.material3.Surface
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.tools.modifiers.ifTrue


### PR DESCRIPTION
## 📋 Changes description

In catalog app, for ghost and outlined styles there's a white background behind the iconButton (for all intents, and loading & not loading)

## 🤔 Context
This PR solves this issue

## ✅ Checklist

- [x] Link to GitHub issues it solves. closes #726 
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots
<img width="308" alt="Screenshot 2023-09-25 at 4 06 30 AM" src="https://github.com/adevinta/spark-android/assets/4202132/76104a8f-305d-4b16-8526-3156b10e2de4">


## 🗒️ Other info

Early there was a PR https://github.com/adevinta/spark-android/pull/702
to introduce material 2 elevation instead of material 3 elevation

Using M2 Surface caused this bug as the surface is being drawn even if container color from color intent is transparent color,
**expected behavior:**
Background Surface should not be drawn if container color is transparent

[Contributing](https://github.com/adevinta/spark-android/blob/main/docs/contributing.md) has more information and tips for a great pull request.
