### PR TITLE
feat: improve `pr-icon-updates` workflow

### DIFF
--- a/.github/workflows/pr-icon-updates.yml
+++ b/.github/workflows/pr-icon-updates.yml
@@ -9,17 +9,20 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GH_TOKEN: ${{ github.token }}
   FILE: 'spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcons.kt'
+  COMMIT_MSG: '🎨 Update `SparkIcons.kt`'
 
 jobs:
   pr-icon-updates:
+    # Detect recursive calls based on last commit message
+    if: ${{ github.event.head_commit.message != env.COMMIT_MSG }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           ref: chore-updated-icons
           fetch-depth: 0
+          token: ${{ secrets.PAT_SPARK || secrets.GITHUB_TOKEN }}
       - run: gh pr create --fill
         continue-on-error: true
       - run: |
@@ -28,7 +31,7 @@ jobs:
           then
             git config user.name 'spark-ui-bot'
             git config user.email 'spark-ui-bot@users.noreply.github.com'
-            git commit "$FILE" -m "🎨 Update `SparkIcons.kt`"
+            git commit "$FILE" -m "$COMMIT_MSG"
             git show
             git push
             echo "::notice::UPDATED"


### PR DESCRIPTION
## 📋 Changes

- Checkout repository with appropriate token to trigger the CI if updates are committed
- Detect recursive calls based on last commit message
- Fix commit message with properly escaped backticks