### PR TITLE
feat(maven): add repository for pre-release artifacts of compose-compiler

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,15 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+
+        // Pre-release artifacts of compose-compiler
+        // https://androidx.dev/storage/compose-compiler/repository
+        maven("https://androidx.dev/storage/compose-compiler/repository/") {
+            name = "compose-compiler-dev"
+            content {
+                includeGroup("androidx.compose.compiler")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 🤔 Context

Finding where/what to add when testing new compose versions is a pain in the a**, adding this repository once for all would streamline future updates.