### PR TITLE
chore: fix typos in `TabsExamples` and replace one icon to fit the style

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tabs/TabsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tabs/TabsExamples.kt
@@ -31,8 +31,8 @@ import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.badge.Badge
 import com.adevinta.spark.components.tab.Tab
 import com.adevinta.spark.components.tab.TabGroup
-import com.adevinta.spark.icons.AlarmOnFill
 import com.adevinta.spark.icons.AccountFill
+import com.adevinta.spark.icons.AlarmOnFill
 import com.adevinta.spark.icons.MessageOutline
 import com.adevinta.spark.icons.SparkIcons
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tabs/TabsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tabs/TabsExamples.kt
@@ -32,7 +32,7 @@ import com.adevinta.spark.components.badge.Badge
 import com.adevinta.spark.components.tab.Tab
 import com.adevinta.spark.components.tab.TabGroup
 import com.adevinta.spark.icons.AlarmOnFill
-import com.adevinta.spark.icons.Garage
+import com.adevinta.spark.icons.AccountFill
 import com.adevinta.spark.icons.MessageOutline
 import com.adevinta.spark.icons.SparkIcons
 
@@ -48,21 +48,21 @@ public val TabsExamples: List<Example> = listOf(
     },
     Example(
         name = "Tabs with badge",
-        description = "3 tabs and the middle one contain a badge",
+        description = "3 tabs and the middle one contains a badge",
         sourceUrl = TabsExampleSourceUrl,
     ) {
         TabWithBadgeSample()
     },
     Example(
         name = "Scrollable tabs",
-        description = "Display 3 tabs with a long one that overflow to showcase the",
+        description = "Display 3 tabs with a long one that overflows to showcase the scrolling",
         sourceUrl = TabsExampleSourceUrl,
     ) {
         ScrollableTabsSample()
     },
     Example(
         name = "Icons tabs",
-        description = "tabs with no label, only icons",
+        description = "Tabs with no label, only icons",
         sourceUrl = TabsExampleSourceUrl,
     ) {
         IconsTabsSample()
@@ -160,7 +160,7 @@ private fun IconsTabsSample() {
     val tabs = mutableListOf(
         SparkIcons.AlarmOnFill to 0,
         SparkIcons.MessageOutline to 1,
-        SparkIcons.Garage to 0,
+        SparkIcons.AccountFill to 0,
     )
     var selectedIndex by remember { mutableIntStateOf(0) }
     TabGroup(


### PR DESCRIPTION
| Before | After |
|---|---|
| ![2023-11-07-12 58 32](https://github.com/adevinta/spark-android/assets/1921278/e9732bad-264c-4fed-b507-0dc3060e44d3) | ![2023-11-07-12 59 13](https://github.com/adevinta/spark-android/assets/1921278/15ce87ba-ada5-4eeb-9f52-11fa18fe001d) |
| ![2023-11-07-12 53 03](https://github.com/adevinta/spark-android/assets/1921278/3477796b-7283-4b46-868d-bb5e8972c935) | ![2023-11-07-12 53 06](https://github.com/adevinta/spark-android/assets/1921278/74dd1417-3303-4d64-920e-530a2d2a1a2d) |