### PR TITLE
feat(dependabot): add DependencyGuard baseline on PRs

### DIFF
--- a/.github/workflows/dependabot-dependency-guard.yml
+++ b/.github/workflows/dependabot-dependency-guard.yml
@@ -1,0 +1,36 @@
+name: 🤖 Dependabot Dependency Guard baseline
+on:
+  pull_request:
+    paths:
+      - '**.gradle.kts'
+      - 'gradle/libs.versions.toml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/gradle/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PAT_SPARK }}
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
+      - uses: ./.github/actions/setup-gradle-properties
+      - run: ./gradlew dependencyGuardBaseline
+      - run: |
+          if ! git diff --quiet --exit-code -- ':(glob)**/dependencies/*.txt';
+          then
+            git config --global user.name "dependabot[bot]"
+            git config --global user.email "49699333+dependabot[bot]@users.noreply.github.com"
+            git commit -m "🤖 Update dependencies baseline" -m "[dependabot skip]" -- ':(glob)**/dependencies/*.txt'
+            git show
+            git push
+            echo "::notice::UPDATED"
+          else
+            echo "::notice::UP-TO-DATE"
+          fi


### PR DESCRIPTION
## 📋 Changes

Adds a new automated workflow to run `dependencyGuardBaseline` Gradle task whenever a new PR updates a Gradle dependency.

This _should_ automatically makes PRs merge-able without needing to manually update the dependencies files.

<img width="410" alt="image" src="https://github.com/adevinta/spark-android/assets/1921278/aafb514f-1a59-4534-b163-373f7aa099d8">