### PR TITLE
feat(paparazzi): migrate from `recordPaparazziRelease` to `cleanRecordPaparazziRelease`

### DIFF
--- a/.github/actions/paparazzi-golden-images/action.yml
+++ b/.github/actions/paparazzi-golden-images/action.yml
@@ -30,7 +30,7 @@ runs:
     - run: git rm -- **/src/test/snapshots/**/*.png
       shell: bash
       if: inputs.force == 'true'
-    - run: ./gradlew recordPaparazziRelease
+    - run: ./gradlew cleanRecordPaparazziRelease
       shell: bash
     - run: |
         # Record all snapshots to the index, to be able to detect untracked ones


### PR DESCRIPTION
This will force cleaning unused golden images.