### PR TITLE
feat: decorrelate spotless and ktlint

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import kotlin.reflect.KProperty
 
 plugins {
     `kotlin-dsl`
@@ -81,6 +82,15 @@ fun NamedDomainObjectContainer<PluginDeclaration>.create(
     this.implementationClass = implementationClass
 }
 
+private operator fun VersionCatalog.getValue(
+    thisRef: Any?,
+    property: KProperty<*>,
+) = findVersion(property.name).orElseThrow {
+    IllegalStateException("Missing catalog version ${property.name}")
+}
+
+val ktlint: VersionConstraint by extensions.getByType<VersionCatalogsExtension>().named("libs")
+
 // This block is a copy of SparkSpotlessPlugin since this included build can't use it's own plugins...
 spotless {
     val licenseHeader = rootProject.file("./../spotless/spotless.kt")
@@ -90,13 +100,13 @@ spotless {
     }
     kotlin {
         target("src/**/*.kt")
-        ktlint()
+        ktlint(ktlint.toString())
         trimTrailingWhitespace()
         endWithNewline()
         licenseHeaderFile(licenseHeader)
     }
     kotlinGradle {
-        ktlint()
+        ktlint(ktlint.toString())
         trimTrailingWhitespace()
         endWithNewline()
         licenseHeaderFile(

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkProperties.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkProperties.kt
@@ -48,6 +48,7 @@ internal class SparkVersions(catalog: VersionCatalog) {
     val `compileSdk` by catalog
     val `kotlin` by catalog
     val `showkase` by catalog
+    val `ktlint` by catalog
 
     private operator fun VersionCatalog.getValue(
         thisRef: Any?,

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
@@ -40,14 +40,14 @@ internal class SparkSpotlessPlugin : Plugin<Project> {
                 }
                 kotlin {
                     target("src/**/*.kt")
-                    ktlint()
+                    ktlint(spark().versions.ktlint.toString())
                     trimTrailingWhitespace()
                     endWithNewline()
                     licenseHeaderFile(licenseHeader)
                     targetExclude("spotless/*.kt")
                 }
                 kotlinGradle {
-                    ktlint()
+                    ktlint(spark().versions.ktlint.toString())
                     trimTrailingWhitespace()
                     endWithNewline()
                     licenseHeaderFile(

--- a/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
+++ b/build-logic/src/main/kotlin/com/adevinta/spark/SparkSpotlessPlugin.kt
@@ -32,6 +32,7 @@ internal class SparkSpotlessPlugin : Plugin<Project> {
         with(target) {
             apply(plugin = "com.diffplug.spotless")
 
+            val ktlint = spark().versions.ktlint
             configure<SpotlessExtension> {
                 val licenseHeader = rootProject.file("spotless/spotless.kt")
                 format("misc") {
@@ -40,14 +41,14 @@ internal class SparkSpotlessPlugin : Plugin<Project> {
                 }
                 kotlin {
                     target("src/**/*.kt")
-                    ktlint(spark().versions.ktlint.toString())
+                    ktlint(ktlint.toString())
                     trimTrailingWhitespace()
                     endWithNewline()
                     licenseHeaderFile(licenseHeader)
                     targetExclude("spotless/*.kt")
                 }
                 kotlinGradle {
-                    ktlint(spark().versions.ktlint.toString())
+                    ktlint(ktlint.toString())
                     trimTrailingWhitespace()
                     endWithNewline()
                     licenseHeaderFile(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ kotlinx-coroutines = "1.8.0"
 kotlinx-collections-immutable = "0.3.7"
 kotlinx-serialization-json = "1.6.3"
 ksp = "1.9.22-1.0.18"
+ktlint = "1.0.1"
 lint = "31.3.0"
 minCompileSdk = "24"
 paparazzi = "1.3.1"
@@ -99,6 +100,8 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+
+ktlint-bom = { module = "com.pinterest.ktlint:ktlint-bom", version.ref = "ktlint" }
 
 lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }


### PR DESCRIPTION
We used to rely on spotless's default ktlint version (`KtLintStep.defaultVersion()`).  
This will enable us to update versions independently.  
As a first step, the default version `1.0.1` will be used (`1.2.1` being the current latest version).  
`ktlint-bom` is referenced in `libs.versions.toml` to make dependabot aware of it.

This should unlock #911