### PR TITLE
fix(modal): Allow ModalScaffold to take no buttons

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/ModalExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/ModalExamples.kt
@@ -38,7 +38,15 @@ public val DialogsExamples: List<Example> = listOf(
     },
     Example(
         name = "Modal with no content padding",
-        description = "Showcase the modal component with not start and end padding on the content placeholder",
+        description = "Showcase the modal component with no start and end padding on the content placeholder",
+        sourceUrl = ModalsExampleSourceUrl,
+    ) {
+        ModalSample(PaddingValues(0.dp))
+    },
+    Example(
+        name = "Modal with no buttons",
+        description = "Showcase the modal component with no main and support button. \n This will hide the Bottom " +
+                "App Bar and add a close button in the dialog layout",
         sourceUrl = ModalsExampleSourceUrl,
     ) {
         ModalSample(PaddingValues(0.dp))

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/ModalExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/ModalExamples.kt
@@ -46,9 +46,9 @@ public val DialogsExamples: List<Example> = listOf(
     Example(
         name = "Modal with no buttons",
         description = "Showcase the modal component with no main and support button. \n This will hide the Bottom " +
-                "App Bar and add a close button in the dialog layout",
+            "App Bar and add a close button in the dialog layout",
         sourceUrl = ModalsExampleSourceUrl,
     ) {
-        ModalSample(PaddingValues(0.dp))
+        ModalSample(withButtons = false)
     },
 )

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
@@ -168,33 +168,33 @@ private fun MainButton(
 }
 
 private val exampleContent = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula " +
-        "eget dolor. " +
-        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
+    "eget dolor. " +
+    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
 
 @Preview
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
@@ -168,33 +168,33 @@ private fun MainButton(
 }
 
 private val exampleContent = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula " +
-    "eget dolor. " +
-    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
+        "eget dolor. " +
+        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
 
 @Preview
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.buttons.ButtonFilled
@@ -57,12 +58,13 @@ import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.icons.ImageFill
 import com.adevinta.spark.icons.MoreMenuVertical
 import com.adevinta.spark.icons.SparkIcons
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun ModalSample(
     paddingValues: PaddingValues = ModalDefault.DialogPadding,
+    withButtons: Boolean = true,
 ) {
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -84,34 +86,12 @@ internal fun ModalSample(
             ModalScaffold(
                 onClose = { showDialog = false },
                 contentPadding = paddingValues,
-                mainButton = {
-                    ButtonFilled(
-                        modifier = it,
-                        onClick = {
-                            coroutineScope.launch {
-                                snackbarHostState.showSnackbar(
-                                    message = "Snackbar",
-                                    actionLabel = "Action",
-                                    duration = SnackbarDuration.Short,
-                                )
-                            }
-                        },
-                        text = "Main Action",
-                    )
-                },
-                snackbarHost = {
-                    SnackbarHost(snackbarHostState)
-                },
-                supportButton = {
-                    ButtonOutlined(
-                        modifier = it,
-                        onClick = {
-                            focusRequester.requestFocus()
-                            controller?.show()
-                        },
-                        text = "Alternative Action",
-                    )
-                },
+                mainButton = if (withButtons) {
+                    { MainButton(it, coroutineScope, snackbarHostState) }
+                } else null,
+                supportButton = if (withButtons) {
+                    { SupportButton(it, focusRequester, controller) }
+                } else null,
                 title = {
                     Text(text = "Title")
                 },
@@ -125,6 +105,9 @@ internal fun ModalSample(
                     IconButton(onClick = { /*TODO*/ }) {
                         Icon(sparkIcon = SparkIcons.MoreMenuVertical, contentDescription = "")
                     }
+                },
+                snackbarHost = {
+                    SnackbarHost(snackbarHostState)
                 },
             ) { innerPadding ->
                 Column(
@@ -144,34 +127,71 @@ internal fun ModalSample(
     }
 }
 
+@Composable
+private fun SupportButton(
+    modifier: Modifier,
+    focusRequester: FocusRequester,
+    controller: SoftwareKeyboardController?,
+) {
+    ButtonOutlined(
+        modifier = modifier,
+        onClick = {
+            focusRequester.requestFocus()
+            controller?.show()
+        },
+        text = "Alternative Action",
+    )
+}
+
+@Composable
+private fun MainButton(
+    modifier: Modifier,
+    coroutineScope: CoroutineScope,
+    snackbarHostState: SnackbarHostState,
+) {
+    ButtonFilled(
+        modifier = modifier,
+        onClick = {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar(
+                    message = "Snackbar",
+                    actionLabel = "Action",
+                    duration = SnackbarDuration.Short,
+                )
+            }
+        },
+        text = "Main Action",
+    )
+}
+
 private val exampleContent = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula " +
-    "eget dolor. " +
-    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
+        "eget dolor. " +
+        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
 
 @Preview
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -88,10 +87,14 @@ internal fun ModalSample(
                 contentPadding = paddingValues,
                 mainButton = if (withButtons) {
                     { MainButton(it, coroutineScope, snackbarHostState) }
-                } else null,
+                } else {
+                    null
+                },
                 supportButton = if (withButtons) {
                     { SupportButton(it, focusRequester, controller) }
-                } else null,
+                } else {
+                    null
+                },
                 title = {
                     Text(text = "Title")
                 },
@@ -165,33 +168,33 @@ private fun MainButton(
 }
 
 private val exampleContent = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula " +
-        "eget dolor. " +
-        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
+    "eget dolor. " +
+    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,"
 
 @Preview
 @Composable

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -47,11 +47,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.OutlinedTextFieldDefaults.MinWidth
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
@@ -77,15 +77,13 @@ import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.R
 import com.adevinta.spark.SparkTheme
-import com.adevinta.spark.components.IntentColors
 import com.adevinta.spark.components.appbar.TopAppBar
 import com.adevinta.spark.components.buttons.ButtonFilled
 import com.adevinta.spark.components.buttons.ButtonOutlined
 import com.adevinta.spark.components.chips.ChipDefaults.MaxWidth
 import com.adevinta.spark.components.dialog.ModalDefault.DialogPadding
-import com.adevinta.spark.components.iconbuttons.IconButtonDefaults
-import com.adevinta.spark.components.iconbuttons.SparkIconButton
 import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.icons.IconButton
 import com.adevinta.spark.components.image.Illustration
 import com.adevinta.spark.components.scaffold.Scaffold
 import com.adevinta.spark.components.surface.Surface
@@ -121,13 +119,13 @@ import com.adevinta.spark.tools.preview.DevicePreviews
     message = "Use ModalScaffold instead",
     replaceWith = ReplaceWith(
         expression = "ModalScaffold(" +
-            "onClose = onClose," +
-            "modifier = modifier," +
-            "snackbarHost = snackbarHost," +
-            "mainButton = mainButton," +
-            "supportButton = supportButton," +
-            "content = content," +
-            ")",
+                "onClose = onClose," +
+                "modifier = modifier," +
+                "snackbarHost = snackbarHost," +
+                "mainButton = mainButton," +
+                "supportButton = supportButton," +
+                "content = content," +
+                ")",
         imports = ["com.adevinta.spark.components.dialog.ModalScaffold"],
     ),
 )
@@ -212,14 +210,14 @@ public fun ModalScaffold(
     val isPhoneLandscape = size.heightSizeClass == WindowHeightSizeClass.Compact
     val isPhonePortraitOrFoldable =
         (size.widthSizeClass == WindowWidthSizeClass.Compact || size.widthSizeClass == WindowWidthSizeClass.Medium) &&
-            (
-                size.heightSizeClass == WindowHeightSizeClass.Medium ||
-                    size.heightSizeClass == WindowHeightSizeClass.Expanded
-                )
+                (
+                        size.heightSizeClass == WindowHeightSizeClass.Medium ||
+                                size.heightSizeClass == WindowHeightSizeClass.Expanded
+                        )
     val activityWindow = getActivityWindow()
 
     val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-        activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
     val properties = DialogProperties(
         usePlatformDefaultWidth = isEdgeToEdge,
         decorFitsSystemWindows = false,
@@ -369,7 +367,7 @@ private fun PhonePortraitModalScaffold(
         val dialogWindow = getDialogWindow()
 
         val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+                activityWindow?.navigationBarColor == Color.Transparent.toArgb()
 
         SideEffect {
             if (
@@ -491,7 +489,7 @@ private fun PhoneLandscapeModalScaffold(
 
         @Suppress("DEPRECATION")
         val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+                activityWindow?.navigationBarColor == Color.Transparent.toArgb()
 
         SideEffect {
             if (
@@ -581,15 +579,13 @@ private fun PhoneLandscapeModalScaffold(
 
 @Composable
 private fun CloseIconButton(onClose: () -> Unit) {
-    SparkIconButton(
-        icon = SparkIcons.Close,
-        onClick = onClose,
-        contentDescription = stringResource(id = R.string.spark_a11y_modal_fullscreen_close),
-        colors = IconButtonDefaults.ghostIconButtonColors(
-            IntentColors.Danger.colors(),
-            contentColor = LocalContentColor.current,
-        ),
-    )
+    IconButton(onClick = onClose) {
+        Icon(
+            sparkIcon = SparkIcons.Close,
+            modifier = Modifier.size(24.dp),
+            contentDescription = stringResource(id = R.string.spark_a11y_modal_fullscreen_close),
+        )
+    }
 }
 
 /**
@@ -598,10 +594,10 @@ private fun CloseIconButton(onClose: () -> Unit) {
  */
 private operator fun PaddingValues.plus(other: PaddingValues): PaddingValues = PaddingValues(
     start = this.calculateStartPadding(LayoutDirection.Ltr) +
-        other.calculateStartPadding(LayoutDirection.Ltr),
+            other.calculateStartPadding(LayoutDirection.Ltr),
     top = this.calculateTopPadding() + other.calculateTopPadding(),
     end = this.calculateEndPadding(LayoutDirection.Ltr) +
-        other.calculateEndPadding(LayoutDirection.Ltr),
+            other.calculateEndPadding(LayoutDirection.Ltr),
     bottom = this.calculateBottomPadding() + other.calculateBottomPadding(),
 )
 
@@ -633,22 +629,22 @@ private fun ModalPreview() {
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
                 text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
-                    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-                    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-                    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-                    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-                    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-                    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-                    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-                    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-                    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-                    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-                    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-                    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-                    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-                    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-                    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-                    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
+                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }
@@ -678,22 +674,22 @@ private fun DeprecatedModalPreview() {
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
                 text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
-                    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-                    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-                    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-                    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-                    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-                    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-                    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-                    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-                    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-                    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-                    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-                    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-                    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-                    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-                    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-                    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
+                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -67,6 +67,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -224,9 +226,12 @@ public fun ModalScaffold(
     )
     val navigationBarPadding = WindowInsets.navigationBars.asPaddingValues()
 
+    val dialogPaneDescription = stringResource(R.string.spark_dialog_pane_a11y)
+    val dialogModifier = modifier.then(Modifier.semantics { paneTitle = dialogPaneDescription })
+
     when {
         isPhonePortraitOrFoldable -> PhonePortraitModalScaffold(
-            modifier = modifier,
+            modifier = dialogModifier,
             properties = properties,
             navigationBarPadding = navigationBarPadding,
             contentPadding = contentPadding,
@@ -240,7 +245,7 @@ public fun ModalScaffold(
         )
 
         isPhoneLandscape -> PhoneLandscapeModalScaffold(
-            modifier = modifier,
+            modifier = dialogModifier,
             properties = properties,
             navigationBarPadding = navigationBarPadding,
             contentPadding = contentPadding,
@@ -254,7 +259,7 @@ public fun ModalScaffold(
         )
 
         else -> DialogScaffold(
-            modifier = modifier,
+            modifier = dialogModifier,
             onClose = onClose,
             contentPadding = contentPadding,
             snackbarHost = snackbarHost,
@@ -285,14 +290,13 @@ private fun DialogScaffold(
     ) {
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
         Surface(
-            modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = modifier
+                .sizeIn(minWidth = 280.dp, maxWidth = 560.dp)
+                .nestedScroll(scrollBehavior.nestedScrollConnection),
             elevation = 6.dp,
             shape = SparkTheme.shapes.large,
         ) {
-            Column(
-                modifier = Modifier
-                    .sizeIn(minWidth = MinWidth, maxWidth = MaxWidth),
-            ) {
+            Column {
                 TopAppBar(
                     navigationIcon = {
                         // As a fallback when to action button is displayed to easily close the dialog

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -52,7 +52,6 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedTextFieldDefaults.MinWidth
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -82,7 +81,6 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.appbar.TopAppBar
 import com.adevinta.spark.components.buttons.ButtonFilled
 import com.adevinta.spark.components.buttons.ButtonOutlined
-import com.adevinta.spark.components.chips.ChipDefaults.MaxWidth
 import com.adevinta.spark.components.dialog.ModalDefault.DialogPadding
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.icons.IconButton
@@ -121,13 +119,13 @@ import com.adevinta.spark.tools.preview.DevicePreviews
     message = "Use ModalScaffold instead",
     replaceWith = ReplaceWith(
         expression = "ModalScaffold(" +
-                "onClose = onClose," +
-                "modifier = modifier," +
-                "snackbarHost = snackbarHost," +
-                "mainButton = mainButton," +
-                "supportButton = supportButton," +
-                "content = content," +
-                ")",
+            "onClose = onClose," +
+            "modifier = modifier," +
+            "snackbarHost = snackbarHost," +
+            "mainButton = mainButton," +
+            "supportButton = supportButton," +
+            "content = content," +
+            ")",
         imports = ["com.adevinta.spark.components.dialog.ModalScaffold"],
     ),
 )
@@ -212,14 +210,14 @@ public fun ModalScaffold(
     val isPhoneLandscape = size.heightSizeClass == WindowHeightSizeClass.Compact
     val isPhonePortraitOrFoldable =
         (size.widthSizeClass == WindowWidthSizeClass.Compact || size.widthSizeClass == WindowWidthSizeClass.Medium) &&
-                (
-                        size.heightSizeClass == WindowHeightSizeClass.Medium ||
-                                size.heightSizeClass == WindowHeightSizeClass.Expanded
-                        )
+            (
+                size.heightSizeClass == WindowHeightSizeClass.Medium ||
+                    size.heightSizeClass == WindowHeightSizeClass.Expanded
+                )
     val activityWindow = getActivityWindow()
 
     val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+        activityWindow?.navigationBarColor == Color.Transparent.toArgb()
     val properties = DialogProperties(
         usePlatformDefaultWidth = isEdgeToEdge,
         decorFitsSystemWindows = false,
@@ -371,7 +369,7 @@ private fun PhonePortraitModalScaffold(
         val dialogWindow = getDialogWindow()
 
         val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-                activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
 
         SideEffect {
             if (
@@ -493,7 +491,7 @@ private fun PhoneLandscapeModalScaffold(
 
         @Suppress("DEPRECATION")
         val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-                activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
 
         SideEffect {
             if (
@@ -598,10 +596,10 @@ private fun CloseIconButton(onClose: () -> Unit) {
  */
 private operator fun PaddingValues.plus(other: PaddingValues): PaddingValues = PaddingValues(
     start = this.calculateStartPadding(LayoutDirection.Ltr) +
-            other.calculateStartPadding(LayoutDirection.Ltr),
+        other.calculateStartPadding(LayoutDirection.Ltr),
     top = this.calculateTopPadding() + other.calculateTopPadding(),
     end = this.calculateEndPadding(LayoutDirection.Ltr) +
-            other.calculateEndPadding(LayoutDirection.Ltr),
+        other.calculateEndPadding(LayoutDirection.Ltr),
     bottom = this.calculateBottomPadding() + other.calculateBottomPadding(),
 )
 
@@ -633,22 +631,22 @@ private fun ModalPreview() {
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
                 text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
-                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
+                    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }
@@ -678,22 +676,22 @@ private fun DeprecatedModalPreview() {
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
                 text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
-                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
+                    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -121,13 +121,13 @@ import com.adevinta.spark.tools.preview.DevicePreviews
     message = "Use ModalScaffold instead",
     replaceWith = ReplaceWith(
         expression = "ModalScaffold(" +
-                "onClose = onClose," +
-                "modifier = modifier," +
-                "snackbarHost = snackbarHost," +
-                "mainButton = mainButton," +
-                "supportButton = supportButton," +
-                "content = content," +
-                ")",
+            "onClose = onClose," +
+            "modifier = modifier," +
+            "snackbarHost = snackbarHost," +
+            "mainButton = mainButton," +
+            "supportButton = supportButton," +
+            "content = content," +
+            ")",
         imports = ["com.adevinta.spark.components.dialog.ModalScaffold"],
     ),
 )
@@ -212,14 +212,14 @@ public fun ModalScaffold(
     val isPhoneLandscape = size.heightSizeClass == WindowHeightSizeClass.Compact
     val isPhonePortraitOrFoldable =
         (size.widthSizeClass == WindowWidthSizeClass.Compact || size.widthSizeClass == WindowWidthSizeClass.Medium) &&
-                (
-                        size.heightSizeClass == WindowHeightSizeClass.Medium ||
-                                size.heightSizeClass == WindowHeightSizeClass.Expanded
-                        )
+            (
+                size.heightSizeClass == WindowHeightSizeClass.Medium ||
+                    size.heightSizeClass == WindowHeightSizeClass.Expanded
+                )
     val activityWindow = getActivityWindow()
 
     val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+        activityWindow?.navigationBarColor == Color.Transparent.toArgb()
     val properties = DialogProperties(
         usePlatformDefaultWidth = isEdgeToEdge,
         decorFitsSystemWindows = false,
@@ -369,7 +369,7 @@ private fun PhonePortraitModalScaffold(
         val dialogWindow = getDialogWindow()
 
         val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-                activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
 
         SideEffect {
             if (
@@ -428,8 +428,12 @@ private fun PhonePortraitModalScaffold(
 @Composable
 private fun BottomBarPortrait(
     navigationBarPadding: PaddingValues,
-    mainButton: @Composable() ((Modifier) -> Unit)?,
-    supportButton: @Composable() ((Modifier) -> Unit)?,
+    mainButton:
+    @Composable()
+    ((Modifier) -> Unit)?,
+    supportButton:
+    @Composable()
+    ((Modifier) -> Unit)?,
 ) {
     if (supportButton == null && mainButton == null) return
     Surface {
@@ -487,7 +491,7 @@ private fun PhoneLandscapeModalScaffold(
 
         @Suppress("DEPRECATION")
         val isEdgeToEdge = activityWindow?.statusBarColor == Color.Transparent.toArgb() ||
-                activityWindow?.navigationBarColor == Color.Transparent.toArgb()
+            activityWindow?.navigationBarColor == Color.Transparent.toArgb()
 
         SideEffect {
             if (
@@ -594,10 +598,10 @@ private fun CloseIconButton(onClose: () -> Unit) {
  */
 private operator fun PaddingValues.plus(other: PaddingValues): PaddingValues = PaddingValues(
     start = this.calculateStartPadding(LayoutDirection.Ltr) +
-            other.calculateStartPadding(LayoutDirection.Ltr),
+        other.calculateStartPadding(LayoutDirection.Ltr),
     top = this.calculateTopPadding() + other.calculateTopPadding(),
     end = this.calculateEndPadding(LayoutDirection.Ltr) +
-            other.calculateEndPadding(LayoutDirection.Ltr),
+        other.calculateEndPadding(LayoutDirection.Ltr),
     bottom = this.calculateBottomPadding() + other.calculateBottomPadding(),
 )
 
@@ -629,22 +633,22 @@ private fun ModalPreview() {
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
                 text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
-                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
+                    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }
@@ -674,22 +678,22 @@ private fun DeprecatedModalPreview() {
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState()),
                 text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. " +
-                        "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
-                        "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
-                        "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
-                        "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
-                        "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
-                        "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
-                        "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
-                        " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
-                        "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
-                        "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
-                        "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
-                        "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
-                        "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
-                        "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
-                        "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
-                        "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
+                    "Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur " +
+                    "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. " +
+                    "\n\nNulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, " +
+                    "vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. " +
+                    "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. " +
+                    "Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. " +
+                    "\n\nAenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante," +
+                    " dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius " +
+                    "laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. " +
+                    "Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. " +
+                    "\n\nMaecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet " +
+                    "adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, " +
+                    "lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis " +
+                    "faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. " +
+                    "Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. " +
+                    "Sed consequat, leo eget bibendum sodales, augue velit cursus nunc,",
             )
         }
     }

--- a/spark/src/main/res/values-de/strings.xml
+++ b/spark/src/main/res/values-de/strings.xml
@@ -49,6 +49,10 @@
     </plurals>
     <!--endregion-->
 
+    <!--region Dialog-->
+    <string name="spark_dialog_pane_a11y">Dialogfeld</string>
+    <!--endregion-->
+
     <!--region TextField-->
     <string name="spark_textfield_content_description">Pflichtfeld</string>
     <string name="spark_textfield_delete_a11y">Löschen</string>

--- a/spark/src/main/res/values-fr/strings.xml
+++ b/spark/src/main/res/values-fr/strings.xml
@@ -55,6 +55,10 @@
     </plurals>
     <!--endregion-->
 
+    <!--region Dialog-->
+    <string name="spark_dialog_pane_a11y">Boîte de dialogue</string>
+    <!--endregion-->
+
     <string name="spark_annotatedStringResource_test">Les <b>Meilleures</b> <annotation typography="large">pratiques</annotation> pour les textes sur <i><annotation color="main">Android</annotation></i></string>
     <string name="spark_annotatedStringResource_test_args">Salut, <b><annotation variable="who" typography="large" color="main">who</annotation></b>!</string>
 

--- a/spark/src/main/res/values/strings.xml
+++ b/spark/src/main/res/values/strings.xml
@@ -50,6 +50,10 @@
     </plurals>
     <!--endregion-->
 
+    <!--region Dialog-->
+    <string name="spark_dialog_pane_a11y">Dialog</string>
+    <!--endregion-->
+
     <string name="spark_annotatedStringResource_test"><b>Best</b> <annotation typography="large">practices</annotation> <p dir="rtl">for text on</p> <i><annotation color="main">Android</annotation></i></string>
     <string name="spark_annotatedStringResource_test_args">Hello, <b><annotation color="main" typography="large" variable="who">who</annotation></b>!</string>
 


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Hide the Bottom App Bar in the Modal when no actions are provided and in the Dialog layout I've also added the Close action so we still have a clear way to indicate that the Dialog can be closed with an action.

A new example screen as been added for testing.


## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
I didn't expect from the specs that the Modal could have no actions. This is now clarified so we need to hide the Bottom App Bar when no actions are provided.

Closes #1168

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.
@adevinta/spark-design 

## 📝 Other Info

I've added a private api to be able to combine 2 `PaddingValues` between each others and we may want to publish it in the future if it's not planned by Google 🤔 
