### PR TITLE
chore: Update Copyright to 2023-2024

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/MainActivity.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/backdrop/Backdrop.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/backdrop/Backdrop.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/ComponentsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/ComponentsScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/Navigation.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/Navigation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/component/Component.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/component/Component.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconButtonsConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconToggleButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconToggleButtonsConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progressbar/ProgressbarConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progressbar/ProgressbarConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/rating/RatingConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/rating/RatingConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tags/TagsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tags/TagsConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/RadioButtonConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/RadioButtonConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemeProperties.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemeProperties.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesHandler.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesSerializer.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/datastore/theme/ThemePropertiesSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/ComponentsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/ComponentsScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/Navigation.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/Navigation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/component/Component.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/component/Component.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/component/ComponentItem.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/component/ComponentItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/example/Example.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/example/Example.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/example/ExampleItem.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/example/ExampleItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/buttons/ButtonsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/buttons/ButtonsExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/buttons/IconButtonsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/buttons/IconButtonsExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/ModalExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/ModalExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/popover/PopoverExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/popover/PopoverExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/progressbar/ProgressbarExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/progressbar/ProgressbarExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/rating/RatingExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/rating/RatingExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tabs/TabsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tabs/TabsExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tags/TagsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tags/TagsExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/TextLinkExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/TextLinkExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/CheckboxExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/CheckboxExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/IconToggleButtonsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/IconToggleButtonsExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/RadioButtonExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/RadioButtonExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/SwitchExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/toggles/SwitchExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tokens/TokensExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tokens/TokensExamples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tokens/colors/ColorSample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/tokens/colors/ColorSample.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconDemoScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconExampleScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconExampleScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/icons/IconsScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Configurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Configurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Example.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Example.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/ComponentDetailScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/ComponentDetailScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/ComponentsInAGroupScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/ComponentsInAGroupScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/CurrentScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/CurrentScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/HomeScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/HomeScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/Navigation.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/showkase/Navigation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/tabbar/CatalogTabBar.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/tabbar/CatalogTabBar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/SegmentedButton.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/SegmentedButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/Theme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/Theme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/ThemeProvider.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/ThemeProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/adevinta/AdevintaTheme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/adevinta/AdevintaTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/Color.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/KleinanzeigenTheme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/KleinanzeigenTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/Shape.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/Shape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/Typography.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/kleinanzeigen/Typography.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/Color.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/LeboncoinTheme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/LeboncoinTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/Shape.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/Shape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/Typography.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/leboncoin/Typography.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/milanuncios/Color.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/milanuncios/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/milanuncios/MilanunciosTheme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/milanuncios/MilanunciosTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/milanuncios/Shape.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/milanuncios/Shape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/subito/Color.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/subito/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/subito/Shape.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/subito/Shape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/subito/SubitoTheme.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/themeprovider/subito/SubitoTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Any.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Any.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/GradientScrim.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/GradientScrim.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Previews.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Previews.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Texts.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Texts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Url.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/util/Url.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-bom/build.gradle.kts
+++ b/spark-bom/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-icons/build.gradle.kts
+++ b/spark-icons/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcon.kt
+++ b/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcon.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcons.kt
+++ b/spark-icons/src/main/kotlin/com/adevinta/spark/icons/SparkIcons.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/build.gradle.kts
+++ b/spark-lint/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/LintIssueRegistry.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/LintIssueRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetector.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/test/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetectorTest.kt
+++ b/spark-lint/src/test/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/CoilStubs.kt
+++ b/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/CoilStubs.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/ComposableStub.kt
+++ b/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/ComposableStub.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/FoundationStub.kt
+++ b/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/FoundationStub.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/MaterialComponentsStub.kt
+++ b/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/MaterialComponentsStub.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/SparkComponentsStub.kt
+++ b/spark-lint/src/test/kotlin/com/adevinta/spark/lint/stubs/SparkComponentsStub.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/build.gradle.kts
+++ b/spark-screenshot-testing/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziRule.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziRule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PaparazziUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PreviewScreenshotTests.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/PreviewScreenshotTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/iconbutton/IconButtonScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/iconbutton/IconButtonScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/iconbutton/IconToggleButtonScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/iconbutton/IconToggleButtonScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/icons/IconsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/icons/IconsScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/progress/ProgressScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/progress/ProgressScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarDocScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarDocScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tab/TabsDocScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tab/TabsDocScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tab/TabsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tab/TabsScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tags/TagsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tags/TagsScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/text/TextLinkScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/text/TextLinkScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/MultilineTextFieldScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/MultilineTextFieldScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldDocScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldDocScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tokens/ColorsScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/tokens/ColorsScreenshot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/androidTest/kotlin/com/adevinta/spark/placeholder/ImageAssertion.kt
+++ b/spark/src/androidTest/kotlin/com/adevinta/spark/placeholder/ImageAssertion.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/androidTest/kotlin/com/adevinta/spark/placeholder/PlaceholderTest.kt
+++ b/spark/src/androidTest/kotlin/com/adevinta/spark/placeholder/PlaceholderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/ExperimentalSparkApi.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/ExperimentalSparkApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/InternalSparkApi.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/InternalSparkApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/SparkShowkaseRootModule.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkShowkaseRootModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/SparkTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/IntentColor.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/IntentColor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/BottomAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/BottomAppBar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/NavigationBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/NavigationBar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/appbar/TopAppBarState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/Badge.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgeIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgeIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgeStyle.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgeStyle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/badge/BadgedBox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/DragHandle.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/DragHandle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/InternalMutatorMutex.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/InternalMutatorMutex.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/ModalBottomSheetLayout.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/ModalBottomSheetLayout.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SheetDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SheetDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/Swipeable.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/Swipeable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SwipeableV2.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/SwipeableV2.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/modal/ModalBottomSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/modal/ModalBottomSheet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/Button.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonContrast.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonFilled.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonGhost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonGhost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonOutlined.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonShape.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonShape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonSize.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonSize.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/ButtonTinted.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/buttons/FloatingActionButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/buttons/FloatingActionButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/Card.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardColors.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardColors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/card/CardElevation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/card/CardElevation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/AssistChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/AssistChip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDashed.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDashed.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipFilled.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipOutlined.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipStyles.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipStyles.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipTinted.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/FilterChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/FilterChip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/InputChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/InputChip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/SuggestionChip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/SuggestionChip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/AlertDialog.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleDrawerSheet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/DismissibleNavigationDrawer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalDrawerSheet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/ModalNavigationDrawer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/drawer/SparkDrawerDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonContrast.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonContrast.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonFilled.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonGhost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonGhost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonOutlined.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonSize.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonSize.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/IconButtonTinted.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonContrast.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonContrast.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonFilled.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonGhost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonGhost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonIcons.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonIcons.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonOutlined.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/iconbuttons/toggle/IconToggleButtonTinted.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/IconToggleButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Illustration.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Illustration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/UserAvatar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/UserAvatar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItem.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItemDefault.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/list/ListItemDefault.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationDrawerItem.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationDrawerItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRail.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRail.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRailItem.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/NavigationRailItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentDrawerSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentDrawerSheet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentNavigationDrawer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/PermanentNavigationDrawer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/navigation/UpNavigationIcon.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/navigation/UpNavigationIcon.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/Placeholder.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/Placeholder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/PlaceholderFoundation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/PlaceholderFoundation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/PlaceholderHighlight.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/placeholder/PlaceholderHighlight.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/PopoverDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/PopoverDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Tooltip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Tooltip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/CircularProgressIndicator.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/CircularProgressIndicator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/LinearProgressIndicator.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/LinearProgressIndicator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/ProgressIndicatorDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/ProgressIndicatorDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/Spinner.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/Spinner.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/SpinnerDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/SpinnerDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/SpinnerIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/SpinnerIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressStep.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressStep.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/ProgressTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/StepAnimation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progress/tracker/StepAnimation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progressbar/Progressbar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progressbar/Progressbar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/progressbar/ProgressbarIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/progressbar/ProgressbarIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/FractionalRectangleShape.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/FractionalRectangleShape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingDisplay.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingDisplay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingInput.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingInput.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingLong.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingSmall.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingStar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/scaffold/Scaffold.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/RangeSlider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/RangeSlider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/SliderDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/SliderDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarColors.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarColors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarDefault.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarDefault.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarError.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarValid.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarValid.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/spacer/Spacers.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/spacer/Spacers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/surface/ElevationOverlay.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/surface/ElevationOverlay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/surface/Surface.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/surface/Surface.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/Tab.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/Tab.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroupDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroupDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRow.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRowDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabRowDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagFilled.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagFilled.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagOutlined.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagOutlined.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagTinted.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/TagTinted.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/text/Text.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/text/Text.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/text/TextLink.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/text/TextLink.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/AddonScope.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/AddonScope.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/DefaultSparkTextFieldColors.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/DefaultSparkTextFieldColors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/MultilineTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/MultilineTextField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SelectTextField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldImpl.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldMeasurePolicy.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldMeasurePolicy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextField.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextFieldState.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/TextFieldState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SparkToggleLabelledContainer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/Switch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SwitchDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/SwitchDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/components/toggles/ToggleIntent.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/toggles/ToggleIntent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/res/SparkStringAnnotations.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/res/SparkStringAnnotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/ContentColor.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/ContentColor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Elevation.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Elevation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Font.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Font.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Layout.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Layout.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Order.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Order.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/PaletteTokens.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/PaletteTokens.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Shape.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Shape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/WindowSizeClass.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/WindowSizeClass.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Conditions.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Conditions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Drawings.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Drawings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Layout.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Layout.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/TouchTarget.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/TouchTarget.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/UsageOverlay.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/UsageOverlay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/preview/ComposeLayoutPreviewHelper.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/preview/ComposeLayoutPreviewHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreview.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreview.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreviewProvider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/preview/SparkPreviewProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/samples/kotlin/com/adevinta/spark/samples/components/ButtonSample.kt
+++ b/spark/src/samples/kotlin/com/adevinta/spark/samples/components/ButtonSample.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/test/kotlin/com/adevinta/spark/button/ButtonTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/button/ButtonTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/test/kotlin/com/adevinta/spark/placeholder/PlaceholderHighlightTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/placeholder/PlaceholderHighlightTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/test/kotlin/com/adevinta/spark/placeholder/PlaceholderTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/placeholder/PlaceholderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spark/src/test/kotlin/com/adevinta/spark/rating/RatingStarStateTest.kt
+++ b/spark/src/test/kotlin/com/adevinta/spark/rating/RatingStarStateTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/spotless/spotless.kt
+++ b/spotless/spotless.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Adevinta
+ * Copyright (c) 2023-2024 Adevinta
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
The Copyright was always updated by AS on commit so we can update ours to the new year 
