### PR TITLE
fix: Fix the button end icon being squished when content is too long

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Adevinta
+ * Copyright (c) 2023 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -118,7 +118,7 @@ internal fun BaseSparkButton(
         }
         ProvideTextStyle(value = SparkTheme.typography.callout) {
             Row(
-                modifier = Modifier.weight(1f, false),
+                modifier = Modifier.weight(weight = 1f, fill = false),
                 content = content,
             )
         }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -117,7 +117,10 @@ internal fun BaseSparkButton(
             Spacer(Modifier.width(SparkButtonDefaults.IconSpacing))
         }
         ProvideTextStyle(value = SparkTheme.typography.callout) {
-            content()
+            Row(
+                modifier = Modifier.weight(1f, false),
+                content = content,
+            )
         }
         if (icon != null && iconSide == IconSide.END) {
             Spacer(Modifier.width(SparkButtonDefaults.IconSpacing))
@@ -265,7 +268,7 @@ private fun SparkButtonPreview() {
     ) {
         ButtonSize.entries.forEach { size ->
             SparkButton(
-                text = "Button",
+                text = "ButtonButton",
                 onClick = { },
                 colors = ButtonDefaults.buttonColors(),
                 size = size,


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
We use the weight modifier to force the content to take only the space it has available instead of pushing the other contents

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Closes #916  

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->

<table>
  <tr>
    <th>Old</th>
    <th>New</th>
  </tr>
  <tr>
    <td><img width="242" alt="image" src="https://github.com/adevinta/spark-android/assets/11772084/f85b4df8-8e89-4295-b526-3df51a842331"></td>
    <td><img width="242" alt="image" src="https://github.com/adevinta/spark-android/assets/11772084/4d9e2f75-861f-42d8-b559-ac357a5d4a3d">
</td>
  </tr>
</table>




