### PR TITLE
fix(TextField): Revert change that made addons not centered

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
@@ -43,7 +43,6 @@ import com.adevinta.spark.catalog.themes.SegmentedButton
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonFilled
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonIcons
-import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.textfields.TextFieldState
@@ -63,7 +62,7 @@ public val TextFieldsConfigurator: Configurator = Configurator(
 
 @Composable
 private fun ColumnScope.TextFieldSample() {
-    var icon: SparkIcon? by remember { mutableStateOf(null) }
+    var icon: SparkIcon? by remember { mutableStateOf(SparkIcons.LikeFill) }
     var isReadOnly by remember { mutableStateOf(false) }
     var isEnabled by remember { mutableStateOf(true) }
     var isRequired by remember { mutableStateOf(true) }
@@ -86,7 +85,7 @@ private fun ColumnScope.TextFieldSample() {
         placeholder = placeHolderText,
         helper = helperText,
         leadingContent = addonText?.let { { Text(it) } },
-        trailingContent = icon?.let { { Icon(it, contentDescription = null) } },
+        trailingContent = icon?.let { { TextFieldIconButton(onClick = {}, icon = it, contentDescription = null) } },
         state = state,
         stateMessage = stateMessageText,
     )

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/textfields/TextfieldsExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/textfields/TextfieldsExamples.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2023-2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.examples.samples.textfields
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupProperties
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.model.Example
+import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.menu.DropdownMenuItem
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.SparkSelectTrailingIcon
+import com.adevinta.spark.components.textfields.TextField
+import com.adevinta.spark.icons.Booster
+import com.adevinta.spark.icons.EyeFill
+import com.adevinta.spark.icons.EyeOffFill
+import com.adevinta.spark.icons.QuestionOutline
+import com.adevinta.spark.icons.SparkIcons
+import kotlin.random.Random
+
+private const val TextFieldsExampleSourceUrl = "$SampleSourceUrl/DropdownExamples.kt"
+
+public val TextFieldsExamples: List<Example> = listOf(
+    Example(
+        name = "Default Addons",
+        description = "Sample of addons provided by Spark through the AddonScope api",
+        sourceUrl = TextFieldsExampleSourceUrl,
+    ) {
+        Addons()
+    },
+)
+
+@Composable
+private fun ColumnScope.Addons() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        TextFieldWithDropdown()
+        TextFieldWithButton()
+        TextFieldWithIcon()
+        TextFieldWithIconButton()
+        TextFieldWithIconToggleButton()
+        TextFieldWithPrefixSuffixButton()
+    }
+}
+
+@Composable
+private fun TextFieldWithDropdown() {
+    var expanded by remember { mutableStateOf(false) }
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = "+33 0123456789",
+        label = "Phone number - Dropdown addon",
+        onValueChange = {},
+        leadingContent = {
+            Dropdown(
+                modifier = Modifier,
+                expanded = expanded,
+                onExpandedChange = {
+                    expanded = !expanded
+                },
+                onDismissRequest = {
+                    expanded = false
+                },
+                properties = PopupProperties(),
+                dropdownLabel = {
+                    Canvas(
+                        modifier = Modifier.size(width = 24.dp, height = 14.dp),
+                    ) {
+                        drawRect(color = Color.Blue)
+                        drawRect(color = Color.White, topLeft = Offset(24.dp.toPx() / 3, 0f))
+                        drawRect(color = Color.Red, topLeft = Offset(24.dp.toPx() / 3 * 2, 0f))
+                    }
+                    Text(text = "FR", style = SparkTheme.typography.body1)
+                    SparkSelectTrailingIcon(expanded = expanded)
+                },
+            ) {
+                repeat(4) {
+                    DropdownMenuItem(
+                        onClick = {
+                            expanded = false
+                        },
+                        text = { Text(text = "Dropdown") },
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun TextFieldWithButton() {
+    var isLoading by remember { mutableStateOf(false) }
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = "AA-123-BB",
+        label = "Button addon",
+        onValueChange = {},
+        trailingContent = {
+            Button(
+                text = "Validate",
+                modifier = Modifier,
+                onClick = { isLoading = !isLoading },
+                isLoading = isLoading,
+            )
+        },
+    )
+}
+
+@Composable
+private fun TextFieldWithIcon() {
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = "AA-123-BB",
+        label = "Icon addon",
+        onValueChange = {},
+        trailingContent = {
+            TextFieldIcon(
+                icon = SparkIcons.QuestionOutline,
+                modifier = Modifier,
+                contentDescription = "",
+            )
+        },
+    )
+}
+
+@Composable
+private fun TextFieldWithIconButton() {
+    var value by remember {
+        mutableStateOf("AA-123-BB")
+    }
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = value,
+        label = "Icon button addon",
+        onValueChange = {},
+        trailingContent = {
+            TextFieldIconButton(
+                modifier = Modifier,
+                icon = SparkIcons.Booster,
+                contentDescription = "",
+                onClick = { value = Random.nextInt(0, 8000).toString() },
+            )
+        },
+    )
+}
+
+@Composable
+private fun TextFieldWithIconToggleButton() {
+    var checked by remember {
+        mutableStateOf(false)
+    }
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = "AA-123-BB",
+        label = "Icon toggle button addon",
+        onValueChange = {},
+        trailingContent = {
+            TextFieldIconToggleButton(
+                modifier = Modifier,
+                checked = checked,
+                checkedIcon = SparkIcons.EyeFill,
+                unCheckedIcon = SparkIcons.EyeOffFill,
+                contentDescription = "",
+                onCheckedChange = { checked = it },
+            )
+        },
+    )
+}
+
+@Composable
+private fun TextFieldWithPrefixSuffixButton() {
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = "www.adevinta.com",
+        label = "Url - Prefix/Suffix addon",
+        onValueChange = {},
+        leadingContent = {
+            TextFieldText(
+                text = "https://",
+            )
+        },
+        trailingContent = {
+            TextFieldText(
+                text = ".com",
+            )
+        },
+    )
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -60,6 +60,7 @@ import com.adevinta.spark.catalog.examples.samples.tabs.TabsExamples
 import com.adevinta.spark.catalog.examples.samples.tags.TagsExamples
 import com.adevinta.spark.catalog.examples.samples.text.DropdownsExamples
 import com.adevinta.spark.catalog.examples.samples.text.TextLinksExamples
+import com.adevinta.spark.catalog.examples.samples.textfields.TextFieldsExamples
 import com.adevinta.spark.catalog.examples.samples.toggles.CheckboxExamples
 import com.adevinta.spark.catalog.examples.samples.toggles.IconToggleButtonsExamples
 import com.adevinta.spark.catalog.examples.samples.toggles.RadioButtonExamples
@@ -312,19 +313,6 @@ private val ProgressTracker = Component(
     configurator = ProgressTrackerConfigurator,
 )
 
-private val TextLinks = Component(
-    id = nextId(),
-    name = "TextLinks",
-    description = R.string.component_textlink_description,
-    illustration = R.drawable.icon_textlink,
-    tintIcon = false,
-    guidelinesUrl = "$ComponentGuidelinesUrl/p/75ed11-textlink/b/403107",
-    docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.text/index.html",
-    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/text/TextLink.kt",
-    examples = TextLinksExamples,
-    configurator = TextLinksConfigurator,
-)
-
 private val Sliders = Component(
     id = nextId(),
     name = "Slider",
@@ -345,8 +333,21 @@ private val TextFields = Component(
     guidelinesUrl = "$ComponentGuidelinesUrl/p/773c60-input--text-field/b/0658e2",
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.textfields/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/textfields/TextField.kt",
-    examples = emptyList(),
+    examples = TextFieldsExamples,
     configurator = TextFieldsConfigurator,
+)
+
+private val TextLinks = Component(
+    id = nextId(),
+    name = "TextLinks",
+    description = R.string.component_textlink_description,
+    illustration = R.drawable.icon_textlink,
+    tintIcon = false,
+    guidelinesUrl = "$ComponentGuidelinesUrl/p/75ed11-textlink/b/403107",
+    docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.text/index.html",
+    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/text/TextLink.kt",
+    examples = TextLinksExamples,
+    configurator = TextLinksConfigurator,
 )
 
 private val Tokens = Component(

--- a/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldScreenshot.kt
+++ b/spark-screenshot-testing/src/test/kotlin/com/adevinta/spark/textfields/TextFieldScreenshot.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.DefaultTestDevices
+import com.adevinta.spark.ExperimentalSparkApi
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.textfields.AddonScope
 import com.adevinta.spark.components.textfields.TextField
@@ -147,6 +148,7 @@ internal class TextFieldScreenshot {
         }
     }
 
+    @OptIn(ExperimentalSparkApi::class)
     @Composable
     private fun TextFields(
         modifier: Modifier = Modifier,
@@ -157,7 +159,7 @@ internal class TextFieldScreenshot {
     ) {
         val leadingContent: (@Composable AddonScope.() -> Unit)? = icon?.let {
             @Composable {
-                Icon(icon, contentDescription = null)
+                TextFieldIconButton(icon = icon, contentDescription = null, onClick = {})
             }
         }
         val trailingContent: (@Composable AddonScope.() -> Unit)? = icon?.let {

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_bigValue.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_bigValue.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88727317c240b39748a11c26257940a21b405abaf2842355127cdc08cfe25ab5
-size 162545
+oid sha256:204e49d7ee83ec1b8a0c338ce3fb7b61af28e3c389a5e02b132a3e12faf7f6c3
+size 162945

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_showcase__dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_showcase__dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:892faac9b0b1d5be19d760dfb48e619c51eaf0c68e3dc078bb3919301fc4c0e1
-size 39121
+oid sha256:eafdcea86dd855a27cbcb327a46eb82eec70d2ecb0ea6b1c6d1065a91ecd757f
+size 39360

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_showcase__light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_showcase__light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93bee000cd4f6121ddc6b22585dbad3ade1fa016a28815534788b498f0f5292f
-size 37670
+oid sha256:df70ebf57fc98c2a30a5c692854072be6be92cca41f03335b7cccb042ed6af49
+size 37879

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_smallValue.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_MultilineTextFieldScreenshot_smallValue.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d61f53701b1e880563ce28463a10440bab917ce2097252e19e2d9ad2ca79203
-size 120145
+oid sha256:e7cace6f1f67481e60018d3184e90e4db2bcd95184df03a26989fa48d76f73f2
+size 120799

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_multilineTextFieldShowcase__dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_multilineTextFieldShowcase__dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf5ef4be034d06347180ce9a2136bbe582b0d4b38b7ae6bd1e46feade345a45b
-size 40487
+oid sha256:e69cdfcaaca4fe9a1d3bdc6843992199dbf9efd829fcee4df3732ea972286907
+size 40718

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_multilineTextFieldShowcase__light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_multilineTextFieldShowcase__light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9e91ee3d56bc6a2f695c24e0ca9b9fb5d5eadea247ed40bfdf05be11df754d7
-size 39062
+oid sha256:c88f82d680ca1658495d03e164d2221844a95ea165db202509794f3e4b57a082
+size 39259

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:856c1ce3f89a50d0f604a6fc2dbf586bb32ef8efe73c6d94b91e98040bd53b3b
-size 36013
+oid sha256:7471fda3eaff0aaf0ef89c3fdcf18345cb57bde2c5059e2442c4079d575fd868
+size 36198

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_selectTextFieldShowcase__light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e30ede2eecb82d27d5c67d6d6f08c3563ab82cfe4559f46cf3dfd4b111ca2b95
-size 34979
+oid sha256:e700025da845947e741914bcb4bbcbc0734226cc8452c39f4d7a7b31b65dd5be
+size 35127

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_textFieldShowcase__dark.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_textFieldShowcase__dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d580aa50efb826721ae1665fb91b1471e6ddc9c594b2b715193ea8bedb5da28
-size 37713
+oid sha256:9643662c28128accc131b525f77a66652e8aea91a0324eebd25ae846472f1d85
+size 37923

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_textFieldShowcase__light.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldDocScreenshot_textFieldShowcase__light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c02917ec1cb6a00a3a95cc03bc179231ea23875ec2a2f7da1ca4c70cf1839b7a
-size 36618
+oid sha256:334e61fa155fd5a84648f868c7aa1d9524205558592fb35edba3e717afcf2c48
+size 36814

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_bigValue.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_bigValue.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a27ced567fdd17e835f0cdcdf6ecf885f58907f1b2ae5650e90914efa648a60
-size 181299
+oid sha256:5adc9e6a330ea6ba6dd6b0f5626457e5288483afd33765c3c0af36657fa23aa1
+size 179922

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_disabled.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_disabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82db3fb460e54f3aacf58af7e7510b2f1f5d67fce66ea1876e378624143b50f7
-size 117802
+oid sha256:3d74235d599a80d4b9b8e7c6853056093b7b3a14dbebce62dfc26d2a0a722d70
+size 119019

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_enabled.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_enabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4cf3dbf35b58c4512b0983e9fff3fb77c8db8d26814cfa4c009185e8169d559
-size 130832
+oid sha256:a41c8f1f12976c666a34ba8d92a9ae90d18bb3c998306da7a1fdb4e04f9ea412
+size 130943

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_smallValue.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark.textfields_TextFieldScreenshot_smallValue.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43aefb94e3d08a8b00313c516ff1f0aa8b5346d569e832ae324ed0ff19bfb3db
-size 159800
+oid sha256:e3fd209437a4a392471f31883f4cc9f26a3d080594fdf61133f26443478de142
+size 160666

--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_textfields_textfieldslots.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_textfields_textfieldslots.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:656f5646324f0c3c5cf8cccf89587494689e4c31ea6d343dd78d8631106f08b1
-size 24805
+oid sha256:cbb1b435ab71a4d3118ff9928f5fd8cb330997fcb9a25cb7f14d98422cd73710
+size 25149

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldImpl.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldImpl.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.lerp
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
@@ -215,7 +216,7 @@ internal fun SparkDecorationBox(
             Box(
                 Modifier
                     .layoutId(ContainerId)
-                    .outlineCutout(labelSize::value, contentPadding),
+                    .outlineCutout(labelSize::value, 16.dp),
                 propagateMinConstraints = true,
             ) {
                 border?.invoke()
@@ -416,13 +417,13 @@ internal fun Placeable?.hasWidthThenDefault(default: Int) = this?.width?.takeIf 
 internal fun heightOrZero(placeable: Placeable?) = placeable?.height ?: 0
 internal fun Placeable?.hasHeightThenDefault(default: Int) = this?.height?.takeIf { it > 0 }?.let { default } ?: 0
 
-internal fun Modifier.outlineCutout(labelSize: () -> Size, paddingValues: PaddingValues) =
+internal fun Modifier.outlineCutout(labelSize: () -> Size, leftPadding: Dp) =
     this.drawWithContent {
         val labelSizeValue = labelSize()
         val labelWidth = labelSizeValue.width
         if (labelWidth > 0f) {
             val innerPadding = OutlinedTextFieldInnerPadding.toPx()
-            val leftLtr = paddingValues.calculateLeftPadding(layoutDirection).toPx() - innerPadding
+            val leftLtr = leftPadding.toPx() - innerPadding
             val rightLtr = leftLtr + labelWidth + 2 * innerPadding
             val left = when (layoutDirection) {
                 LayoutDirection.Rtl -> size.width - rightLtr

--- a/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldMeasurePolicy.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/textfields/SparkTextFieldMeasurePolicy.kt
@@ -465,13 +465,21 @@ private fun Placeable.PlacementScope.place(
     // placed center vertically and to the start edge horizontally
     leadingPlaceable?.placeRelative(
         0,
-        calculateVerticalPosition(leadingPlaceable),
+        if (singleLine) {
+            Alignment.CenterVertically.align(leadingPlaceable.height, height)
+        } else {
+            topPadding
+        },
     )
 
     // placed center vertically and to the end edge horizontally
     trailingPlaceable?.placeRelative(
         width - trailingPlaceable.width,
-        calculateVerticalPosition(trailingPlaceable),
+        if (singleLine) {
+            Alignment.CenterVertically.align(trailingPlaceable.height, height)
+        } else {
+            topPadding
+        },
     )
 
     // label position is animated


### PR DESCRIPTION
# Testing
I've added a new example page in the catalog app to test that they now are centered and I've replaced the Icon addon used in the screenshot test by the

<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
The wrong padding was applied to the TextField label and when aligning vertically the Addons we used the same function for the Palceholdera nd the Label but this doesn't  work for the Addons, we should only center them without relying on their height.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Close #1243

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [ ] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->
![image](https://github.com/user-attachments/assets/ddab84b6-d12b-44b7-b421-da450e3af8de)

