### PR TITLE
fix(Chip): remove chip max-width

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
@@ -237,7 +237,6 @@ public fun Chip(
                     )
                 }
                 .defaultMinSize(minHeight = ChipDefaults.MinHeight)
-                .sizeIn(maxWidth = ChipDefaults.MaxWidth)
                 .padding(ChipDefaults.ChipPadding),
             horizontalArrangement = Arrangement.spacedBy(
                 ChipDefaults.LeadingIconEndSpacing,
@@ -329,7 +328,6 @@ public fun ChipSelectable(
                     )
                 }
                 .defaultMinSize(minHeight = ChipDefaults.MinHeight)
-                .sizeIn(maxWidth = ChipDefaults.MaxWidth)
                 .animateContentSize()
                 .padding(ChipDefaults.ChipPadding),
             horizontalArrangement = Arrangement.spacedBy(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/Chip.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.LocalContentColor

--- a/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/chips/ChipDefaults.kt
@@ -59,9 +59,4 @@ public object ChipDefaults {
      * The chip's default height
      */
     internal val MinHeight = 32.dp
-
-    /**
-     * The chip's max width
-     */
-    internal val MaxWidth = 240.dp
 }


### PR DESCRIPTION
Closes [#1167](https://github.com/adevinta/spark-android/issues/1167)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted sizing behavior for `Chip` and `ChipSelectable` components by removing the default maximum width constraint, offering more flexibility in their use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->