### PR TITLE
fix(kotlin): specify Kotlin BoM version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,7 +99,7 @@ gradlePlugins-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradl
 
 junit = { module = "junit:junit", version.ref = "junit" }
 
-kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }


### PR DESCRIPTION
This should fix the issue on consumer side:

```
> Could not resolve com.adevinta.spark:spark:0.11.2.
   > Could not parse POM https://repo.maven.apache.org/maven2/com/adevinta/spark/spark/0.11.2/spark-0.11.2.pom
      > Required version must not be null
```
