### PR TITLE
chore(gha): add missing permissions for workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
 
   validation:


### PR DESCRIPTION
`security-event` is required for [github/codeql-action](https://github.com/github/codeql-action#permissions)
