### PR TITLE
feat: Add `emptyIcon` and `errorIcon` parameters with default values to `Image` Composable

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/image/Image.kt
@@ -138,6 +138,8 @@ internal fun SparkImage(
  * @param modifier Modifier used to adjust the layout algorithm or draw decoration content (ex.
  * background)
  * @param onState A callback function that is called when the state of the image changes.
+ * @param emptyIcon Placeholder used when the image loading has not started yet.
+ * @param errorIcon Placeholder used when the image loading failed.
  * @param alignment Optional alignment parameter used to place the image in the given
  * bounds defined by the width and height
  * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be used
@@ -149,7 +151,7 @@ internal fun SparkImage(
  * into the destination. The default is [FilterQuality.Low] which scales using a bilinear
  * sampling algorithm
  * @param loadingPlaceholder Placeholder used when the image is loading. You can use a different one in special cases
- * like when the image is displayed in fullscreen for example.
+like when the image is displayed in fullscreen for example.
  */
 @Composable
 public fun Image(
@@ -157,6 +159,8 @@ public fun Image(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     onState: ((State) -> Unit)? = null,
+    emptyIcon: @Composable () -> Unit = { ImageIconState(SparkIcons.NoPhoto) },
+    errorIcon: @Composable () -> Unit = { ImageIconState(SparkIcons.ErrorPhoto) },
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
@@ -169,6 +173,8 @@ public fun Image(
         contentDescription = contentDescription,
         modifier = modifier,
         onState = onState,
+        emptyIcon = emptyIcon,
+        errorIcon = errorIcon,
         alignment = alignment,
         contentScale = contentScale,
         alpha = alpha,


### PR DESCRIPTION
resolves adevinta/spark-android#1061

<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes
adevinta/spark-android#1061

<!-- Describe your changes in details -->

As mentioned in the linked issue, I just added the errorIcon and emptyIcon fun args to the public Image fun.

## 🤔 Context
If you desire to have a custom error placeholder instead of the default error image or if you want to easily be able to have the same placeholder for both, this is necessary.

Closes #1061

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
