### PR TITLE
fix(deps): Fix for #1031 - Update build.gradle.kts

### DIFF
--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     api(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.ui.util)
     api(libs.coilCompose)
-    implementation(libs.kotlinx.collections.immutable)
+    api(libs.kotlinx.collections.immutable)
 
     implementation(libs.androidx.compose.ui.tooling.preview)
     debugImplementation(libs.androidx.compose.ui.tooling)


### PR DESCRIPTION
Expose kotlinx.collections.immutable dependency as it is needed for TextLink component

## 📋 Changes

This PR intends to solve the error `Cannot access class 'kotlinx.collections.immutable.ImmutableMap'. Check your module classpath for missing or conflicting dependencies` when a `TextLink` is used in a Gradle module that does not include the `org.jetbrains.kotlinx:kotlinx-collections-immutable` dependency.

## 🤔 Context

Closes #1031

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

Does not apply.

## 🗒️ Other info

