### PR TITLE
chore: merge Gradle setup and Wrapper validation steps

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -5,6 +5,6 @@ runs:
   steps:
     - uses: gradle/actions/setup-gradle@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11 # v3.3.0
       with:
+        validate-wrappers: true
         gradle-home-cache-cleanup: true
         add-job-summary-as-pr-comment: on-failure
-    - uses: gradle/wrapper-validation-action@460a3ca55fc5d559238a0efc7fa9f7465df8585d # v3.3.0


### PR DESCRIPTION
`validate-wrappers: true` has been recently added to `gradle/actions/setup-gradle`