### PR TITLE
chore(catalog): remove non-clickable icon on example Cards

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/example/ExampleItem.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/example/ExampleItem.kt
@@ -22,19 +22,13 @@
 package com.adevinta.spark.catalog.examples.example
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
@@ -55,27 +49,16 @@ public fun ExampleItem(
             containerColor = SparkTheme.colors.surface,
         ),
     ) {
-        Row(modifier = Modifier.padding(ExampleItemPadding)) {
-            Column(modifier = Modifier.weight(1f, fill = true)) {
-                Text(
-                    text = example.name,
-                    style = SparkTheme.typography.display3,
-                )
-                Spacer(modifier = Modifier.height(ExampleItemTextPadding))
-                Text(
-                    text = example.description,
-                    style = SparkTheme.typography.body2,
-                )
-            }
-            Spacer(modifier = Modifier.width(ExampleItemPadding))
-            Icon(
-                imageVector = Icons.Default.Share,
-                contentDescription = null,
-                modifier = Modifier.align(Alignment.CenterVertically),
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = example.name,
+                style = SparkTheme.typography.display3,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = example.description,
+                style = SparkTheme.typography.body2,
             )
         }
     }
 }
-
-private val ExampleItemPadding = 16.dp
-private val ExampleItemTextPadding = 8.dp


### PR DESCRIPTION
| Before | After |
|---|---|
| ![2024-02-14-15 32 39](https://github.com/adevinta/spark-android/assets/1921278/4b658857-9e37-4918-923e-e59d0dd913f1) | ![2024-02-14-15 34 29](https://github.com/adevinta/spark-android/assets/1921278/788aaff7-d78f-490e-b24b-100839c9e8bc) |