### PR TITLE
chore(dependabot): Use official multi-directory wildcard

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,9 +3,8 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directories:
-      - "/"
-      - "/.github/actions/setup-gradle"
-      - "/.github/actions/setup-java"
+      - "/.github/actions/*"
+      - "/.github/workflows/*"
     schedule:
       interval: "daily"
   - package-ecosystem: "gradle"


### PR DESCRIPTION
https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dependabot configuration to automatically include all subdirectories under `/actions` and `/workflows` for GitHub Actions and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->