### PR TITLE
fix: Fix Slider configurator vertical scroll crash

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/slider/SliderConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/slider/SliderConfigurator.kt
@@ -26,8 +26,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -70,7 +68,6 @@ public val SlidersConfigurator: Configurator = Configurator(
 @Preview(showBackground = true)
 @Composable
 private fun SliderSample() {
-    val scrollState = rememberScrollState()
     var enabled by remember { mutableStateOf(true) }
     var rounded by remember { mutableStateOf(true) }
     var intent by remember { mutableStateOf(SliderIntent.Basic) }
@@ -82,7 +79,6 @@ private fun SliderSample() {
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.verticalScroll(scrollState),
     ) {
         Text(text = "Slider", style = SparkTheme.typography.headline1)
 


### PR DESCRIPTION

## 📋 Changes
Fix Slider configurator vertical scroll crash
## 🤔 Context

After merging vertical layout PR #975 
it doen't allow nested scroll
So this caused a crash on Slider configurator,
now it's fixed

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
