### PR TITLE
fix(Popover): The intent was not applied in the configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Spark
+
+* 🎨 Add a new intent param to the `Popover`
+
+### Catalog App
+
 ## [0.8.0]
 
 _2024-02-28_

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
@@ -78,12 +78,16 @@ public val PopoverConfigurator: Configurator = Configurator(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ColumnScope.PopoverSample() {
-    var isDismissButtonEnabled by remember { mutableStateOf(true) }
+    var isDismissButtonEnabled by remember { mutableStateOf(false) }
     var popoverContentExample by remember { mutableStateOf(PopoverContentExamples.TextList) }
     var popoverTriggerExample by remember { mutableStateOf(PopoverTriggerExamples.Button) }
     var intent by remember { mutableStateOf(PopoverIntent.Surface) }
-    val popoverState = rememberTooltipState(isPersistent = true)
+    val popoverState = rememberTooltipState(isPersistent = false)
     val scope = rememberCoroutineScope()
+
+    ConfiguredPopover(scope, intent, popoverState, isDismissButtonEnabled, popoverContentExample, popoverTriggerExample)
+
+    VerticalSpacer(40.dp)
 
     SwitchLabelled(
         checked = isDismissButtonEnabled,
@@ -138,40 +142,38 @@ private fun ColumnScope.PopoverSample() {
                 .fillMaxWidth()
                 .height(48.dp),
         )
-
-        val intents = PopoverIntent.entries
-        var intentExpanded by remember { mutableStateOf(false) }
-        SelectTextField(
-            modifier = Modifier.fillMaxWidth(),
-            value = intent.name,
-            onValueChange = {},
-            readOnly = true,
-            label = "Popover Intent",
-            expanded = intentExpanded,
-            onExpandedChange = { intentExpanded = !intentExpanded },
-            onDismissRequest = { intentExpanded = false },
-            dropdownContent = {
-                intents.forEach {
-                    DropdownMenuItem(
-                        text = { Text(it.name) },
-                        onClick = {
-                            intent = it
-                            intentExpanded = false
-                        },
-                    )
-                }
-            },
-        )
-        VerticalSpacer(40.dp)
-
-        ConfiguredPopover(scope, popoverState, isDismissButtonEnabled, popoverContentExample, popoverTriggerExample)
     }
+
+    val intents = PopoverIntent.entries
+    var intentExpanded by remember { mutableStateOf(false) }
+    SelectTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = intent.name,
+        onValueChange = {},
+        readOnly = true,
+        label = "Popover Intent",
+        expanded = intentExpanded,
+        onExpandedChange = { intentExpanded = !intentExpanded },
+        onDismissRequest = { intentExpanded = false },
+        dropdownContent = {
+            intents.forEach {
+                DropdownMenuItem(
+                    text = { Text(it.name) },
+                    onClick = {
+                        intent = it
+                        intentExpanded = false
+                    },
+                )
+            }
+        },
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ConfiguredPopover(
     scope: CoroutineScope,
+    intent: PopoverIntent,
     popoverState: TooltipState,
     isDismissButtonEnabled: Boolean,
     popoverContentExample: PopoverContentExamples,
@@ -179,6 +181,7 @@ private fun ConfiguredPopover(
 ) {
     Popover(
         popoverState = popoverState,
+        intent = intent,
         popover = {
             when (popoverContentExample) {
                 PopoverContentExamples.TextList -> LazyColumn(


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
The popover configurator  was present and updated correctly but it was not applied on the actual popover.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Close #986 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->
<img width="342" alt="image" src="https://github.com/adevinta/spark-android/assets/11772084/03b4d314-9d28-4bfd-8a07-13aec833a920">

