### PR TITLE
fix: Make UserAvatar compatible with dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased]
 
+### Spark
+
+- 🎨 The Avatar component was using the color icon without tinting it rendering them incompatible with the dark mode
+
+### Catalog App
+
+- 🎨 KA theme colors for outline has been changed in light mode and in dark mode it's the background + variants color.
+
+### CI
+
+
 ## [0.10.0]
 
 _2024-05-16_

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:099545d7429f10f8148ce37af23bee2d3caac6bb147dd10160b385e4ac56ada7
-size 32189
+oid sha256:7bc547beb2992650bfb05b47e978b77ad3ef62e6e62b8a9f5ee036b4b156dea0
+size 24954

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_images_useravatar_light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a975fa6173dc038f19f53536d38c046f16d93ef8bbeee271a8cfbf8a39337e90
-size 36955
+oid sha256:fb8c0f53da1b8fda5e1f889e00196af6c45ad223e2d6ba57ebd72384e5b4d3f5
+size 25145

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_dark.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cab544d00cfd81611dbcbd40cbf00944d6c3e870427827be0f7aed35bfd83ce
-size 3597

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_menu_dropdownmenu_light.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76b977e4fb8b85f641f448c83c80558e2f07dc4939c15963a7211ee6d16154fb
-size 3414


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Refactor the indicator to position it at the new right place and use an `Icon` instead of an `Illustration` to display the empty image to make it tinted now.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
Closes #1128 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->
![image](https://github.com/adevinta/spark-android/assets/11772084/7fcbe7a9-9079-4c95-8a9d-0438c3070f5a)

