### PR TITLE
fix(release): Provide Replace fixes for Snackbar breaking changes

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarrConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarrConfigurator.kt
@@ -65,10 +65,10 @@ public val SnackbarConfigurator: Configurator = Configurator(
 
 @Composable
 private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
-    var isDismissIconEnabled by remember { mutableStateOf(false) }
+    var withDismissAction by remember { mutableStateOf(false) }
     var isIconEnabled by remember { mutableStateOf(false) }
     var style by remember { mutableStateOf(SnackbarStyle.Filled) }
-    var isActionOnNewLine by remember { mutableStateOf(false) }
+    var actionOnNewLine by remember { mutableStateOf(false) }
     var expanded by remember { mutableStateOf(false) }
     var intent by remember { mutableStateOf(SnackbarIntent.Basic) }
     var actionText by remember { mutableStateOf("Action") }
@@ -98,9 +98,9 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
     )
 
     SwitchLabelled(
-        checked = isActionOnNewLine,
+        checked = actionOnNewLine,
         onCheckedChange = {
-            isActionOnNewLine = it
+            actionOnNewLine = it
         },
     ) {
         Text(
@@ -110,9 +110,9 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
     }
 
     SwitchLabelled(
-        checked = isDismissIconEnabled,
+        checked = withDismissAction,
         onCheckedChange = {
-            isDismissIconEnabled = it
+            withDismissAction = it
         },
     ) {
         Text(
@@ -149,8 +149,8 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
     }
     Snackbar(
         intent = intent,
-        isDismissIconEnabled = isDismissIconEnabled,
-        isActionOnNewLine = isActionOnNewLine,
+        withDismissAction = withDismissAction,
+        actionOnNewLine = actionOnNewLine,
         style = style,
         icon = if (isIconEnabled) SparkIcons.FlashlightFill else null,
         actionLabel = actionText,
@@ -163,8 +163,8 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
             snackbarHostState.showSnackbar(
                 SnackbarSparkVisuals(
                     intent = intent,
-                    isDismissIconEnabled = isDismissIconEnabled,
-                    isActionOnNewLine = isActionOnNewLine,
+                    withDismissAction = withDismissAction,
+                    actionOnNewLine = actionOnNewLine,
                     style = style,
                     icon = if (isIconEnabled) SparkIcons.FlashlightFill else null,
                     actionLabel = actionText,

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/snackbar/SnackbarExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/snackbar/SnackbarExamples.kt
@@ -54,8 +54,8 @@ public val SnackbarExamples: List<Example> = listOf(
     ) {
         Snackbar(
             intent = SnackbarIntent.Info,
-            isDismissIconEnabled = true,
-            isActionOnNewLine = true,
+            withDismissAction = true,
+            actionOnNewLine = true,
             style = SnackbarStyle.Filled,
             icon = SparkIcons.LikeFill,
             actionLabel = "Action",
@@ -70,8 +70,8 @@ public val SnackbarExamples: List<Example> = listOf(
     ) {
         Snackbar(
             intent = SnackbarIntent.Alert,
-            isDismissIconEnabled = true,
-            isActionOnNewLine = false,
+            withDismissAction = true,
+            actionOnNewLine = false,
             style = SnackbarStyle.Tinted,
             icon = SparkIcons.LikeFill,
             actionLabel = "Action",

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarDocScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarDocScreenshot.kt
@@ -51,8 +51,8 @@ internal class SnackbarDocScreenshot {
                         Snackbar(
                             intent = visual.intent,
                             style = visual.style,
-                            isActionOnNewLine = visual.message == stubBody,
-                            isDismissIconEnabled = visual.isDismissIconEnabled,
+                            actionOnNewLine = visual.message == stubBody,
+                            withDismissAction = visual.withDismissAction,
                             icon = visual.icon,
                             actionLabel = visual.actionLabel,
                         ) { Text(visual.message) }

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/SnackbarScreenshot.kt
@@ -51,8 +51,8 @@ internal class SnackbarScreenshot {
                     Snackbar(
                         style = SnackbarStyle.Filled,
                         intent = it,
-                        isActionOnNewLine = true,
-                        isDismissIconEnabled = true,
+                        actionOnNewLine = true,
+                        withDismissAction = true,
                         icon = SparkIcons.LikeFill,
                         actionLabel = "Action",
                     ) {
@@ -71,9 +71,9 @@ internal class SnackbarScreenshot {
                     Snackbar(
                         style = SnackbarStyle.Tinted,
                         intent = it,
-                        isDismissIconEnabled = true,
+                        withDismissAction = true,
                         icon = SparkIcons.LikeFill,
-                        isActionOnNewLine = true,
+                        actionOnNewLine = true,
                         actionLabel = "Action",
                     ) {
                         Text("Lorem ipsum dolor sit amet")

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/TestData.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/snackbar/TestData.kt
@@ -42,14 +42,14 @@ internal val BodyIconSnackbar = SnackbarSparkVisuals(stubShortBody, icon = Spark
 internal val BodyIconActionNewLineSnackbar = SnackbarSparkVisuals(
     stubBody,
     actionLabel = stubAction,
-    isDismissIconEnabled = true,
+    withDismissAction = true,
     icon = SparkIcons.AlarmOnOutline,
 )
 internal val BodyTitleSnackbar = SnackbarSparkVisuals(stubBody)
 internal val BodyTitleActionSnackbar = SnackbarSparkVisuals(
     stubBody,
     actionLabel = stubAction,
-    isDismissIconEnabled = false,
+    withDismissAction = false,
 )
 
 internal val data = listOf(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt
@@ -65,13 +65,13 @@ public val SnackbarDefaults.intent: SnackbarIntent
 internal fun SparkSnackbar(
     intent: SnackbarIntent,
     style: SnackbarStyle,
-    isActionOnNewLine: Boolean,
-    isDismissIconEnabled: Boolean,
+    actionOnNewLine: Boolean,
+    withDismissAction: Boolean,
     modifier: Modifier = Modifier,
     icon: SparkIcon? = null,
     actionLabel: String? = null,
     onActionClick: (() -> Unit)? = null,
-    onDismissIconClick: (() -> Unit)? = null,
+    onDismissClick: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     val backgroundColor = when (style) {
@@ -85,15 +85,15 @@ internal fun SparkSnackbar(
             .padding(16.dp)
             .sparkUsageOverlay(),
         shape = SparkTheme.shapes.small,
-        actionOnNewLine = isActionOnNewLine,
+        actionOnNewLine = actionOnNewLine,
         containerColor = backgroundColor,
         contentColor = contentColor,
         dismissAction = {
             DismissIcon(
                 intent = intent,
                 style = style,
-                onClick = { onDismissIconClick?.invoke() },
-                isDismissIconEnabled = isDismissIconEnabled,
+                onClick = { onDismissClick?.invoke() },
+                withDismissAction = withDismissAction,
             )
         },
         action = {
@@ -102,7 +102,7 @@ internal fun SparkSnackbar(
                 onClick = { onActionClick?.invoke() },
                 actionLabel = actionLabel,
                 style = style,
-                isActionOnNewLine = isActionOnNewLine,
+                actionOnNewLine = actionOnNewLine,
             )
         },
     ) {
@@ -127,9 +127,9 @@ private fun DismissIcon(
     intent: SnackbarIntent,
     style: SnackbarStyle,
     onClick: () -> Unit,
-    isDismissIconEnabled: Boolean,
+    withDismissAction: Boolean,
 ) {
-    if (!isDismissIconEnabled) return
+    if (!withDismissAction) return
 
     SparkIconButton(
         icon = SparkIcons.Close,
@@ -147,7 +147,7 @@ private fun SnackbarAction(
     onClick: () -> Unit,
     style: SnackbarStyle,
     actionLabel: String? = null,
-    isActionOnNewLine: Boolean = false,
+    actionOnNewLine: Boolean = false,
 ) {
     actionLabel ?: return
     val colors = ButtonDefaults.textButtonColors(
@@ -157,7 +157,7 @@ private fun SnackbarAction(
         },
     )
     val buttonModifier = when {
-        isActionOnNewLine ->
+        actionOnNewLine ->
             Modifier
                 .fillMaxWidth(0.8f)
                 .wrapContentWidth(Alignment.End)
@@ -186,37 +186,37 @@ private fun SnackbarAction(
  * @param modifier modifiers for the Snackbar layout
  * @param intent The intent of the Snackbar.
  * @param style The style of the Snackbar.
- * @param isDismissIconEnabled Whether the dismiss icon is enabled.
- * @param isActionOnNewLine whether or not action should be put on the separate line. Recommended
+ * @param withDismissAction Whether the dismiss icon is enabled.
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
  * for action with long action text
  * @param icon icon to be shown on the start side of the content when there's no title.
  * @param actionLabel action to add as an action to the snackbar.
  * @param onActionClick callback when the action is clicked.
- * @param onDismissIconClick Callback for dismiss icon click.
+ * @param onDismissClick Callback for dismiss icon click.
  */
 @Composable
 public fun Snackbar(
     modifier: Modifier = Modifier,
     intent: SnackbarIntent = SnackbarDefaults.intent,
     style: SnackbarStyle = SnackbarDefaults.style,
-    isActionOnNewLine: Boolean = false,
-    isDismissIconEnabled: Boolean = false,
+    actionOnNewLine: Boolean = false,
+    withDismissAction: Boolean = false,
     icon: SparkIcon? = null,
     actionLabel: String? = null,
     onActionClick: (() -> Unit)? = null,
-    onDismissIconClick: (() -> Unit)? = null,
+    onDismissClick: (() -> Unit)? = null,
     content: @Composable (() -> Unit),
 ) {
     SparkSnackbar(
         intent = intent,
         style = style,
         modifier = modifier,
-        isActionOnNewLine = isActionOnNewLine,
-        isDismissIconEnabled = isDismissIconEnabled,
+        actionOnNewLine = actionOnNewLine,
+        withDismissAction = withDismissAction,
         icon = icon,
         actionLabel = actionLabel,
         onActionClick = onActionClick,
-        onDismissIconClick = onDismissIconClick,
+        onDismissClick = onDismissClick,
         content = content,
     )
 }
@@ -250,12 +250,12 @@ public fun Snackbar(
         intent = sparkVisuals?.intent ?: SnackbarDefaults.intent,
         style = sparkVisuals?.style ?: SnackbarDefaults.style,
         modifier = modifier,
-        isActionOnNewLine = sparkVisuals?.isActionOnNewLine ?: false,
-        isDismissIconEnabled = sparkVisuals?.isDismissIconEnabled ?: false,
+        actionOnNewLine = sparkVisuals?.actionOnNewLine ?: false,
+        withDismissAction = sparkVisuals?.withDismissAction ?: false,
         icon = sparkVisuals?.icon,
         actionLabel = visuals.actionLabel,
         onActionClick = { data.performAction() },
-        onDismissIconClick = { data.dismiss() },
+        onDismissClick = { data.dismiss() },
     ) { Text(visuals.message) }
 }
 
@@ -270,7 +270,7 @@ public fun Snackbar(
  * @param intent background color, note that the surfaceInverse one is not available with the Tinted style
  * @param style style of the Snackbar, Tinted as a lower emphasis than the Filled style
  * @param actionLabel action label to show as button in the Snackbar
- * @param isDismissIconEnabled a boolean to show a dismiss action in the Snackbar. This is
+ * @param withDismissAction a boolean to show a dismiss action in the Snackbar. This is
  * recommended to be set to true better accessibility when a Snackbar is set with a
  * [SnackbarDuration.Indefinite]
  * @param duration shown duration of the Snackbar, will adapt for a11y context
@@ -281,13 +281,10 @@ public class SnackbarSparkVisuals(
     public val intent: SnackbarIntent = SnackbarDefaults.intent,
     public val style: SnackbarStyle = SnackbarDefaults.style,
     override val actionLabel: String? = null,
-    public val isDismissIconEnabled: Boolean = false,
-    public val isActionOnNewLine: Boolean = false,
+    override val withDismissAction: Boolean = false,
+    public val actionOnNewLine: Boolean = false,
     override val duration: SnackbarDuration = SnackbarDuration.Short,
-) : SnackbarVisuals {
-    override val withDismissAction: Boolean
-        get() = isDismissIconEnabled
-}
+) : SnackbarVisuals
 
 /***
  * Preview
@@ -350,7 +347,7 @@ private fun BodyIconSnackbarPreview() {
     PreviewTheme {
         Snackbar(
             intent = SnackbarIntent.Error,
-            isDismissIconEnabled = true,
+            withDismissAction = true,
             icon = SparkIcons.FlashlightFill,
         ) {
             Text(StubBodyShort)
@@ -364,8 +361,8 @@ private fun BodyIconActionNewLineLongSnackbarPreview() {
     PreviewTheme {
         Snackbar(
             intent = SnackbarIntent.SurfaceInverse,
-            isDismissIconEnabled = true,
-            isActionOnNewLine = true,
+            withDismissAction = true,
+            actionOnNewLine = true,
             style = SnackbarStyle.Tinted,
             icon = SparkIcons.FlashlightFill,
             actionLabel = StubBodyLong,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.md
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/Snackbar.md
@@ -12,8 +12,8 @@ Only one snackbar may be displayed at a time.
 public fun Snackbar(
     data: SnackbarData,
     modifier: Modifier = Modifier,
-    isActionOnNewLine: Boolean = false,
-    isDismissIconEnabled: Boolean = false,
+    actionOnNewLine: Boolean = false,
+    withDismissAction: Boolean = false,
     ){}
 ```
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarColors.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarColors.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023-2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.adevinta.spark.SparkTheme
+
+@Deprecated(
+    message = "Use SnackbarIntent instead as this class supported only 3 intents out of 10",
+    replaceWith = ReplaceWith(
+        "SnackbarIntent",
+        "com.adevinta.spark.components.snackbars.SnackbarIntent",
+    ),
+    level = DeprecationLevel.ERROR,
+)
+public enum class SnackbarColors {
+
+    @Deprecated(
+        message = "Use SnackbarDefaults.intent instead as it's the new default snackbar color",
+        replaceWith = ReplaceWith(
+            "SnackbarDefaults.intent",
+            "com.adevinta.spark.components.snackbars.intent",
+            "androidx.compose.material3.SnackbarDefaults",
+        ),
+        level = DeprecationLevel.ERROR,
+    )
+    Default {
+        override val baseColor: Color
+            @Composable get() {
+                return SparkTheme.colors.supportContainer
+            }
+    },
+
+    @Deprecated(
+        message = "Use SnackbarIntent.Error instead",
+        replaceWith = ReplaceWith(
+            "SnackbarIntent.Error",
+            "com.adevinta.spark.components.snackbars.SnackbarIntent",
+        ),
+        level = DeprecationLevel.ERROR,
+    )
+    Error {
+        override val baseColor: Color
+            @Composable get() {
+                return SparkTheme.colors.errorContainer
+            }
+    },
+
+    @Deprecated(
+        message = "Use SnackbarIntent.Success instead",
+        replaceWith = ReplaceWith(
+            "SnackbarIntent.Success",
+            "com.adevinta.spark.components.snackbars.SnackbarIntent",
+        ),
+        level = DeprecationLevel.ERROR,
+    )
+    Valid {
+        override val baseColor: Color
+            @Composable get() {
+                return SparkTheme.colors.successContainer
+            }
+    },
+    ;
+
+    @get:Composable
+    public abstract val baseColor: Color
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarDefault.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarDefault.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023-2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.material3.SnackbarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ *
+ * Snackbars inform users of a process that an app has performed or will perform. They appear
+ * temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience,
+ * and they don’t require user input to disappear.
+ *
+ * A Snackbar can contain a single action. Because Snackbar disappears automatically, the action
+ * shouldn't be "Dismiss" or "Cancel".
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]
+ *
+ * If you want to change dynamically the snackbar color look at [Snackbar].
+ *
+ * @param modifier modifiers for the Snackbar layout
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
+ * for action with long action text
+ * @param icon icon to be shown on the start side of the content when there's no title.
+ * @param title title to be shown above the [content], currently the SnackBarHost doesn't handle it so avoid using it
+ * @param actionLabel action to add as an action to the snackbar.
+ * @param onActionClick callback when the action is clicked.
+ * @param content content to show information about a process that an app has performed or will
+ * perform
+ */
+@Deprecated(
+    message = "Use Snackbar instead as we now support intents and changed the api for the icon for new specs",
+    replaceWith = ReplaceWith(
+        "Snackbar(intent = SnackbarDefaults.intent, modifier = modifier, " +
+            "actionOnNewLine = actionOnNewLine, actionLabel = actionLabel," +
+            " onActionClick = onActionClick, content = content)",
+        "com.adevinta.spark.components.snackbars.Snackbar",
+    ),
+    level = DeprecationLevel.ERROR,
+)
+@Composable
+public fun SnackbarDefault(
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable (() -> Unit),
+) {
+    Snackbar(
+        intent = SnackbarDefaults.intent,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+//        icon = icon,
+        actionLabel = actionLabel,
+        onActionClick = onActionClick,
+        content = content,
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarError.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarError.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023-2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ *
+ * Snackbars inform users of a process that an app has performed or will perform. They appear
+ * temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience,
+ * and they don’t require user input to disappear.
+ *
+ * A Snackbar can contain a single action. Because Snackbar disappears automatically, the action
+ * shouldn't be "Dismiss" or "Cancel".
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]
+ *
+ * If you want to change dynamically the snackbar color look at [Snackbar].
+ *
+ * @param modifier modifiers for the Snackbar layout
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
+ * for action with long action text
+ * @param icon icon to be shown on the start side of the content when there's no title.
+ * @param title title to be shown above the [content], currently the SnackBarHost doesn't handle it so avoid using it
+ * @param actionLabel action to add as an action to the snackbar.
+ * @param onActionClick callback when the action is clicked.
+ * @param content content to show information about a process that an app has performed or will
+ * perform
+ */
+@Deprecated(
+    message = "Use Snackbar instead as we now support intents and changed the api for the icon for new specs",
+    replaceWith = ReplaceWith(
+        "Snackbar(intent = SnackbarIntent.Error, modifier = modifier, " +
+            "actionOnNewLine = actionOnNewLine, actionLabel = actionLabel," +
+            " onActionClick = onActionClick, content = content)",
+        "com.adevinta.spark.components.snackbars.Snackbar",
+    ),
+    level = DeprecationLevel.ERROR,
+)
+@Composable
+public fun SnackbarError(
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable (() -> Unit),
+) {
+    Snackbar(
+        intent = SnackbarIntent.Error,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+//        icon = icon,
+        actionLabel = actionLabel,
+        onActionClick = onActionClick,
+        content = content,
+    )
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarHost.kt
@@ -109,7 +109,7 @@ public class SnackbarHostState {
      * @param intent The intent of the Snackbar.
      * @param style The style of the Snackbar.
      * @param actionLabel optional action label to show as button in the Snackbar
-     * @param isDismissIconEnabled a boolean to show a dismiss action in the Snackbar. This is
+     * @param withDismissAction a boolean to show a dismiss action in the Snackbar. This is
      * recommended to be set to true for better accessibility when a Snackbar is set with a
      * [SnackbarDuration.Indefinite]
      * @param duration duration to control how long snackbar will be shown in [SnackbarHost], either
@@ -124,7 +124,8 @@ public class SnackbarHostState {
         icon: SparkIcon? = null,
         intent: SnackbarIntent = SnackbarDefaults.intent,
         style: SnackbarStyle = SnackbarDefaults.style,
-        isDismissIconEnabled: Boolean = false,
+        withDismissAction: Boolean = false,
+        actionOnNewLine: Boolean = false,
         duration: SnackbarDuration = if (actionLabel == null) {
             SnackbarDuration.Short
         } else {
@@ -137,7 +138,8 @@ public class SnackbarHostState {
             style = style,
             intent = intent,
             actionLabel = actionLabel,
-            isDismissIconEnabled = isDismissIconEnabled,
+            withDismissAction = withDismissAction,
+            actionOnNewLine = actionOnNewLine,
             duration = duration,
         ),
     )

--- a/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarValid.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/snackbars/SnackbarValid.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023-2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.components.snackbars
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ *
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ *
+ * Snackbars inform users of a process that an app has performed or will perform. They appear
+ * temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience,
+ * and they don’t require user input to disappear.
+ *
+ * A Snackbar can contain a single action. Because Snackbar disappears automatically, the action
+ * shouldn't be "Dismiss" or "Cancel".
+ *
+ * If you want to customize appearance of the [Snackbar], you can pass your own version as a child
+ * of the [SnackbarHost] to the [Scaffold]
+ *
+ * If you want to change dynamically the snackbar color look at [Snackbar].
+ *
+ * @param modifier modifiers for the Snackbar layout
+ * @param actionOnNewLine whether or not action should be put on the separate line. Recommended
+ * for action with long action text
+ * @param icon icon to be shown on the start side of the content when there's no title.
+ * @param title title to be shown above the [content], currently the SnackBarHost doesn't handle it so avoid using it
+ * @param actionLabel action to add as an action to the snackbar.
+ * @param onActionClick callback when the action is clicked.
+ * @param content content to show information about a process that an app has performed or will
+ * perform
+ */
+@Deprecated(
+    message = "Use Snackbar instead as we now support intents and changed the api for the icon for new specs",
+    replaceWith = ReplaceWith(
+        "Snackbar(intent = SnackbarIntent.Success, modifier = modifier, " +
+            "actionOnNewLine = actionOnNewLine, actionLabel = actionLabel," +
+            " onActionClick = onActionClick, content = content)",
+        "com.adevinta.spark.components.snackbars.Snackbar",
+    ),
+    level = DeprecationLevel.ERROR,
+)
+@Composable
+public fun SnackbarValid(
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    icon: @Composable ((iconModifier: Modifier) -> Unit)? = null,
+    title: String? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable (() -> Unit),
+) {
+    Snackbar(
+        intent = SnackbarIntent.Success,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+//        icon = icon,
+        actionLabel = actionLabel,
+        onActionClick = onActionClick,
+        content = content,
+    )
+}


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add previously remove api and add an Error deprecation on them with a `ReplaceWith` to ease migration.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Removal of these apis made upgrading from Spark 0.10.1 to 0.11.0 a nightmare as no instruction was available in the code to replace them.