### PR TITLE
style: Adjust vertical spacing in ModalScaffoldDialogContent

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt
@@ -243,6 +243,7 @@ private fun DialogScaffold(
                         .heightIn(min = 76.dp)
                         .padding(vertical = 16.dp, horizontal = 24.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.End),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     supportButton?.invoke(Modifier)
                     mainButton?.invoke(Modifier)


### PR DESCRIPTION
## 📋 Changes

<!-- Describe your changes in details -->
When the width of buttons is too big then they will stack each others but no padding was set for this case

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
close [SPA-15](https://jira.ets.mpi-internal.com/browse/SPA-15)


## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

