### PR TITLE
docs: update `annotatedStringResource` javadoc

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/res/AnnotatedStringResource.kt
@@ -72,9 +72,23 @@ import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
 
 /**
- * Load a annotated string resource with formatting.
+ * Load an annotated string resource with formatting.
  *
- * Be aware that using this method you'll loose the annotations support.
+ * ```xml
+ * <string name="hello">Hello, <annotation variable="who" color="main">.</annotation>!</string>
+ * ```
+ *
+ * ```kotlin
+ * annotatedStringResource(
+ *     id = R.string.hello,
+ *     formatArgs = persistentMapOf("who" to "Bob"),
+ * )
+ * ```
+ *
+ * Beware, when using annotations with a `variable` mapping (`<annotation variable="...">`):
+ * - The annotation content must not be empty, otherwise it will be stripped by AAPT. You can use a space, a dot, or anything else.
+ * - The entire annotation content will be replaced by the provided argument mapping.
+ * - If the argument mapping is not found, a [NoSuchElementException] will be thrown!
  *
  * @param id the resource identifier
  * @param formatArgs the format arguments
@@ -135,6 +149,7 @@ public fun annotatedStringResource(@StringRes id: Int): AnnotatedString {
  * @param id the resource identifier
  * @param count the count
  * @return the pluralized string data associated with the resource
+ * @see annotatedStringResource for more details
  */
 @Composable
 public fun annotatedPluralStringResource(


### PR DESCRIPTION
## 📋 Changes

<!-- Describe your changes in details -->

## 🤔 Context

`annotatedStringResource` and `annotatedPluralStringResource` have a special handling of `formatArgs`, and some non-trivial rules associated to it.

This PR adds these rules in the javadoc of these methods and an example of how to use it properly.
