### PR TITLE
feat(BottomSheet): Add sheetPeekHeight to BottomSheetScaffold

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberBottomSheetScaffoldState
@@ -42,6 +43,7 @@ import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.bottomsheet.DragHandle
@@ -77,6 +79,7 @@ import com.adevinta.spark.icons.SparkIcons
 public fun BottomSheetScaffold(
     sheetContent: @Composable BoxScope.() -> Unit,
     modifier: Modifier = Modifier,
+    sheetPeekHeight: Dp = BottomSheetDefaults.SheetPeekHeight,
     scaffoldState: BottomSheetScaffoldState = rememberBottomSheetScaffoldState(),
     sheetSwipeEnabled: Boolean = true,
     sheetDragHandle: @Composable (() -> Unit)? = { DragHandle() },
@@ -87,6 +90,7 @@ public fun BottomSheetScaffold(
     content: @Composable (PaddingValues) -> Unit,
 ) {
     androidx.compose.material3.BottomSheetScaffold(
+        sheetPeekHeight = sheetPeekHeight,
         sheetContent = {
             Box {
                 Box(


### PR DESCRIPTION

## 📋 Changes

Add sheetPeekHeight as it's required by consumers,
It used to exist in old versions of BottomSheet,


## 🤔 Context

After the addition of the new BottomSheet Component we have not exposed this parameter.
So now we are making it available again

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
