### PR TITLE
feat(spotless): enable `ktlint_function_naming_ignore_when_annotated_with=Composable`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,9 +9,9 @@ max_line_length=120
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 ktlint_code_style = intellij_idea
+ktlint_function_naming_ignore_when_annotated_with=Composable
 ktlint_standard_comment-wrapping = disabled # A block comment may not be followed by any other element on that same line
 ktlint_standard_discouraged-comment-location = disabled # Trailing comments (A comment in a 'value_argument_list' is only allowed when placed on a separate line)
-ktlint_standard_function-naming = disabled # Because of Compose rules
 ktlint_standard_function-signature = disabled # Seems to incorrectly reformat parameter lists in function signatures
 ktlint_standard_property-naming = disabled # Multiple top-level const vals (and Companion vals) are using PascalCase
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/backdrop/Backdrop.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/backdrop/Backdrop.kt
@@ -153,6 +153,7 @@ public class BackdropScaffoldState(
         /**
          * The default [Saver] implementation for [BackdropScaffoldState].
          */
+        @Suppress("ktlint:standard:function-naming")
         public fun Saver(
             animationSpec: AnimationSpec<Float>,
             confirmStateChange: (BackdropValue) -> Boolean,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/ModalBottomSheetLayout.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/ModalBottomSheetLayout.kt
@@ -196,6 +196,7 @@ public class ModalBottomSheetState(
         /**
          * The default [Saver] implementation for [ModalBottomSheetState].
          */
+        @Suppress("ktlint:standard:function-naming")
         public fun Saver(
             animationSpec: AnimationSpec<Float>,
             skipHalfExpanded: Boolean,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SheetDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SheetDefaults.kt
@@ -234,6 +234,7 @@ public class SheetState(
         /**
          * The default [Saver] implementation for [SheetState].
          */
+        @Suppress("ktlint:standard:function-naming")
         public fun Saver(
             skipPartiallyExpanded: Boolean,
             confirmValueChange: (SheetValue) -> Boolean,
@@ -310,6 +311,7 @@ public object BottomSheetDefaults {
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
+@Suppress("ktlint:standard:function-naming")
 internal fun ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
     sheetState: SheetState,
     orientation: Orientation,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/Swipeable.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/Swipeable.kt
@@ -435,6 +435,7 @@ public open class SwipeableState<T>(
         /**
          * The default [Saver] implementation for [SwipeableState].
          */
+        @Suppress("ktlint:standard:function-naming")
         public fun <T : Any> Saver(
             animationSpec: AnimationSpec<Float>,
             confirmStateChange: (T) -> Boolean,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SwipeableV2.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SwipeableV2.kt
@@ -499,6 +499,7 @@ internal class SwipeableV2State<T>(
          * The default [Saver] implementation for [SwipeableV2State].
          */
         @ExperimentalMaterial3Api
+        @Suppress("ktlint:standard:function-naming")
         fun <T : Any> Saver(
             animationSpec: AnimationSpec<Float>,
             confirmValueChange: (T) -> Boolean,
@@ -617,6 +618,7 @@ internal object SwipeableV2Defaults {
      * @param snap A lambda that gets invoked to snap to a new target
      */
     @ExperimentalMaterial3Api
+    @Suppress("ktlint:standard:function-naming")
     internal fun <T> ReconcileAnimationOnAnchorChangeHandler(
         state: SwipeableV2State<T>,
         animate: (target: T, velocity: Float) -> Unit,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/modal/ModalBottomSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/modal/ModalBottomSheet.kt
@@ -352,6 +352,7 @@ private fun Modifier.modalBottomSheetSwipeable(
     }
 
 @ExperimentalMaterial3Api
+@Suppress("ktlint:standard:function-naming")
 private fun ModalBottomSheetAnchorChangeHandler(
     state: SheetState,
     animateTo: (target: SheetValue, velocity: Float) -> Unit,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
@@ -403,6 +403,7 @@ private fun BottomSheetScaffoldLayout(
 }
 
 @ExperimentalMaterial3Api
+@Suppress("ktlint:standard:function-naming")
 private fun BottomSheetScaffoldAnchorChangeHandler(
     state: SheetState,
     animateTo: (target: SheetValue, velocity: Float) -> Unit,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
@@ -155,6 +155,7 @@ internal enum class RatingStarState {
  *
  * @param value whether the ToggleableState is on or off
  */
+@Suppress("ktlint:standard:function-naming")
 internal fun RatingStarState(value: Boolean) = if (value) Full else Empty
 
 /**


### PR DESCRIPTION
And re-enable `ktlint_standard_function-naming`