### PR TITLE
fix(color): Component tha use material color token would be transaprent

### DIFF
--- a/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_bottomsheet_bottomsheetscaffold.png
+++ b/spark-screenshot-testing/src/test/snapshots/images/com.adevinta.spark_PreviewScreenshotTests_preview_tests_bottomsheet_bottomsheetscaffold.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aeae70253a6db459e8c1c2f31bedd80738424a9fa39f6461586dae753a35305c
-size 32027
+oid sha256:6f1a21c60385e792287a8c78998c52a982fe4937be4efe254f8a3281896d42ba
+size 30649

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -852,6 +852,13 @@ public fun SparkColors.asMaterial3Colors(): ColorScheme = ColorScheme(
     outline = outline,
     outlineVariant = outlineHigh,
     scrim = scrim,
+    surfaceBright = surface,
+    surfaceDim = surface,
+    surfaceContainer = surface,
+    surfaceContainerHigh = surface,
+    surfaceContainerHighest = surface,
+    surfaceContainerLow = surface,
+    surfaceContainerLowest = surface,
 )
 
 /**


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
The color for Material tcolor tokens for the new surfaces were using Unspecified which would make them transparent in Dialog for ex.

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
These colors were added with the version upgrade of Material 3 to 1.3.0

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
