### PR TITLE
chore(contributing): move code formatting tasks first in the list

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,6 +43,10 @@ or install it directly from **Android Studio**:
 
 Here is a list of Gradle tasks commonly used in this project:
 
+- Code formatting: run spotless formatter
+  ```bash
+  ./gradlew spotlessApply
+  ```
 - Building: assemble all modules in release mode
   ```bash
   ./gradlew assembleRelease
@@ -58,10 +62,6 @@ Here is a list of Gradle tasks commonly used in this project:
 - Linting: run Lint analysis
   ```bash
   ./gradlew lintRelease
-  ```
-- Code formatting: run spotless formatter
-  ```bash
-  ./gradlew spotlessApply
   ```
 - Deploying: publish all Maven publications to the local Maven cache `~/.m2`.
   ```bash


### PR DESCRIPTION
Code formatting is one of the first steps in the CI, even before attempting to build the code.
It makes more sense to move it first in the list, as it will always fail the PR in case of formatting issue.