### PR TITLE
refactor(catalog): Extract ButtonGroup composable for reusability and simplify it.

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -91,7 +91,6 @@ import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.google.accompanist.testharness.TestHarness
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun ComponentActivity.CatalogApp(
     theme: Theme,

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -26,7 +26,6 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
@@ -154,7 +153,6 @@ private fun ColumnScope.ButtonSample() {
         selectedOption = shape,
         onOptionSelect = { shape = it },
     )
-
 
     val intents = ButtonIntent.entries.toTypedArray()
     var expanded by remember { mutableStateOf(false) }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
@@ -24,11 +24,9 @@ package com.adevinta.spark.catalog.configurator.samples.buttons
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,10 +36,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonContrast
 import com.adevinta.spark.components.buttons.ButtonFilled
@@ -64,6 +64,7 @@ import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.LikeOutline
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.tokens.highlight
 
 public val ButtonsConfigurator: Configurator = Configurator(
     name = "Button",
@@ -105,10 +106,8 @@ private fun ColumnScope.ButtonSample() {
     ) {
         Text(
             text = "With Icon",
-            modifier = Modifier
-                .weight(1f)
-                .padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.weight(1f),
+            style = SparkTheme.typography.body2.highlight,
         )
         IconToggleButtonFilled(
             checked = icon != null,
@@ -140,55 +139,22 @@ private fun ColumnScope.ButtonSample() {
         )
     }
 
-    Column {
-        Text(
-            text = "Icon side",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val iconsSidesLabel = IconSide.entries.map(IconSide::name)
-        SegmentedButton(
-            options = iconsSidesLabel,
-            selectedOption = iconSide.name,
-            onOptionSelect = { iconSide = IconSide.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
-    Column {
-        Text(
-            text = "Style",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonStylesLabel = ButtonStyle.entries.map(ButtonStyle::name)
-        SegmentedButton(
-            options = buttonStylesLabel,
-            selectedOption = style.name,
-            onOptionSelect = { style = ButtonStyle.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Icon side",
+        selectedOption = iconSide,
+        onOptionSelect = { iconSide = it },
+    )
+    ButtonGroup(
+        title = "Style",
+        selectedOption = style,
+        onOptionSelect = { style = it },
+    )
+    ButtonGroup(
+        title = "Shape",
+        selectedOption = shape,
+        onOptionSelect = { shape = it },
+    )
 
-    Column {
-        Text(
-            text = "Shape",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonShapesLabel = ButtonShape.entries.map(ButtonShape::name)
-        SegmentedButton(
-            options = buttonShapesLabel,
-            selectedOption = shape.name,
-            onOptionSelect = { shape = ButtonShape.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
 
     val intents = ButtonIntent.entries.toTypedArray()
     var expanded by remember { mutableStateOf(false) }
@@ -216,22 +182,11 @@ private fun ColumnScope.ButtonSample() {
         },
     )
 
-    Column {
-        Text(
-            text = "Button size",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val sizesLabel = ButtonSize.entries.map(ButtonSize::name)
-        SegmentedButton(
-            options = sizesLabel,
-            selectedOption = size.name,
-            onOptionSelect = { size = ButtonSize.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Button size",
+        selectedOption = size,
+        onOptionSelect = { size = it },
+    )
 
     TextField(
         modifier = Modifier.fillMaxWidth(),
@@ -242,6 +197,12 @@ private fun ColumnScope.ButtonSample() {
         label = "Button text",
         placeholder = "Vérifier les Disponibilité",
     )
+}
+
+@Preview
+@Composable
+private fun ButtonSamplePreview() {
+    PreviewTheme { ButtonSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconButtonsConfigurator.kt
@@ -23,10 +23,8 @@ package com.adevinta.spark.catalog.configurator.samples.buttons
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,11 +33,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonShape
 import com.adevinta.spark.components.iconbuttons.IconButtonContrast
@@ -110,22 +109,11 @@ private fun ColumnScope.IconButtonSample() {
         )
     }
 
-    Column {
-        Text(
-            text = "Style",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonStylesLabel = IconButtonStyle.entries.map(IconButtonStyle::name)
-        SegmentedButton(
-            options = buttonStylesLabel,
-            selectedOption = style.name,
-            onOptionSelect = { style = IconButtonStyle.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Style",
+        selectedOption = style,
+        onOptionSelect = { style = it },
+    )
 
     val intents = IconButtonIntent.entries
     var expanded by remember { mutableStateOf(false) }
@@ -153,38 +141,16 @@ private fun ColumnScope.IconButtonSample() {
         },
     )
 
-    Column {
-        Text(
-            text = "Shape",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonShapesLabel = ButtonShape.entries.map(ButtonShape::name)
-        SegmentedButton(
-            options = buttonShapesLabel,
-            selectedOption = shape.name,
-            onOptionSelect = { shape = ButtonShape.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
-    Column {
-        Text(
-            text = "Size",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonSizesLabel = IconButtonSize.entries.map(IconButtonSize::name)
-        SegmentedButton(
-            options = buttonSizesLabel,
-            selectedOption = size.name,
-            onOptionSelect = { size = IconButtonSize.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Shape",
+        selectedOption = shape,
+        onOptionSelect = { shape = it },
+    )
+    ButtonGroup(
+        title = "Size",
+        selectedOption = size,
+        onOptionSelect = { size = it },
+    )
 
     TextField(
         modifier = Modifier.fillMaxWidth(),
@@ -195,6 +161,12 @@ private fun ColumnScope.IconButtonSample() {
         label = "Content Description",
         placeholder = "Content Description",
     )
+}
+
+@Preview
+@Composable
+private fun IconButtonSamplePreview() {
+    PreviewTheme { IconButtonSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconToggleButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/IconToggleButtonsConfigurator.kt
@@ -23,10 +23,8 @@ package com.adevinta.spark.catalog.configurator.samples.buttons
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,11 +33,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonShape
 import com.adevinta.spark.components.iconbuttons.IconButtonIntent
@@ -101,22 +100,11 @@ private fun ColumnScope.IconToggleButtonSample() {
         )
     }
 
-    Column {
-        Text(
-            text = "Style",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonStylesLabel = IconToggleButtonStyle.entries.map { it.name }
-        SegmentedButton(
-            options = buttonStylesLabel,
-            selectedOption = style.name,
-            onOptionSelect = { style = IconToggleButtonStyle.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Style",
+        selectedOption = style,
+        onOptionSelect = { style = it },
+    )
 
     var expanded by remember { mutableStateOf(false) }
     Dropdown(
@@ -143,38 +131,16 @@ private fun ColumnScope.IconToggleButtonSample() {
         },
     )
 
-    Column {
-        Text(
-            text = "Shape",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonShapesLabel = ButtonShape.entries.map { it.name }
-        SegmentedButton(
-            options = buttonShapesLabel,
-            selectedOption = shape.name,
-            onOptionSelect = { shape = ButtonShape.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
-    Column {
-        Text(
-            text = "Size",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val buttonSizesLabel = IconButtonSize.entries.map { it.name }
-        SegmentedButton(
-            options = buttonSizesLabel,
-            selectedOption = size.name,
-            onOptionSelect = { size = IconButtonSize.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Shape",
+        selectedOption = shape,
+        onOptionSelect = { shape = it },
+    )
+    ButtonGroup(
+        title = "Size",
+        selectedOption = size,
+        onOptionSelect = { size = it },
+    )
 
     TextField(
         modifier = Modifier.fillMaxWidth(),
@@ -185,6 +151,12 @@ private fun ColumnScope.IconToggleButtonSample() {
         label = "Content Description",
         placeholder = "Content Description",
     )
+}
+
+@Preview
+@Composable
+private fun IconToggleButtonSamplePreview() {
+    PreviewTheme { IconToggleButtonSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/chips/ChipsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/chips/ChipsConfigurator.kt
@@ -22,12 +22,9 @@
 package com.adevinta.spark.catalog.configurator.samples.chips
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,10 +32,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.chips.ChipIntent
 import com.adevinta.spark.components.chips.ChipSelectable
@@ -92,9 +91,7 @@ private fun ColumnScope.ChipSample() {
     ) {
         Text(
             text = "With Icon",
-            modifier = Modifier
-                .weight(1f)
-                .padding(bottom = 8.dp),
+            modifier = Modifier.weight(1f),
             style = SparkTheme.typography.body2.highlight,
         )
         FilledTonalIconToggleButton(
@@ -110,23 +107,11 @@ private fun ColumnScope.ChipSample() {
         }
     }
 
-    Column {
-        Text(
-            text = "Style",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.highlight,
-        )
-        val tagStyles = ChipStyles.entries
-        val tagStylesLabel = tagStyles.map { it.name }
-        SegmentedButton(
-            options = tagStylesLabel,
-            selectedOption = style.name,
-            onOptionSelect = { style = ChipStyles.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Style",
+        selectedOption = style,
+        onOptionSelect = { style = it },
+    )
 
     val intents = ChipIntent.entries
     var expanded by remember { mutableStateOf(false) }
@@ -177,6 +162,12 @@ private fun ColumnScope.ChipSample() {
         label = "Chip text",
         placeholder = "jane.doe@email.com",
     )
+}
+
+@Preview
+@Composable
+private fun ChipSamplePreview() {
+    PreviewTheme { ChipSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/divider/DivivderConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/divider/DivivderConfigurator.kt
@@ -21,10 +21,9 @@
  */
 package com.adevinta.spark.catalog.configurator.samples.divider
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -37,7 +36,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.divider.DividerIntent
 import com.adevinta.spark.components.divider.HorizontalDivider
@@ -47,7 +47,6 @@ import com.adevinta.spark.components.divider.VerticalDivider
 import com.adevinta.spark.components.spacer.VerticalSpacer
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.TextField
-import com.adevinta.spark.tokens.highlight
 
 public val DividerConfigurator: Configurator = Configurator(
     name = "Divider",
@@ -57,109 +56,71 @@ public val DividerConfigurator: Configurator = Configurator(
     DividerSample()
 }
 
-@Preview(
-    showBackground = true,
-)
+
 @Composable
-private fun DividerSample() {
-    Column {
-        var intent by remember { mutableStateOf(DividerIntent.Outline) }
-        var hLabelAlignments by remember { mutableStateOf(LabelHorizontalAlignment.Center) }
-        var vLabelAlignments by remember { mutableStateOf(LabelVerticalAlignment.Center) }
-        var labelText by remember { mutableStateOf("label") }
+private fun ColumnScope.DividerSample() {
+    var intent by remember { mutableStateOf(DividerIntent.Outline) }
+    var hLabelAlignments by remember { mutableStateOf(LabelHorizontalAlignment.Center) }
+    var vLabelAlignments by remember { mutableStateOf(LabelVerticalAlignment.Center) }
+    var labelText by remember { mutableStateOf("label") }
 
-        Column {
-            Text(
-                text = "Divider Intent",
-                modifier = Modifier.padding(bottom = 8.dp),
-                style = SparkTheme.typography.body2.highlight,
-            )
-            val dividerIntents = DividerIntent.entries.map(DividerIntent::name)
-            SegmentedButton(
-                options = dividerIntents,
-                selectedOption = intent.name,
-                onOptionSelect = { intent = DividerIntent.valueOf(it) },
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        VerticalSpacer(8.dp)
+    ButtonGroup(
+        title = "Divider Intent",
+        selectedOption = intent,
+        onOptionSelect = { intent = it },
+    )
 
-        Text(
-            text = "HorizontalDivider",
-            style = SparkTheme.typography.headline2,
-        )
+    Text(
+        text = "HorizontalDivider",
+        style = SparkTheme.typography.headline2,
+    )
 
-        HorizontalDivider(
-            intent = intent,
-            label = if (labelText.isEmpty()) {
-                null
-            } else {
-                { TextComposable(label = labelText) }
-            },
-            labelHorizontalAlignment = hLabelAlignments,
-        )
-        VerticalSpacer(8.dp)
+    HorizontalDivider(
+        intent = intent,
+        label = labelText.takeUnless { it.isBlank() }?.let { { TextComposable(label = it) } },
+        labelHorizontalAlignment = hLabelAlignments,
+    )
 
-        Text(
-            text = "VerticalDivider",
-            style = SparkTheme.typography.headline2,
-        )
+    Text(
+        text = "VerticalDivider",
+        style = SparkTheme.typography.headline2,
+    )
 
-        VerticalDivider(
-            modifier = Modifier
-                .height(200.dp)
-                .fillMaxWidth(),
-            intent = intent,
-            label = if (labelText.isEmpty()) {
-                null
-            } else {
-                {
-                    TextComposable(label = labelText)
-                }
-            },
-            labelVerticalAlignment = vLabelAlignments,
-        )
+    VerticalDivider(
+        modifier = Modifier
+            .height(200.dp)
+            .fillMaxWidth(),
+        intent = intent,
+        label = labelText.takeUnless { it.isBlank() }?.let { { TextComposable(label = it) } },
+        labelVerticalAlignment = vLabelAlignments,
+    )
 
-        Column {
-            Text(
-                text = "HorizontalDivider Label Alignment",
-                modifier = Modifier.padding(bottom = 8.dp),
-                style = SparkTheme.typography.body2.highlight,
-            )
-            val labelAlignments = LabelHorizontalAlignment.entries.map(LabelHorizontalAlignment::name)
-            SegmentedButton(
-                options = labelAlignments,
-                selectedOption = hLabelAlignments.name,
-                onOptionSelect = { hLabelAlignments = LabelHorizontalAlignment.valueOf(it) },
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        VerticalSpacer(8.dp)
+    ButtonGroup(
+        title = "HorizontalDivider Label Alignment",
+        selectedOption = hLabelAlignments,
+        onOptionSelect = { hLabelAlignments = it },
+    )
 
-        Column {
-            Text(
-                text = "VerticalDivider Label Alignment",
-                modifier = Modifier.padding(bottom = 8.dp),
-                style = SparkTheme.typography.body2.highlight,
-            )
-            val labelAlignments = LabelVerticalAlignment.entries.map(LabelVerticalAlignment::name)
-            SegmentedButton(
-                options = labelAlignments,
-                selectedOption = vLabelAlignments.name,
-                onOptionSelect = { vLabelAlignments = LabelVerticalAlignment.valueOf(it) },
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
+    ButtonGroup(
+        title = "VerticalDivider Label Alignment",
+        selectedOption = vLabelAlignments,
+        onOptionSelect = { vLabelAlignments = it },
+    )
 
-        VerticalSpacer(8.dp)
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = labelText,
+        onValueChange = { labelText = it },
+        label = "Change label",
+        helper = "Divider label",
+    )
+}
 
-        TextField(
-            modifier = Modifier.fillMaxWidth(),
-            value = labelText,
-            onValueChange = { labelText = it },
-            label = "Change label",
-            helper = "Divider label",
-        )
+@Composable
+@Preview
+private fun DividerSamplePreview() {
+    PreviewTheme {
+        DividerSample()
     }
 }
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/divider/DivivderConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/divider/DivivderConfigurator.kt
@@ -44,7 +44,6 @@ import com.adevinta.spark.components.divider.HorizontalDivider
 import com.adevinta.spark.components.divider.LabelHorizontalAlignment
 import com.adevinta.spark.components.divider.LabelVerticalAlignment
 import com.adevinta.spark.components.divider.VerticalDivider
-import com.adevinta.spark.components.spacer.VerticalSpacer
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.components.textfields.TextField
 
@@ -55,7 +54,6 @@ public val DividerConfigurator: Configurator = Configurator(
 ) {
     DividerSample()
 }
-
 
 @Composable
 private fun ColumnScope.DividerSample() {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/popover/PopoverConfigurator.kt
@@ -26,8 +26,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -42,11 +40,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonOutlined
 import com.adevinta.spark.components.iconbuttons.IconButtonFilled
@@ -122,25 +121,11 @@ private fun ColumnScope.PopoverSample() {
             }
         },
     )
-    Column {
-        Text(
-            text = "Popover Anchor",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val triggerExamples = PopoverTriggerExamples.entries.toTypedArray()
-        val contentSidesLabel = triggerExamples.map { it.name }
-        SegmentedButton(
-            options = contentSidesLabel,
-            selectedOption = popoverTriggerExample.name,
-            onOptionSelect = {
-                popoverTriggerExample = PopoverTriggerExamples.valueOf(it)
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Popover Anchor",
+        selectedOption = popoverTriggerExample,
+        onOptionSelect = { popoverTriggerExample = it },
+    )
 
     val intents = PopoverIntent.entries
     var intentExpanded by remember { mutableStateOf(false) }
@@ -163,6 +148,12 @@ private fun ColumnScope.PopoverSample() {
             }
         },
     )
+}
+
+@Preview
+@Composable
+private fun PopOverSamplePreview() {
+    PreviewTheme { PopoverSample() }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progressbar/ProgressbarConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progressbar/ProgressbarConfigurator.kt
@@ -33,9 +33,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.progressbar.Progressbar
@@ -145,4 +147,10 @@ private fun ColumnScope.ProgressbarSample() {
         enabled = true,
         steps = 7,
     )
+}
+
+@Preview
+@Composable
+private fun ProgressbarSamplePreview() {
+    PreviewTheme { ProgressbarSample() }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progresstracker/ProgressTrackerConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/progresstracker/ProgressTrackerConfigurator.kt
@@ -41,7 +41,8 @@ import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonIntent
 import com.adevinta.spark.components.buttons.ButtonTinted
@@ -70,9 +71,6 @@ public val ProgressTrackerConfigurator: Configurator = Configurator(
     ProgressTrackerSample()
 }
 
-@Preview(
-    showBackground = true,
-)
 @Composable
 private fun ColumnScope.ProgressTrackerSample() {
     var intent by remember { mutableStateOf(ProgressTrackerIntent.Basic) }
@@ -157,35 +155,17 @@ private fun ColumnScope.ProgressTrackerSample() {
         )
     }
 
-    Column {
-        Text(
-            text = "Style",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.highlight,
-        )
-        val progressStylesLabel = ProgressStyles.entries.map(ProgressStyles::name)
-        SegmentedButton(
-            options = progressStylesLabel,
-            selectedOption = style.name,
-            onOptionSelect = { style = ProgressStyles.valueOf(it) },
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
+    ButtonGroup(
+        title = "Style",
+        selectedOption = style,
+        onOptionSelect = { style = it },
+    )
 
-    Column {
-        Text(
-            text = "Sizes",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.highlight,
-        )
-        val progressSizesLabel = ProgressSizes.entries.map(ProgressSizes::name)
-        SegmentedButton(
-            options = progressSizesLabel,
-            selectedOption = size.name,
-            onOptionSelect = { size = ProgressSizes.valueOf(it) },
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
+    ButtonGroup(
+        title = "Sizes",
+        selectedOption = size,
+        onOptionSelect = { size = it },
+    )
 
     Column {
         Text(
@@ -246,4 +226,10 @@ private fun ColumnScope.ProgressTrackerSample() {
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun ProgressTrackerSamplePreview() {
+    PreviewTheme { ProgressTrackerSample() }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/rating/RatingConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/rating/RatingConfigurator.kt
@@ -36,11 +36,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.rating.RatingDefault
 import com.adevinta.spark.components.rating.RatingDisplay
@@ -73,23 +75,11 @@ private fun ColumnScope.RatingSample() {
         enabled = enabled,
     )
 
-    Column {
-        Text(
-            text = "Size",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.highlight,
-        )
-        val ratingSizes = RatingSize.entries
-        val ratingSizesLabel = ratingSizes.map { it.name }
-        SegmentedButton(
-            options = ratingSizesLabel,
-            selectedOption = size.name,
-            onOptionSelect = { size = RatingSize.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Sizes",
+        selectedOption = size,
+        onOptionSelect = { size = it },
+    )
 
     SwitchLabelled(
         checked = enabled,
@@ -118,6 +108,12 @@ private fun ColumnScope.RatingSample() {
             valueRange = 0.5f..5f,
         )
     }
+}
+
+@Preview
+@Composable
+private fun RatingSamplePreview() {
+    PreviewTheme { RatingSample() }
 }
 
 private enum class RatingSize(val size: Dp) {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/rating/RatingConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/rating/RatingConfigurator.kt
@@ -25,7 +25,6 @@ import androidx.annotation.FloatRange
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeGesturesPadding
 import androidx.compose.runtime.Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/slider/SliderConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/slider/SliderConfigurator.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.sp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.iconbuttons.IconButtonFilled
 import com.adevinta.spark.components.menu.DropdownMenuItem
@@ -56,6 +57,7 @@ import com.adevinta.spark.components.toggles.SwitchLabelled
 import com.adevinta.spark.icons.Minus
 import com.adevinta.spark.icons.Plus
 import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.tokens.highlight
 
 public val SlidersConfigurator: Configurator = Configurator(
     name = "Slider",
@@ -65,7 +67,6 @@ public val SlidersConfigurator: Configurator = Configurator(
     SliderSample()
 }
 
-@Preview(showBackground = true)
 @Composable
 private fun SliderSample() {
     var enabled by remember { mutableStateOf(true) }
@@ -128,7 +129,7 @@ private fun SliderSample() {
             Text(
                 text = "Number of Slider Steps",
                 modifier = Modifier.padding(bottom = 8.dp),
-                style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+                style = SparkTheme.typography.body2.highlight,
             )
             Row(
                 modifier = Modifier.padding(horizontal = 16.dp),
@@ -180,4 +181,10 @@ private fun SliderSample() {
             },
         )
     }
+}
+
+@Preview
+@Composable
+private fun SliderSamplePreview() {
+    PreviewTheme { SliderSample() }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarConfigurator.kt
@@ -21,10 +21,8 @@
  */
 package com.adevinta.spark.catalog.configurator.samples.snackbar
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -34,10 +32,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonSize
 import com.adevinta.spark.components.buttons.ButtonTinted
@@ -131,22 +130,12 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
             modifier = Modifier.fillMaxWidth(),
         )
     }
-    Text(
-        text = "Snackbar Style",
-        modifier = Modifier.fillMaxWidth(),
-    )
 
-    Column {
-        val snackBarStyle = SnackbarStyle.entries.map(SnackbarStyle::name)
-        SegmentedButton(
-            options = snackBarStyle,
-            selectedOption = style.name,
-            onOptionSelect = { style = SnackbarStyle.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Style",
+        selectedOption = style,
+        onOptionSelect = { style = it },
+    )
     Snackbar(
         intent = intent,
         withDismissAction = withDismissAction,
@@ -158,22 +147,25 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
         Text(contentText)
     }
 
-    ButtonTinted(modifier = Modifier.fillMaxWidth(), size = ButtonSize.Medium, onClick = {
-        scope.launch {
-            snackbarHostState.showSnackbar(
-                SnackbarSparkVisuals(
-                    intent = intent,
-                    withDismissAction = withDismissAction,
-                    actionOnNewLine = actionOnNewLine,
-                    style = style,
-                    icon = if (isIconEnabled) SparkIcons.FlashlightFill else null,
-                    actionLabel = actionText,
-                    message = contentText,
-                    duration = SnackbarDuration.Short,
-                ),
-            )
-        }
-    }) {
+    ButtonTinted(
+        modifier = Modifier.fillMaxWidth(), size = ButtonSize.Medium,
+        onClick = {
+            scope.launch {
+                snackbarHostState.showSnackbar(
+                    SnackbarSparkVisuals(
+                        intent = intent,
+                        withDismissAction = withDismissAction,
+                        actionOnNewLine = actionOnNewLine,
+                        style = style,
+                        icon = if (isIconEnabled) SparkIcons.FlashlightFill else null,
+                        actionLabel = actionText,
+                        message = contentText,
+                        duration = SnackbarDuration.Short,
+                    ),
+                )
+            }
+        },
+    ) {
         Text("Launch Snackbar")
     }
 
@@ -191,4 +183,10 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
         label = "Change Text Content",
         stateMessage = contentText,
     )
+}
+
+@Preview
+@Composable
+private fun SnackbarSamplePreview() {
+    PreviewTheme { SnackbarSample(SnackbarHostState()) }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/snackbar/SnackbarConfigurator.kt
@@ -148,7 +148,8 @@ private fun ColumnScope.SnackbarSample(snackbarHostState: SnackbarHostState) {
     }
 
     ButtonTinted(
-        modifier = Modifier.fillMaxWidth(), size = ButtonSize.Medium,
+        modifier = Modifier.fillMaxWidth(),
+        size = ButtonSize.Medium,
         onClick = {
             scope.launch {
                 snackbarHostState.showSnackbar(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,10 +36,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.badge.Badge
 import com.adevinta.spark.components.iconbuttons.IconButtonFilled
@@ -57,6 +58,7 @@ import com.adevinta.spark.icons.Minus
 import com.adevinta.spark.icons.Plus
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tokens.bodyWidth
+import com.adevinta.spark.tokens.highlight
 import kotlin.random.Random
 
 public val TabsConfigurator: Configurator = Configurator(
@@ -149,28 +151,16 @@ private fun ColumnScope.TabSample() {
         },
     )
 
-    Column {
-        Text(
-            text = "Tab size",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val sizes = TabSize.entries.toTypedArray()
-        val sizesLabel = sizes.map { it.name }
-        SegmentedButton(
-            options = sizesLabel,
-            selectedOption = tabSize.name,
-            onOptionSelect = { tabSize = TabSize.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Sizes",
+        selectedOption = tabSize,
+        onOptionSelect = { tabSize = it },
+    )
     Column {
         Text(
             text = "Number of tabs",
             modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            style = SparkTheme.typography.body2.highlight,
         )
         Row {
             Spacer(modifier = Modifier.padding(start = 16.dp))
@@ -178,7 +168,7 @@ private fun ColumnScope.TabSample() {
                 icon = SparkIcons.Minus,
                 onClick = {
                     if (tabs.size > 1) {
-                        tabs.removeLast()
+                        tabs.removeAt(tabs.lastIndex)
                     }
                 },
             )
@@ -193,4 +183,10 @@ private fun ColumnScope.TabSample() {
             )
         }
     }
+}
+
+@Preview
+@Composable
+private fun TabSamplePreview() {
+    PreviewTheme { TabSample() }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tabs/TabsConfigurator.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tags/TagsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/tags/TagsConfigurator.kt
@@ -23,11 +23,9 @@ package com.adevinta.spark.catalog.configurator.samples.tags
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,11 +34,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.icons.FilledTonalIconToggleButton
 import com.adevinta.spark.components.icons.Icon
@@ -56,6 +55,7 @@ import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.tokens.highlight
 
 public val TagsConfigurator: Configurator = Configurator(
     name = "Tag",
@@ -87,10 +87,8 @@ private fun ColumnScope.TagSample() {
     ) {
         Text(
             text = "With Icon",
-            modifier = Modifier
-                .weight(1f)
-                .padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.weight(1f),
+            style = SparkTheme.typography.body2.highlight,
         )
         FilledTonalIconToggleButton(
             checked = icon != null,
@@ -105,23 +103,11 @@ private fun ColumnScope.TagSample() {
         }
     }
 
-    Column {
-        Text(
-            text = "Style",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val tagStyles = TagStyle.entries
-        val tagStylesLabel = tagStyles.map { it.name }
-        SegmentedButton(
-            options = tagStylesLabel,
-            selectedOption = style.name,
-            onOptionSelect = { style = TagStyle.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Style",
+        selectedOption = style,
+        onOptionSelect = { style = it },
+    )
 
     val intents = TagIntent.entries
     var expanded by remember { mutableStateOf(false) }
@@ -156,6 +142,12 @@ private fun ColumnScope.TagSample() {
         label = "Tag text",
         placeholder = "Vérifier les Disponibilité",
     )
+}
+
+@Preview
+@Composable
+private fun TagSamplePreview() {
+    PreviewTheme { TagSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/text/TextLinkConfigurator.kt
@@ -21,11 +21,8 @@
  */
 package com.adevinta.spark.catalog.configurator.samples.text
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,12 +32,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.buttons.ButtonIntent
 import com.adevinta.spark.components.buttons.IconSide
@@ -123,23 +121,11 @@ private fun ColumnScope.TextLinkSample(snackbarHostState: SnackbarHostState) {
         )
     }
 
-    Column {
-        Text(
-            text = "Icon Alignment",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val iconSides = IconSide.entries.toTypedArray()
-        val iconSideLabel = iconSides.map { it.name }
-        SegmentedButton(
-            options = iconSideLabel,
-            selectedOption = iconSide.name,
-            onOptionSelect = { iconSide = IconSide.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = "Icon side",
+        selectedOption = iconSide,
+        onOptionSelect = { iconSide = it },
+    )
 
     Dropdown(
         modifier = Modifier.fillMaxWidth(),
@@ -160,4 +146,10 @@ private fun ColumnScope.TextLinkSample(snackbarHostState: SnackbarHostState) {
             }
         },
     )
+}
+
+@Preview
+@Composable
+private fun TextLinkSamplePreview() {
+    PreviewTheme { TextLinkSample(SnackbarHostState()) }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
@@ -21,21 +21,18 @@
  */
 package com.adevinta.spark.catalog.configurator.samples.textfields
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.adevinta.spark.SparkTheme
+import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
@@ -44,7 +41,6 @@ import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.textfields.TextFieldState
 import com.adevinta.spark.components.toggles.SwitchLabelled
-import com.adevinta.spark.tokens.highlight
 
 public val ComboBoxConfigurator: Configurator = Configurator(
     name = "ComboBox",
@@ -125,24 +121,15 @@ private fun ColumnScope.ComboBoxSample() {
         )
     }
 
-    Column {
-        Text(
-            text = "State",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.highlight,
-        )
-        val textFieldStates: MutableSet<TextFieldState?> =
-            TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
-        val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
-        SegmentedButton(
-            options = buttonStylesLabel,
-            selectedOption = state?.name ?: "Default",
-            onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    val textFieldStates: MutableSet<TextFieldState?> =
+        TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
+    val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
+    ButtonGroup(
+        title = "State",
+        selectedOption = state?.name ?: "Default",
+        onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
+        options = buttonStylesLabel,
+    )
 
     TextField(
         modifier = Modifier.fillMaxWidth(),
@@ -189,4 +176,10 @@ private fun ColumnScope.ComboBoxSample() {
         label = "Prefix",
         placeholder = "State message of the ComboBox",
     )
+}
+
+@Preview
+@Composable
+private fun ComboBoxSamplePreview() {
+    PreviewTheme { ComboBoxSample() }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
@@ -22,11 +22,8 @@
 package com.adevinta.spark.catalog.configurator.samples.textfields
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,10 +31,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.unit.dp
-import com.adevinta.spark.SparkTheme
+import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.menu.DropdownMenuGroupItem
 import com.adevinta.spark.components.menu.DropdownMenuItem
@@ -47,7 +44,6 @@ import com.adevinta.spark.components.textfields.Dropdown
 import com.adevinta.spark.components.textfields.TextField
 import com.adevinta.spark.components.textfields.TextFieldState
 import com.adevinta.spark.components.toggles.SwitchLabelled
-import com.adevinta.spark.tokens.highlight
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -153,24 +149,15 @@ private fun ColumnScope.DropdownSample() {
         )
     }
 
-    Column {
-        Text(
-            text = "State",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.highlight,
-        )
-        val textFieldStates: MutableSet<TextFieldState?> =
-            TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
-        val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
-        SegmentedButton(
-            options = buttonStylesLabel,
-            selectedOption = state?.name ?: "Default",
-            onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    val textFieldStates: MutableSet<TextFieldState?> =
+        TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
+    val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
+    ButtonGroup(
+        title = "State",
+        selectedOption = state?.name ?: "Default",
+        onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
+        options = buttonStylesLabel,
+    )
 
     TextField(
         modifier = Modifier.fillMaxWidth(),
@@ -217,6 +204,12 @@ private fun ColumnScope.DropdownSample() {
         label = "Prefix",
         placeholder = "State message of the Dropdown",
     )
+}
+
+@Preview
+@Composable
+private fun DropdownSamplePreview() {
+    PreviewTheme { DropdownSample() }
 }
 
 private data class DropdownExampleGroup(val name: String, val books: ImmutableList<String>)

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/TextFieldsConfigurator.kt
@@ -22,12 +22,9 @@
 package com.adevinta.spark.catalog.configurator.samples.textfields
 
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,10 +33,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonFilled
 import com.adevinta.spark.components.iconbuttons.toggle.IconToggleButtonIcons
@@ -52,6 +51,7 @@ import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.LikeOutline
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.tokens.highlight
 
 public val TextFieldsConfigurator: Configurator = Configurator(
     name = "TextFields",
@@ -97,10 +97,8 @@ private fun ColumnScope.TextFieldSample() {
     ) {
         Text(
             text = "With Icon",
-            modifier = Modifier
-                .weight(1f)
-                .padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.weight(1f),
+            style = SparkTheme.typography.body2.highlight,
         )
         IconToggleButtonFilled(
             checked = icon != null,
@@ -141,24 +139,15 @@ private fun ColumnScope.TextFieldSample() {
         )
     }
 
-    Column {
-        Text(
-            text = "State",
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val textFieldStates: MutableSet<TextFieldState?> =
-            TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
-        val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
-        SegmentedButton(
-            options = buttonStylesLabel,
-            selectedOption = state?.name ?: "Default",
-            onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    val textFieldStates: MutableSet<TextFieldState?> =
+        TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
+    val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
+    ButtonGroup(
+        title = "State",
+        selectedOption = state?.name ?: "Default",
+        onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
+        options = buttonStylesLabel,
+    )
 
     TextField(
         modifier = Modifier.fillMaxWidth(),
@@ -205,4 +194,10 @@ private fun ColumnScope.TextFieldSample() {
         label = "Prefix",
         placeholder = "State message of the TextField",
     )
+}
+
+@Preview
+@Composable
+private fun TextFieldSamplePreview() {
+    PreviewTheme { TextFieldSample() }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/CheckboxConfigurator.kt
@@ -21,10 +21,7 @@
  */
 package com.adevinta.spark.catalog.configurator.samples.toggles
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,12 +30,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.state.ToggleableState
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import com.adevinta.spark.SparkTheme
+import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
@@ -91,24 +87,11 @@ private fun CheckboxSample() {
             modifier = Modifier.fillMaxWidth(),
         )
     }
-    Column {
-        Text(
-            text = stringResource(id = R.string.configurator_component_checkbox_toggleable_state_label),
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val toggleStateLabel = ToggleableState.entries.map(ToggleableState::name)
-        SegmentedButton(
-            options = toggleStateLabel,
-            selectedOption = state.name,
-            onOptionSelect = {
-                state = ToggleableState.valueOf(it)
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = stringResource(id = R.string.configurator_component_checkbox_toggleable_state_label),
+        selectedOption = state,
+        onOptionSelect = { state = it },
+    )
     var expanded by remember { mutableStateOf(false) }
     Dropdown(
         modifier = Modifier.fillMaxWidth(),
@@ -129,24 +112,11 @@ private fun CheckboxSample() {
             }
         },
     )
-    Column {
-        Text(
-            text = stringResource(id = R.string.configurator_component_toggle_content_side_label),
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val contentSidesLabel = ContentSide.entries.map(ContentSide::name)
-        SegmentedButton(
-            options = contentSidesLabel,
-            selectedOption = contentSide.name,
-            onOptionSelect = {
-                contentSide = ContentSide.valueOf(it)
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = stringResource(id = R.string.configurator_component_toggle_content_side_label),
+        selectedOption = contentSide,
+        onOptionSelect = { contentSide = it },
+    )
     TextField(
         modifier = Modifier.fillMaxWidth(),
         value = label.orEmpty(),
@@ -156,6 +126,12 @@ private fun CheckboxSample() {
         label = stringResource(id = R.string.configurator_component_screen_textfield_label),
         placeholder = stringResource(id = R.string.configurator_component_toggle_placeholder_label),
     )
+}
+
+@Preview
+@Composable
+private fun CheckboxSamplePreview() {
+    PreviewTheme { CheckboxSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/RadioButtonConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/RadioButtonConfigurator.kt
@@ -21,11 +21,8 @@
  */
 package com.adevinta.spark.catalog.configurator.samples.toggles
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,12 +30,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import com.adevinta.spark.SparkTheme
+import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
@@ -106,24 +102,11 @@ private fun ColumnScope.RadioButtonSample() {
             }
         },
     )
-    Column {
-        Text(
-            text = stringResource(id = R.string.configurator_component_toggle_content_side_label),
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val contentSidesLabel = ContentSide.entries.map(ContentSide::name)
-        SegmentedButton(
-            options = contentSidesLabel,
-            selectedOption = contentSide.name,
-            onOptionSelect = {
-                contentSide = ContentSide.valueOf(it)
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = stringResource(id = R.string.configurator_component_toggle_content_side_label),
+        selectedOption = contentSide,
+        onOptionSelect = { contentSide = it },
+    )
     TextField(
         modifier = Modifier.fillMaxWidth(),
         value = label.orEmpty(),
@@ -133,6 +116,12 @@ private fun ColumnScope.RadioButtonSample() {
         label = stringResource(id = R.string.configurator_component_screen_textfield_label),
         placeholder = stringResource(id = R.string.configurator_component_toggle_placeholder_label),
     )
+}
+
+@Preview
+@Composable
+private fun RadioButtonSamplePreview() {
+    PreviewTheme { RadioButtonSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/toggles/SwitchConfigurator.kt
@@ -21,11 +21,8 @@
  */
 package com.adevinta.spark.catalog.configurator.samples.toggles
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,12 +30,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import com.adevinta.spark.SparkTheme
+import androidx.compose.ui.tooling.preview.Preview
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Configurator
-import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.SampleSourceUrl
 import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.text.Text
@@ -104,24 +100,11 @@ private fun ColumnScope.SwitchSample() {
             }
         },
     )
-    Column {
-        Text(
-            text = stringResource(id = R.string.configurator_component_toggle_content_side_label),
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
-        )
-        val contentSidesLabel = ContentSide.entries.map(ContentSide::name)
-        SegmentedButton(
-            options = contentSidesLabel,
-            selectedOption = contentSide.name,
-            onOptionSelect = {
-                contentSide = ContentSide.valueOf(it)
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-        )
-    }
+    ButtonGroup(
+        title = stringResource(id = R.string.configurator_component_toggle_content_side_label),
+        selectedOption = contentSide,
+        onOptionSelect = { contentSide = it },
+    )
     TextField(
         modifier = Modifier.fillMaxWidth(),
         value = label.orEmpty(),
@@ -131,6 +114,12 @@ private fun ColumnScope.SwitchSample() {
         label = stringResource(id = R.string.configurator_component_screen_textfield_label),
         placeholder = stringResource(id = R.string.configurator_component_toggle_placeholder_label),
     )
+}
+
+@Preview
+@Composable
+private fun SwitchSamplePreview() {
+    PreviewTheme { SwitchSample() }
 }
 
 @Composable

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/popover/PopoverExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/popover/PopoverExamples.kt
@@ -41,6 +41,7 @@ import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.tokens.highlight
 import kotlinx.coroutines.launch
 
 private const val PopoverExampleDescription = "Popover examples"
@@ -64,17 +65,17 @@ public val PopoverExamples: List<Example> = listOf(
                             Text(
                                 text = "Title",
                                 modifier = Modifier.padding(bottom = 16.dp),
-                                style = SparkTheme.typography.headline1.copy(fontWeight = FontWeight.Bold),
+                                style = SparkTheme.typography.headline1.highlight,
                             )
                             Text(
                                 text = "Do you want to have this cookie now?",
                                 modifier = Modifier.padding(bottom = 16.dp),
-                                style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+                                style = SparkTheme.typography.body2.highlight,
                             )
                             Text(
                                 text = "Text Link",
                                 textDecoration = TextDecoration.Underline,
-                                style = SparkTheme.typography.body1.copy(fontWeight = FontWeight.Bold)
+                                style = SparkTheme.typography.body1.highlight
                                     .copy(color = SparkTheme.colors.accent),
                             )
                         }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/popover/PopoverExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/popover/PopoverExamples.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/ThemePicker.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -40,11 +39,15 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
+import com.adevinta.spark.catalog.ui.ButtonGroup
+import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.slider.Slider
@@ -78,53 +81,37 @@ public fun ThemePicker(
         verticalArrangement = Arrangement.spacedBy(ThemePickerPadding),
     ) {
         item {
-            Column {
-                Text(
-                    text = stringResource(id = R.string.theme_picker_mode_title),
-                    style = SparkTheme.typography.body2.highlight,
-                    modifier = Modifier.padding(vertical = 8.dp),
-                )
-                val themeModes = ThemeMode.entries.toTypedArray()
-                val themeModesLabel = themeModes.map { it.name }
-                SegmentedButton(
-                    options = themeModesLabel,
-                    selectedOption = theme.themeMode.name,
-                    onOptionSelect = { onThemeChange(theme.copy(themeMode = ThemeMode.valueOf(it))) },
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth()
-                        .height(48.dp),
-                )
-            }
+            val themeModes = ThemeMode.entries
+            val themeModesLabel = themeModes.map { it.name }
+            ButtonGroup(
+                title = stringResource(id = R.string.theme_picker_mode_title),
+                selectedOption = theme.themeMode.name,
+                onOptionSelect = { onThemeChange(theme.copy(themeMode = ThemeMode.valueOf(it))) },
+                options = themeModesLabel,
+            )
         }
         item {
             Column {
-                Text(
-                    text = stringResource(id = R.string.theme_picker_theme_title),
-                    style = SparkTheme.typography.body2.highlight,
-                    modifier = Modifier.padding(vertical = 8.dp),
-                )
-                val colorModes = ColorMode.entries.toTypedArray()
+                val colorModes = ColorMode.entries
                 val colorModesLabel = colorModes.map { it.name }
-                SegmentedButton(
-                    options = colorModesLabel,
+                ButtonGroup(
+                    title = stringResource(id = R.string.theme_picker_theme_title),
                     selectedOption = theme.colorMode.name,
                     onOptionSelect = { onThemeChange(theme.copy(colorMode = ColorMode.valueOf(it))) },
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth()
-                        .height(48.dp),
+                    options = colorModesLabel,
                 )
                 AnimatedVisibility(
                     visible = theme.colorMode == ColorMode.Brand,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .fillMaxWidth(),
                 ) {
                     var expanded by remember { mutableStateOf(false) }
                     val selectedIcon = @Composable { Icon(SparkIcons.Check, contentDescription = null) }
                     Dropdown(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(ThemePickerPadding),
+                            .padding(vertical = ThemePickerPadding),
                         value = theme.brandMode.name,
                         label = stringResource(id = R.string.brand),
                         onDismissRequest = {
@@ -149,9 +136,11 @@ public fun ThemePicker(
                         }
                     }
                 }
-                AnimatedVisibility(visible = theme.colorMode == ColorMode.Brand) {
+                AnimatedVisibility(
+                    visible = theme.colorMode == ColorMode.Brand,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                ) {
                     SwitchLabelled(
-                        modifier = Modifier.padding(ThemePickerPadding),
                         checked = theme.userMode == UserMode.Pro,
                         onCheckedChange = { checked ->
                             onThemeChange(theme.copy(userMode = if (checked) UserMode.Pro else UserMode.Part))
@@ -167,58 +156,42 @@ public fun ThemePicker(
         }
 
         item {
-            Column {
-                Text(
-                    text = stringResource(id = R.string.theme_picker_text_direction_title),
-                    style = SparkTheme.typography.body2.highlight,
-                    modifier = Modifier.padding(vertical = 8.dp),
-                )
-                val textDirections = TextDirection.entries.toTypedArray()
-                val textDirectionsLabel = textDirections.map { it.name }
-                SegmentedButton(
-                    options = textDirectionsLabel,
-                    selectedOption = theme.textDirection.name,
-                    onOptionSelect = { onThemeChange(theme.copy(textDirection = TextDirection.valueOf(it))) },
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth()
-                        .height(48.dp),
-                )
-            }
+            val textDirections = TextDirection.entries
+            val textDirectionsLabel = textDirections.map { it.name }
+            ButtonGroup(
+                title = stringResource(id = R.string.theme_picker_text_direction_title),
+                selectedOption = theme.textDirection.name,
+                onOptionSelect = { onThemeChange(theme.copy(textDirection = TextDirection.valueOf(it))) },
+                options = textDirectionsLabel,
+            )
         }
         item {
             Column {
-                Text(
-                    text = stringResource(id = R.string.theme_picker_font_scale_title),
-                    style = SparkTheme.typography.body2.highlight,
-                    modifier = Modifier.padding(vertical = 8.dp),
-                )
-                val fontScaleModes = FontScaleMode.entries.toTypedArray()
-                val colorModesLabel = fontScaleModes.map { it.name }
-                SegmentedButton(
-                    options = colorModesLabel,
+                val fontScaleModes = FontScaleMode.entries
+                val fontModesLabel = fontScaleModes.map { it.name }
+                ButtonGroup(
+                    title = stringResource(id = R.string.theme_picker_font_scale_title),
                     selectedOption = theme.fontScaleMode.name,
                     onOptionSelect = { onThemeChange(theme.copy(fontScaleMode = FontScaleMode.valueOf(it))) },
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth()
-                        .height(48.dp),
+                    options = fontModesLabel,
                 )
-            }
-            var fontScale by remember { mutableFloatStateOf(theme.fontScale) }
-            AnimatedVisibility(visible = theme.fontScaleMode == FontScaleMode.Custom) {
-                FontScaleItem(
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = theme.fontScaleMode == FontScaleMode.Custom,
-                    fontScale = fontScale,
-                    onValueChange = { fontScale = it },
-                    onValueChangeFinished = { onThemeChange(theme.copy(fontScale = fontScale)) },
-                )
+                var fontScale by remember { mutableFloatStateOf(theme.fontScale) }
+                AnimatedVisibility(
+                    visible = theme.fontScaleMode == FontScaleMode.Custom,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                ) {
+                    FontScaleItem(
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = theme.fontScaleMode == FontScaleMode.Custom,
+                        fontScale = fontScale,
+                        onValueChange = { fontScale = it },
+                        onValueChangeFinished = { onThemeChange(theme.copy(fontScale = fontScale)) },
+                    )
+                }
             }
         }
         item {
             SwitchLabelled(
-                modifier = Modifier.padding(horizontal = ThemePickerPadding),
                 checked = theme.useLegacyTheme,
                 onCheckedChange = { checked ->
                     onThemeChange(theme.copy(useLegacyTheme = checked))
@@ -232,7 +205,6 @@ public fun ThemePicker(
         }
         item {
             SwitchLabelled(
-                modifier = Modifier.padding(horizontal = ThemePickerPadding),
                 checked = theme.highlightSparkComponents,
                 onCheckedChange = { checked ->
                     onThemeChange(theme.copy(highlightSparkComponents = checked))
@@ -246,7 +218,6 @@ public fun ThemePicker(
         }
         item {
             SwitchLabelled(
-                modifier = Modifier.padding(horizontal = ThemePickerPadding),
                 checked = theme.highlightSparkTokens,
                 onCheckedChange = { checked ->
                     onThemeChange(theme.copy(highlightSparkTokens = checked))
@@ -283,6 +254,17 @@ private fun FontScaleItem(
         Text(
             text = stringResource(id = R.string.scale, fontScale),
             style = SparkTheme.typography.body2.highlight,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ThemePickerPreview() {
+    PreviewTheme {
+        ThemePicker(
+            theme = Theme(),
+            onThemeChange = {},
         )
     }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ButtonGroup.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ButtonGroup.kt
@@ -27,12 +27,30 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.themes.SegmentedButton
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.tokens.highlight
 import kotlin.enums.enumEntries
+
+
+@Composable
+private fun ButtonGroupLayout(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = modifier.semantics(mergeDescendants = true) {  }) {
+        Text(
+            text = title,
+            modifier = Modifier.padding(bottom = 8.dp),
+            style = SparkTheme.typography.body2.highlight,
+        )
+        content()
+    }
+}
 
 @Composable
 internal inline fun <reified T : Enum<T>> ButtonGroup(
@@ -41,16 +59,35 @@ internal inline fun <reified T : Enum<T>> ButtonGroup(
     crossinline onOptionSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier) {
-        Text(
-            text = title,
-            modifier = Modifier.padding(bottom = 8.dp),
-            style = SparkTheme.typography.body2.highlight,
-        )
+    ButtonGroupLayout(
+        title = title,
+        modifier = modifier,
+    ) {
         SegmentedButton(
             options = enumEntries<T>().map { it.name },
             selectedOption = selectedOption.name,
             onOptionSelect = { onOptionSelect(enumValueOf<T>(it)) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+internal fun ButtonGroup(
+    title: String,
+    selectedOption: String,
+    onOptionSelect: (String) -> Unit,
+    options: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    ButtonGroupLayout(
+        title = title,
+        modifier = modifier,
+    ) {
+        SegmentedButton(
+            options = options,
+            selectedOption = selectedOption,
+            onOptionSelect = onOptionSelect,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ButtonGroup.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ButtonGroup.kt
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.adevinta.spark.catalog.ui
 
 import androidx.compose.foundation.layout.Column
@@ -35,14 +34,13 @@ import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.tokens.highlight
 import kotlin.enums.enumEntries
 
-
 @Composable
 private fun ButtonGroupLayout(
     title: String,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    Column(modifier = modifier.semantics(mergeDescendants = true) {  }) {
+    Column(modifier = modifier.semantics(mergeDescendants = true) { }) {
         Text(
             text = title,
             modifier = Modifier.padding(bottom = 8.dp),

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ButtonGroup.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/ButtonGroup.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.adevinta.spark.catalog.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.tokens.highlight
+import kotlin.enums.enumEntries
+
+@Composable
+internal inline fun <reified T : Enum<T>> ButtonGroup(
+    title: String,
+    selectedOption: T,
+    crossinline onOptionSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = title,
+            modifier = Modifier.padding(bottom = 8.dp),
+            style = SparkTheme.typography.body2.highlight,
+        )
+        SegmentedButton(
+            options = enumEntries<T>().map { it.name },
+            selectedOption = selectedOption.name,
+            onOptionSelect = { onOptionSelect(enumValueOf<T>(it)) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
@@ -60,6 +60,7 @@ import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.icons.Close
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tokens.ElevationTokens
+import com.adevinta.spark.tokens.highlight
 import kotlinx.coroutines.launch
 
 /**
@@ -164,17 +165,17 @@ private fun PopoverPreview() {
                         Text(
                             text = "Title",
                             modifier = Modifier.padding(bottom = 16.dp),
-                            style = SparkTheme.typography.headline1.copy(fontWeight = FontWeight.Bold),
+                            style = SparkTheme.typography.headline1.highlight,
                         )
                         Text(
                             text = "Do you want to have this cookie now?",
                             modifier = Modifier.padding(bottom = 16.dp),
-                            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+                            style = SparkTheme.typography.body2.highlight,
                         )
                         Text(
                             text = "Text Link",
                             textDecoration = TextDecoration.Underline,
-                            style = SparkTheme.typography.body1.copy(fontWeight = FontWeight.Bold)
+                            style = SparkTheme.typography.body1.highlight
                                 .copy(color = colors.accent),
                         )
                     }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adevinta.spark.InternalSparkApi

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
@@ -106,7 +106,7 @@ internal fun BaseSparkTag(
                     }
                 }
 
-                ProvideTextStyle(value = SparkTheme.typography.caption.copy(fontWeight = FontWeight.Bold)) {
+                ProvideTextStyle(value = SparkTheme.typography.caption.highlight) {
                     content()
                 }
             }


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add a ButtonGroup component that encapsulate a `Text` that serve as a label and a `SegmentedButton`

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
We use the same pattern when using the Segmented button which is show a label and the `SegmentedButton`.
We also 95% of the time list enum values in it so the `ButtonGroup` can work with them to automatically list them.

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.
