### PR TITLE
fix(gradle): Migrate to configuration avoidance APIs

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -30,7 +30,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
     compilerOptions.allWarningsAsErrors.set(true)
     kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 }

--- a/build-logic/src/main/kotlin/com/adevinta/spark/ProjectExtensions.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/ProjectExtensions.kt
@@ -94,7 +94,7 @@ internal inline fun <reified T : KotlinTopLevelExtension> Project.configureKotli
         explicitApi()
         configure()
     }
-    tasks.withType<KotlinCompile> {
+    tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
             // kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkDokkaPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkDokkaPlugin.kt
@@ -46,7 +46,7 @@ internal class SparkDokkaPlugin : Plugin<Project> {
                 else -> configureSubProject()
             }
 
-            tasks.withType<DokkaTask> {
+            tasks.withType<DokkaTask>().configureEach {
                 notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
             }
 
@@ -71,7 +71,7 @@ internal class SparkDokkaPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.configureSubProject() = tasks.withType<DokkaTaskPartial> {
+    private fun Project.configureSubProject() = tasks.withType<DokkaTaskPartial>().configureEach {
         dokkaSourceSets.configureEach {
             // Parse Module and Package docs
             // https://kotlinlang.org/docs/dokka-module-and-package-docs.html

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkUnitTests.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkUnitTests.kt
@@ -96,7 +96,7 @@ internal object SparkUnitTests {
     }
 
     private fun configureTestTasks(project: Project) {
-        project.tasks.withType<Test> {
+        project.tasks.withType<Test>().configureEach {
             testLogging {
                 showStandardStreams = true
                 showStackTraces = true


### PR DESCRIPTION
- With eager APIs: https://scans.gradle.com/s/2e4hhzdjjpida/performance/configuration#summary-tasks-created-during-configuration
  Created during configuration: 82
- With configuration avoidance APIs: https://scans.gradle.com/s/diht3rnwwokbk/performance/configuration#summary-tasks-created-during-configuration
  Created during configuration: 18
