### PR TITLE
fix: Add Info as Icon buttons intent color

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconButtonScreenshot_test_large.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconButtonScreenshot_test_large.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8505b11337c3c785a2815b9a83452d44079262e75e22d9f067b400d81dece17f
-size 177685
+oid sha256:76c1c0d1deddcde10ca5b7dbb20464312f85a0c95e22fa48a596f3d0a84efbd2
+size 162543

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconButtonScreenshot_test_medium.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconButtonScreenshot_test_medium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ad811cd5eed8128dfb6d79a71e16b8a069624d446e48670a8556247a8dd6889
-size 90571
+oid sha256:76f5256108bcbc659c67cdfa94bfb44c8e0f9f85107540754f2daa92930278b2
+size 175479

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconButtonScreenshot_test_small.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconButtonScreenshot_test_small.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:716c8d5e32e9b708b3d334233ed9e39fc2cc01946b4d917257cf6e783c712d2b
-size 84950
+oid sha256:c2da0f6ad553df18034ee3bb9fdd82930aed94497c38962adae98452dba1fdc5
+size 168226

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_pill_large.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_pill_large.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f263f9be222cc4c8631d77abb75447edf256d8de912202fe1274f176608cbb9
-size 102351
+oid sha256:55ac8c6d21d5903aefc15f5a0d95de790eb887e93aeb1858be093e0b0bf1f92d
+size 113019

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_pill_medium.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_pill_medium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9820b0dcf2d17ed36ddbbcfead732dcaa3d23d63636bec7489b24d4397c092ff
-size 92481
+oid sha256:964943e6849d8846080470df697b83fce922656a78f91bcfd1cf045f28aa736b
+size 102152

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_pill_small.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_pill_small.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b041e2b612d4e0abc65ab2cb83689206f64f90c6dcf3ff0df009d0a06d36aa22
-size 80501
+oid sha256:e9ac37f91ec6579828546474193bb9f87f7b0ef013a731e44db639091572592a
+size 88611

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_rounded_large.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_rounded_large.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17870e752b8d3db265c2dedde280f2bfff03b0af7f47922745a394ce06560461
-size 89784
+oid sha256:f2d86e8849882f690f4b62bc727e1813a4751c713cbc42579d1b2a9ab52140e5
+size 99122

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_rounded_medium.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_rounded_medium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e95a533b606af94f07ae6c538164940e494200ed16a7d76de62abb556c908c6
-size 85243
+oid sha256:657ca8052b41e2cebb80a37f1c46bb49ff7a47d0932cba6dd36465e446804910
+size 94083

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_rounded_small.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_rounded_small.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b041e2b612d4e0abc65ab2cb83689206f64f90c6dcf3ff0df009d0a06d36aa22
-size 80501
+oid sha256:e9ac37f91ec6579828546474193bb9f87f7b0ef013a731e44db639091572592a
+size 88611

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_square_large.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_square_large.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4db35258d4ec7509f7c9be03d195a6a3c7881932a4e24c128a477d7897658e24
-size 67673
+oid sha256:0e92400abe1e5770dd114a92355b03c71bf9b2437cae332b4ee3f1d092e4d578
+size 74581

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_square_medium.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_square_medium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:256acb6c62cc9b8f29c5c0706933d4c00f919885f0bdfa26675b38baaaa5396c
-size 62887
+oid sha256:cf1a1139100c11f96c61a5d0264f64fdb6eec2f9d5149c3d4b524fa66213f73f
+size 69265

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_square_small.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.iconbutton_IconToggleButtonScreenshot_test_square_small.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b4a9233ecd8be80d31559d5132f5f4fb5b2e158380d56dd5dfacfe7fb8be91b
-size 63856
+oid sha256:6eaaa35f37f20687443e566267448e7c42599427651512cb5e7146c821e6d14d
+size 70285

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonIntent.kt
@@ -94,6 +94,14 @@ public enum class IconButtonIntent {
     },
 
     /**
+     * Used informational valuable actions.
+     */
+    Info {
+        @Composable
+        override fun colors(): IntentColor = IntentColors.Info.colors()
+    },
+
+    /**
      * Used for low or irrelevant actions.
      */
     Neutral {


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

IconButton and IconToggleButton were missing the info intent color

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
I think this was because this intent was added later to the button intents

Close #706 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

![image](https://github.com/adevinta/spark-android/assets/11772084/5387457e-fe6c-445e-8f05-38d6c3887ab1)

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
