### PR TITLE
fix: restore GitHub token for CLI command in `pr-icon-updates.yml`

### DIFF
--- a/.github/workflows/pr-icon-updates.yml
+++ b/.github/workflows/pr-icon-updates.yml
@@ -24,6 +24,8 @@ jobs:
           token: ${{ secrets.PAT_SPARK || secrets.GITHUB_TOKEN }}
       - run: gh pr create --fill
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: |
           ./scripts/spark-icons-kt/spark-icons-kt.main.kts --input=spark-icons/src/main/res/drawable --output="$FILE" --copyright=scripts/spark-icons-kt/COPYRIGHT.kt
           if ! git diff --quiet --exit-code -- "$FILE" ;


### PR DESCRIPTION
https://github.com/adevinta/spark-android/actions/runs/6473222749/job/17575468633#step:3:7

```
Run gh pr create --fill
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
Error: Process completed with exit code 4.
```