### PR TITLE
fix: Fix for TextLink QA Comments

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
@@ -78,7 +78,7 @@ private fun TextLinkSample() {
     var iconSide by remember { mutableStateOf(IconSide.START) }
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
-    var intent by remember { mutableStateOf(ButtonIntent.Main) }
+    var intent by remember { mutableStateOf(ButtonIntent.Basic) }
     val intents = ButtonIntent.entries
     var expanded by remember { mutableStateOf(false) }
 

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -91,7 +91,7 @@
 
     <string name="icons_screen_search_helper">Search Spark Icon</string>
 
-    <string name="spark_text_link_paragraph_example_"><annotation typography="body1" color="neutral">This is Adevinta </annotation><annotation typography="body1" color="main"><u><b>Privacy &amp; Policy</b></u></annotation><annotation typography="body1" color="neutral">also lots of extra information you maybe interested in or should I inform you about that extra information. you might be not knowing it</annotation></string>
+    <string name="spark_text_link_paragraph_example_"><annotation typography="body1" color="neutral">This is Adevinta </annotation><annotation typography="body1" color="main"><u><b>Privacy &amp; Policy</b></u></annotation><annotation typography="body1" color="neutral"> also lots of extra information you maybe interested in or should I inform you about that extra information. you might be not knowing it</annotation></string>
 
     <string name="spark_text_link_short_example_"><annotation typography="display2" color="neutral">Learn Kotlin Programming </annotation><annotation typography="display3" color="success"><u><b>https://kotlinlang.org</b></u></annotation></string>
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/text/TextLink.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/text/TextLink.kt
@@ -162,7 +162,7 @@ public fun TextLinkButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     size: ButtonSize = ButtonSize.Medium,
-    intent: ButtonIntent = ButtonIntent.Danger,
+    intent: ButtonIntent = ButtonIntent.Basic,
     enabled: Boolean = true,
     icon: SparkIcon? = null,
     iconSide: IconSide = IconSide.START,


### PR DESCRIPTION


## 📋 Changes

Fixes QA comments by @elisa-hery 
https://github.com/adevinta/spark-android/issues/775#issuecomment-1916567106

- according to the specs, default color is basic. I think it should be default color on catalog app as well, for consistancy (at the moment it's main).

## 🤔 Context


## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots


## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
