### PR TITLE
fix: Replace zeroheight links with spark.adevinta.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and designers.
 But these native components and tokens are overridden to respect Spark's Visual Identity. You'll
 find
 the design specifications and technical information for supported platforms by Adevinta on
-[zeroheight](https://zeroheight.com/1186e1705/p/25ae4e-spark).
+[spark.adevinta.com](https://spark.adevinta.com).
 
 The demo app is not currently available, but we plan to publish it in the near future.
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextFields.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextFields.md
@@ -1,6 +1,6 @@
 # Package com.adevinta.spark.components.textfields
 
-[SelectTextFields](https://zeroheight.com/25c15666f/p/29d201-textfield-) allow users to select an
+[SelectTextFields](https://spark.adevinta.com/1186e1705/p/773c60-input--text-field/b/0658e2) allow users to select an
 option from a dropdown and optionally enter text to filter the options available in the dropdown.
 
 They typically appear in forms and dialogs.

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -392,7 +392,7 @@ public fun darkSparkColors(
  * [lightSparkColors] and a [darkSparkColors], that can be used as-is or customized.
  *
  * To learn more about colors, see [Material Design colors](https://m3.material.io/styles/color/overview) and
- * [Spark colors](https://zeroheight.com/25c15666f/p/40105d-colors/b/77b3e7).
+ * [Spark colors](https://spark.adevinta.com/1186e1705/p/0879a9-colors/b/27d7a3).
  *
  * @property accent
  * @property onAccent


### PR DESCRIPTION
## 🤔 Context

Now that we have a proper domain name, we should use it 🤓