### PR TITLE
fix: Fix ConstraintLayout Constraint not being applied to IconButtons  & IconToggleButton

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
@@ -97,39 +97,41 @@ internal fun SparkIconButton(
             size = size.iconSize,
         )
     }
-    PlainTooltipBox(
-        tooltip = { Text(contentDescription.orEmpty()) },
-        shape = IconButtonDefaults.TooltipContainerShape,
-        containerColor = IconButtonDefaults.TooltipContainerColor,
-        contentColor = IconButtonDefaults.TooltipContentColor,
-    ) {
-        Surface(
-            onClick = onClick,
-            modifier = modifier
-                .minimumTouchTargetSize()
-                .tooltipAnchor()
-                .sparkUsageOverlay(),
-            enabled = enabled,
-            shape = shape.shape,
-            color = colors.containerColor(enabled = enabled).value,
-            contentColor = colors.contentColor(enabled).value,
-            border = border,
-            interactionSource = interactionSource,
+    Box(modifier = modifier) {
+        PlainTooltipBox(
+            tooltip = { Text(contentDescription.orEmpty()) },
+            shape = IconButtonDefaults.TooltipContainerShape,
+            containerColor = IconButtonDefaults.TooltipContainerColor,
+            contentColor = IconButtonDefaults.TooltipContentColor,
         ) {
-            Box(
-                modifier = Modifier.size(size.height),
-                contentAlignment = Alignment.Center,
+            Surface(
+                onClick = onClick,
+                modifier = Modifier
+                    .minimumTouchTargetSize()
+                    .tooltipAnchor()
+                    .sparkUsageOverlay(),
+                enabled = enabled,
+                shape = shape.shape,
+                color = colors.containerColor(enabled = enabled).value,
+                contentColor = colors.contentColor(enabled).value,
+                border = border,
+                interactionSource = interactionSource,
             ) {
-                AnimatedContent(targetState = isLoading, label = "loadingAnimation") { isLoading ->
-                    if (isLoading) {
-                        Spinner(
-                            size = when (size) {
-                                IconButtonSize.Small, IconButtonSize.Medium -> SpinnerSize.Small
-                                IconButtonSize.Large -> SpinnerSize.Medium
-                            },
-                        )
-                    } else {
-                        content()
+                Box(
+                    modifier = Modifier.size(size.height),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    AnimatedContent(targetState = isLoading, label = "loadingAnimation") { isLoading ->
+                        if (isLoading) {
+                            Spinner(
+                                size = when (size) {
+                                    IconButtonSize.Small, IconButtonSize.Medium -> SpinnerSize.Small
+                                    IconButtonSize.Large -> SpinnerSize.Medium
+                                },
+                            )
+                        } else {
+                            content()
+                        }
                     }
                 }
             }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButton.kt
@@ -108,32 +108,34 @@ internal fun SparkIconToggleButton(
         )
     }
 
-    PlainTooltipBox(
-        tooltip = { Text(contentDescription.orEmpty()) },
-        shape = IconButtonDefaults.TooltipContainerShape,
-        containerColor = IconButtonDefaults.TooltipContainerColor,
-        contentColor = IconButtonDefaults.TooltipContentColor,
-    ) {
-        Surface(
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-            modifier = modifier
-                .minimumTouchTargetSize()
-                .tooltipAnchor()
-                .sparkUsageOverlay()
-                .semantics { role = Role.Checkbox },
-            enabled = enabled,
-            shape = shape.shape,
-            border = border,
-            color = colors.containerColor(enabled).value,
-            contentColor = colors.contentColor(enabled).value,
-            interactionSource = interactionSource,
+    Box(modifier = modifier) {
+        PlainTooltipBox(
+            tooltip = { Text(contentDescription.orEmpty()) },
+            shape = IconButtonDefaults.TooltipContainerShape,
+            containerColor = IconButtonDefaults.TooltipContainerColor,
+            contentColor = IconButtonDefaults.TooltipContentColor,
         ) {
-            Box(
-                modifier = Modifier.size(size.height),
-                contentAlignment = Alignment.Center,
+            Surface(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                modifier = Modifier
+                    .minimumTouchTargetSize()
+                    .tooltipAnchor()
+                    .sparkUsageOverlay()
+                    .semantics { role = Role.Checkbox },
+                enabled = enabled,
+                shape = shape.shape,
+                border = border,
+                color = colors.containerColor(enabled).value,
+                contentColor = colors.contentColor(enabled).value,
+                interactionSource = interactionSource,
             ) {
-                content()
+                Box(
+                    modifier = Modifier.size(size.height),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    content()
+                }
             }
         }
     }


### PR DESCRIPTION
## 📋 Changes

<!-- Describe your changes in details -->
The Tooltip Box seems to not apply the constraint so I had to wrap all of it inside a Box.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Close #773 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots
It now behaves like a Material `IconButton`
![image](https://github.com/adevinta/spark-android/assets/11772084/0cb0f8e6-abca-4842-bff7-6e49339765eb)
