### PR TITLE
fix: Other APi of surface where using the wrong elevation

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/surface/Surface.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/surface/Surface.kt
@@ -231,7 +231,7 @@ public fun Surface(
                         absoluteElevation = absoluteElevation,
                     ),
                     border = border,
-                    elevation = absoluteElevation,
+                    elevation = elevation,
                 )
                 .clickable(
                     interactionSource = interactionSource,
@@ -338,7 +338,7 @@ public fun Surface(
                         absoluteElevation = absoluteElevation,
                     ),
                     border = border,
-                    elevation = absoluteElevation,
+                    elevation = elevation,
                 )
                 .selectable(
                     selected = selected,
@@ -446,7 +446,7 @@ public fun Surface(
                         absoluteElevation = absoluteElevation,
                     ),
                     border = border,
-                    elevation = absoluteElevation,
+                    elevation = elevation,
                 )
                 .toggleable(
                     value = checked,


### PR DESCRIPTION
## 📋 Changes description

<!--- Describe your changes in detail -->
Use elevation instead of absolute elevation as shadow elevation in `Surface`.

## 🤔 Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue… How can it be reproduced in order to compare between both behaviors? -->
This changed was inspired from #740 
In #702 we updated the `Surface` to use the M2 elevation system instead of the tinted one from M3. During the dev I made the mistake of using the absolute elevation as shadow elevation.

This was fixed but I found out it was only in one of the 4-5 different api for `Surface`. As we use these api for icon buttons every buttons where using the absolute elevation and was more visible on buttons with no background like `GhostButton`

close #726

## ✅ Checklist

<!--- Feel free to add other steps if needed -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!--- Put your screenshots here -->
<img width="353" alt="image" src="https://github.com/adevinta/spark-android/assets/11772084/21c52508-2444-4025-982e-3384ec274652">

