### PR TITLE
feat(Dropdown): Add custom item support examples

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
@@ -45,6 +45,7 @@ import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.textfields.TextFieldState
 import com.adevinta.spark.components.toggles.SwitchLabelled
+import com.adevinta.spark.tokens.highlight
 
 public val ComboBoxConfigurator: Configurator = Configurator(
     name = "ComboBox",
@@ -129,7 +130,7 @@ private fun ColumnScope.ComboBoxSample() {
         Text(
             text = "State",
             modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            style = SparkTheme.typography.body2.highlight,
         )
         val textFieldStates: MutableSet<TextFieldState?> =
             TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
@@ -40,6 +40,7 @@ import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.themes.SegmentedButton
 import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.menu.DropdownMenuGroupItem
 import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.AddonScope
@@ -47,6 +48,9 @@ import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.textfields.TextFieldState
 import com.adevinta.spark.components.toggles.SwitchLabelled
+import com.adevinta.spark.tokens.highlight
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 public val DropdownsConfigurator: Configurator = Configurator(
     name = "Dropdowns",
@@ -59,11 +63,12 @@ public val DropdownsConfigurator: Configurator = Configurator(
 @Composable
 private fun ColumnScope.DropdownSample() {
     var isEnabled by remember { mutableStateOf(true) }
+    var hideOnSelect by remember { mutableStateOf(true) }
     var expanded by remember { mutableStateOf(false) }
     var isRequired by remember { mutableStateOf(true) }
     var state: TextFieldState? by remember { mutableStateOf(null) }
     var labelText by remember { mutableStateOf("Label") }
-    var valueText by remember { mutableStateOf("Value") }
+    var valueText by remember { mutableStateOf("") }
     var placeHolderText by remember { mutableStateOf("Placeholder") }
     var helperText by remember { mutableStateOf("Helper message") }
     var stateMessageText by remember { mutableStateOf("State Message") }
@@ -102,14 +107,34 @@ private fun ColumnScope.DropdownSample() {
         visualTransformation = VisualTransformation.None,
         interactionSource = remember { MutableInteractionSource() },
     ) {
-        repeat(5) {
-            DropdownMenuItem(
-                text = { Text("Item $it") },
-                onClick = { expanded = false },
-            )
+        DropdownStubData.forEach { (groupName, books) ->
+            DropdownMenuGroupItem(
+                title = {
+                    Text(groupName)
+                },
+            ) {
+                books.forEach { book ->
+                    DropdownMenuItem(
+                        text = { Text(book) },
+                        onClick = {
+                            valueText = book
+                            if(hideOnSelect) expanded = false
+                        },
+                    )
+                }
+            }
         }
     }
 
+    SwitchLabelled(
+        checked = hideOnSelect,
+        onCheckedChange = { hideOnSelect = it },
+    ) {
+        Text(
+            text = "Hide the menu on selection",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
     SwitchLabelled(
         checked = isRequired,
         onCheckedChange = { isRequired = it },
@@ -133,7 +158,7 @@ private fun ColumnScope.DropdownSample() {
         Text(
             text = "State",
             modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            style = SparkTheme.typography.body2.highlight,
         )
         val textFieldStates: MutableSet<TextFieldState?> =
             TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
@@ -194,3 +219,10 @@ private fun ColumnScope.DropdownSample() {
         placeholder = "State message of the Dropdown",
     )
 }
+
+private data class DropdownExampleGroup(val name: String, val books: ImmutableList<String>)
+
+private val DropdownStubData = persistentListOf(
+    DropdownExampleGroup("Best Sellers", persistentListOf("To Kill a Mockingbird", "War and Peace", "The Idiot")),
+    DropdownExampleGroup("Novelties", persistentListOf("A Picture of Dorian Gray", "1984", "Pride and Prejudice")),
+)

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
@@ -118,7 +118,7 @@ private fun ColumnScope.DropdownSample() {
                         text = { Text(book) },
                         onClick = {
                             valueText = book
-                            if(hideOnSelect) expanded = false
+                            if (hideOnSelect) expanded = false
                         },
                     )
                 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
@@ -22,7 +22,6 @@
 package com.adevinta.spark.catalog.examples.samples.text
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -30,7 +29,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontStyle
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Example
 import com.adevinta.spark.catalog.util.SampleSourceUrl
@@ -71,7 +69,7 @@ public val DropdownsExamples: List<Example> = listOf(
     Example(
         name = "Custom Item",
         description = "The Dropdown takes a slot for the menu content, you can use a different item than " +
-                "DropdownItem if you need a different layout than the classic one.",
+            "DropdownItem if you need a different layout than the classic one.",
         sourceUrl = DropdownsExampleSourceUrl,
     ) {
         CustomItemsDropdown()
@@ -233,7 +231,7 @@ private fun CustomItemsDropdown() {
                             },
                             trailingIcon = {
                                 TagFilled(text = "New", intent = TagIntent.Basic)
-                            }
+                            },
                         )
                     }
                 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
@@ -100,7 +100,7 @@ public val DropdownsExamples: List<Example> = listOf(
     ) {
         val multiSelectionFilter by remember {
             mutableStateOf(DropdownStubData)
-        }
+                                        }
 
         var selectedItems by remember {
             mutableStateOf(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
@@ -70,8 +70,8 @@ public val DropdownsExamples: List<Example> = listOf(
     },
     Example(
         name = "Custom Item",
-        description = "The Dropdown takes a slot for the menu content, you can use a different item than DropdownItem " +
-                "if you need a different layout than the classic one.",
+        description = "The Dropdown takes a slot for the menu content, you can use a different item than " +
+                "DropdownItem if you need a different layout than the classic one.",
         sourceUrl = DropdownsExampleSourceUrl,
     ) {
         CustomItemsDropdown()

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/text/DropdownExamples.kt
@@ -22,17 +22,22 @@
 package com.adevinta.spark.catalog.examples.samples.text
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Example
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.menu.DropdownMenuGroupItem
 import com.adevinta.spark.components.menu.DropdownMenuItem
+import com.adevinta.spark.components.tags.TagFilled
+import com.adevinta.spark.components.tags.TagIntent
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.tokens.highlight
@@ -51,122 +56,188 @@ private val DropdownStubData = persistentListOf(
 public val DropdownsExamples: List<Example> = listOf(
     Example(
         name = "Single selection",
-        description = "Link inside title no icon",
+        description = "Clicking the selected item does not unselect it",
         sourceUrl = DropdownsExampleSourceUrl,
     ) {
-        val singleSelectionFilter by remember {
-            mutableStateOf(DropdownStubData)
-        }
-
-        var singleSelected by remember { mutableStateOf("") }
-        var expanded by remember { mutableStateOf(false) }
-        Dropdown(
-            modifier = Modifier.fillMaxWidth(),
-            value = singleSelected,
-            label = "Book",
-            placeholder = "Pick a Book",
-            expanded = expanded,
-            onExpandedChange = {
-                expanded = !expanded
-            },
-            onDismissRequest = {
-                expanded = false
-            },
-            dropdownContent = {
-                singleSelectionFilter.forEach { group ->
-                    DropdownMenuGroupItem(
-                        title = {
-                            Text(group.name)
-                        },
-                    ) {
-                        group.books.forEach { book ->
-                            DropdownMenuItem(
-                                text = { Text(book) },
-                                onClick = {
-                                    singleSelected = book
-                                    expanded = false
-                                },
-                            )
-                        }
-                    }
-                }
-            },
-        )
+        SingleSelectDropdown()
     },
     Example(
         name = "Multi selection",
-        description = "Link inside title no icon",
+        description = "You have full control on how the menu behave when clicking an item to close it or not.",
         sourceUrl = DropdownsExampleSourceUrl,
     ) {
-        val multiSelectionFilter by remember {
-            mutableStateOf(DropdownStubData)
-                                        }
-
-        var selectedItems by remember {
-            mutableStateOf(
-                listOf(
-                    "To Kill a Mockingbird",
-                    "War and Peace",
-                ),
-            )
-        }
-        val multiSelectedValues by remember(selectedItems.size) {
-            derivedStateOf {
-                val suffix = if (selectedItems.size > 1) ", +${selectedItems.size - 1}" else ""
-                selectedItems.firstOrNull().orEmpty() + suffix
-            }
-        }
-        var expanded by remember { mutableStateOf(false) }
-        Dropdown(
-            modifier = Modifier.fillMaxWidth(),
-            value = multiSelectedValues,
-            label = "Book",
-            placeholder = "Pick a Book",
-            expanded = expanded,
-            onExpandedChange = {
-                expanded = !expanded
-            },
-            onDismissRequest = {
-                expanded = false
-            },
-            dropdownContent = {
-                multiSelectionFilter.forEach { group ->
-                    DropdownMenuGroupItem(
-                        title = {
-                            Text(group.name)
-                        },
-                    ) {
-                        group.books.forEach { book ->
-                            // This should be part of your model otherwise it's a huge work that done on
-                            // each items but we're simplifying things since it's an example here.
-                            val isSelected = book in selectedItems
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        text = book,
-                                        style = if (isSelected) {
-                                            SparkTheme.typography.body1.highlight
-                                        } else {
-                                            SparkTheme.typography.body1
-                                        },
-                                    )
-                                },
-                                onClick = {
-                                    selectedItems = if (book in selectedItems) {
-                                        selectedItems - book
-                                    } else {
-                                        selectedItems + book
-                                    }
-                                    // Here we want to have the dropdown to stay expanded when we multiSelect but
-                                    // you could use the line below if in the case you want to have the same behaviour
-                                    // as the single selection.
-                                    // expanded = false
-                                },
-                            )
-                        }
-                    }
-                }
-            },
-        )
+        MultiSelectDropdown()
+    },
+    Example(
+        name = "Custom Item",
+        description = "The Dropdown takes a slot for the menu content, you can use a different item than DropdownItem " +
+                "if you need a different layout than the classic one.",
+        sourceUrl = DropdownsExampleSourceUrl,
+    ) {
+        CustomItemsDropdown()
     },
 )
+
+@Composable
+private fun SingleSelectDropdown() {
+    val singleSelectionFilter by remember {
+        mutableStateOf(DropdownStubData)
+    }
+
+    var singleSelected by remember { mutableStateOf("") }
+    var expanded by remember { mutableStateOf(false) }
+    Dropdown(
+        modifier = Modifier.fillMaxWidth(),
+        value = singleSelected,
+        label = "Book",
+        placeholder = "Pick a Book",
+        expanded = expanded,
+        onExpandedChange = {
+            expanded = !expanded
+        },
+        onDismissRequest = {
+            expanded = false
+        },
+        dropdownContent = {
+            singleSelectionFilter.forEach { (groupName, books) ->
+                DropdownMenuGroupItem(
+                    title = {
+                        Text(groupName)
+                    },
+                ) {
+                    books.forEach { book ->
+                        DropdownMenuItem(
+                            text = { Text(book) },
+                            onClick = {
+                                singleSelected = book
+                                expanded = false
+                            },
+                        )
+                    }
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun MultiSelectDropdown() {
+    val multiSelectionFilter by remember {
+        mutableStateOf(DropdownStubData)
+    }
+
+    var selectedItems by remember {
+        mutableStateOf(
+            listOf(
+                "To Kill a Mockingbird",
+                "War and Peace",
+            ),
+        )
+    }
+    val multiSelectedValues by remember(selectedItems.size) {
+        derivedStateOf {
+            val suffix = if (selectedItems.size > 1) ", +${selectedItems.size - 1}" else ""
+            selectedItems.firstOrNull().orEmpty() + suffix
+        }
+    }
+    var expanded by remember { mutableStateOf(false) }
+    Dropdown(
+        modifier = Modifier.fillMaxWidth(),
+        value = multiSelectedValues,
+        label = "Book",
+        placeholder = "Pick a Book",
+        expanded = expanded,
+        onExpandedChange = {
+            expanded = !expanded
+        },
+        onDismissRequest = {
+            expanded = false
+        },
+        dropdownContent = {
+            multiSelectionFilter.forEach { (groupName, books) ->
+                DropdownMenuGroupItem(
+                    title = {
+                        Text(groupName)
+                    },
+                ) {
+                    books.forEach { book ->
+                        // This should be part of your model otherwise it's a huge work that done on
+                        // each items but we're simplifying things since it's an example here.
+                        val isSelected = book in selectedItems
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    text = book,
+                                    style = if (isSelected) {
+                                        SparkTheme.typography.body1.highlight
+                                    } else {
+                                        SparkTheme.typography.body1
+                                    },
+                                )
+                            },
+                            onClick = {
+                                selectedItems = if (book in selectedItems) {
+                                    selectedItems - book
+                                } else {
+                                    selectedItems + book
+                                }
+                                // Here we want to have the dropdown to stay expanded when we multiSelect but
+                                // you could use the line below if in the case you want to have the same behaviour
+                                // as the single selection.
+                                // expanded = false
+                            },
+                        )
+                    }
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun CustomItemsDropdown() {
+    val singleSelectionFilter by remember {
+        mutableStateOf(DropdownStubData)
+    }
+
+    var singleSelected by remember { mutableStateOf("") }
+    var expanded by remember { mutableStateOf(false) }
+    Dropdown(
+        modifier = Modifier.fillMaxWidth(),
+        value = singleSelected,
+        label = "Book",
+        placeholder = "Pick a Book",
+        expanded = expanded,
+        onExpandedChange = {
+            expanded = !expanded
+        },
+        onDismissRequest = {
+            expanded = false
+        },
+        dropdownContent = {
+            singleSelectionFilter.forEach { (groupName, books) ->
+                DropdownMenuGroupItem(
+                    title = {
+                        Text(
+                            text = groupName,
+                            style = SparkTheme.typography.body1.highlight,
+                        )
+                    },
+                ) {
+                    books.forEach { book ->
+                        DropdownMenuItem(
+                            text = { Text(book) },
+                            onClick = {
+                                singleSelected = book
+                                expanded = false
+                            },
+                            trailingIcon = {
+                                TagFilled(text = "New", intent = TagIntent.Basic)
+                            }
+                        )
+                    }
+                }
+            }
+        },
+    )
+}

--- a/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetector.kt
+++ b/spark-lint/src/main/kotlin/com/adevinta/spark/lint/MaterialComposableUsageDetector.kt
@@ -42,7 +42,9 @@ import java.util.EnumSet
 /**
  * Checks if a Composable has a Spark replacement.
  */
-public class MaterialComposableUsageDetector : Detector(), SourceCodeScanner {
+public class MaterialComposableUsageDetector :
+    Detector(),
+    SourceCodeScanner {
 
     override fun getApplicableMethodNames(): List<String> = METHOD_NAMES
 
@@ -97,8 +99,10 @@ public class MaterialComposableUsageDetector : Detector(), SourceCodeScanner {
             "androidx.compose.material3.RadioButton" to "com.adevinta.spark.components.toggles.RadioButton",
             "androidx.compose.material3.Switch" to "com.adevinta.spark.components.toggles.Switch",
             "androidx.compose.material3.Snackbar" to "com.adevinta.spark.components.snackbars.Snackbar",
-            "androidx.compose.material3.LinearProgressIndicator" to "com.adevinta.spark.components.progress.LinearProgressIndicator",
-            "androidx.compose.material3.CircularProgressIndicator" to "com.adevinta.spark.components.progress.CircularProgressIndicator",
+            "androidx.compose.material3.LinearProgressIndicator" to
+                "com.adevinta.spark.components.progress.LinearProgressIndicator",
+            "androidx.compose.material3.CircularProgressIndicator" to
+                "com.adevinta.spark.components.progress.CircularProgressIndicator",
             "androidx.compose.material3.MaterialTheme" to "com.adevinta.spark.SparkTheme",
             //endregion
             //region Foundation

--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -275,7 +276,9 @@ public fun DropdownMenuGroupItem(
 private inline fun SectionHeadline(
     crossinline content: @Composable () -> Unit,
 ) {
-    ProvideTextStyle(value = SparkTheme.typography.body2) {
+    ProvideTextStyle(
+        value = SparkTheme.typography.body2.copy(fontStyle = FontStyle.Italic)
+    ) {
         EmphasizeDim1 {
             content()
         }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -277,7 +277,7 @@ private inline fun SectionHeadline(
     crossinline content: @Composable () -> Unit,
 ) {
     ProvideTextStyle(
-        value = SparkTheme.typography.body2.copy(fontStyle = FontStyle.Italic)
+        value = SparkTheme.typography.body2.copy(fontStyle = FontStyle.Italic),
     ) {
         EmphasizeDim1 {
             content()

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/AddonScope.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/AddonScope.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -54,7 +53,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.adevinta.spark.ExperimentalSparkApi
@@ -285,50 +283,48 @@ internal object AddonScopeInstance : AddonScope()
 private fun TextFieldWithDropdownPreview() {
     var expanded by remember { mutableStateOf(false) }
     PreviewTheme {
-        Box(modifier = Modifier.fillMaxSize()) {
-            TextField(
-                value = "+33 0123456789",
-                label = "Phone number",
-                onValueChange = {},
-                leadingContent = {
-                    Dropdown(
-                        modifier = Modifier,
-                        expanded = expanded,
-                        onExpandedChange = {
-                            expanded = !expanded
-                        },
-                        onDismissRequest = {
-                            expanded = false
-                        },
-                        properties = PopupProperties(),
-                        dropdownLabel = {
-                            Canvas(
-                                modifier = Modifier.size(width = 24.dp, height = 14.dp),
-                            ) {
-                                drawRect(color = Color.Blue)
-                                drawRect(color = Color.White, topLeft = Offset(24.dp.toPx() / 3, 0f))
-                                drawRect(color = Color.Red, topLeft = Offset(24.dp.toPx() / 3 * 2, 0f))
-                            }
-                            Text(text = "FR", style = SparkTheme.typography.body1)
-                            SparkSelectTrailingIcon(expanded = expanded)
-                        },
-                    ) {
-                        repeat(4) {
-                            DropdownMenuItem(
-                                onClick = {
-                                    expanded = false
-                                },
-                                text = { Text(text = "Dropdown") },
-                            )
+        TextField(
+            value = "+33 0123456789",
+            label = "Phone number",
+            onValueChange = {},
+            leadingContent = {
+                Dropdown(
+                    modifier = Modifier,
+                    expanded = expanded,
+                    onExpandedChange = {
+                        expanded = !expanded
+                    },
+                    onDismissRequest = {
+                        expanded = false
+                    },
+                    properties = PopupProperties(),
+                    dropdownLabel = {
+                        Canvas(
+                            modifier = Modifier.size(width = 24.dp, height = 14.dp),
+                        ) {
+                            drawRect(color = Color.Blue)
+                            drawRect(color = Color.White, topLeft = Offset(24.dp.toPx() / 3, 0f))
+                            drawRect(color = Color.Red, topLeft = Offset(24.dp.toPx() / 3 * 2, 0f))
                         }
+                        Text(text = "FR", style = SparkTheme.typography.body1)
+                        SparkSelectTrailingIcon(expanded = expanded)
+                    },
+                ) {
+                    repeat(4) {
+                        DropdownMenuItem(
+                            onClick = {
+                                expanded = false
+                            },
+                            text = { Text(text = "Dropdown") },
+                        )
                     }
-                },
-            )
-        }
+                }
+            },
+        )
     }
 }
 
-@PreviewFontScale
+@Preview
 @Composable
 private fun TextFieldWithButtonPreview() {
     var isLoading by remember { mutableStateOf(false) }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt
@@ -297,7 +297,8 @@ public fun SelectTextField(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = onDismissRequest,
-            modifier = Modifier.exposedDropdownSize()
+            modifier = Modifier
+                .exposedDropdownSize()
                 .padding(16.dp),
             properties = properties,
             content = dropdownContent,
@@ -362,7 +363,13 @@ public fun Dropdown(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     dropdownContent: @Composable ColumnScope.() -> Unit,
 ) {
-    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = onExpandedChange) {
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = {
+            // Don't expand the menu when the Textfield is disabled
+            if (enabled) onExpandedChange(it)
+        },
+    ) {
         TextField(
             value = value,
             onValueChange = { },


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add Custom items examples and improve the configurator to actually represent the selection when an item is tapped.
Also fix the Dropdown showing the menu while the Textfield is not enabled.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
Close #1163 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
A11y need some fixes in the examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new `DropdownMenuGroupItem` component for dropdown groups.
  - Added new custom dropdown item examples (Single/Multi-Select, Custom Items).

- **Enhancements**
  - Improved text element styling with new highlight style.
  - Updated dropdown text field state message styling.
  - Refactored dropdown examples into separate composable functions.

- **Bug Fixes**
  - Prevented menu expansion when the text field is disabled.
  - Adjusted progress indicator mappings for better Spark compatibility.

- **Refactor**
  - Reformatted class declarations for better readability.
  - Removed unnecessary imports and reorganized component structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->