### PR TITLE
chore: Ajust sparkUsageOverlay modifier usage in components

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
@@ -65,6 +65,7 @@ import com.adevinta.spark.components.toggles.CheckboxLabelled
 import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tokens.contentColorFor
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import kotlinx.coroutines.launch
 
 /**
@@ -105,7 +106,7 @@ public fun BottomSheet(
 ) {
     SparkModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        modifier = modifier,
+        modifier = modifier.sparkUsageOverlay(),
         sheetState = sheetState,
         content = content,
         dragHandle = dragHandle,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/scaffold/BottomSheetScaffold.kt
@@ -54,6 +54,7 @@ import com.adevinta.spark.components.list.ListItem
 import com.adevinta.spark.components.text.Text
 import com.adevinta.spark.icons.LikeFill
 import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 
 /**
  *  BottomSheetScaffold is a composable that implements a scaffold with a bottom sheet.
@@ -107,7 +108,7 @@ public fun BottomSheetScaffold(
                 }
             }
         },
-        modifier = modifier,
+        modifier = modifier.sparkUsageOverlay(),
         scaffoldState = scaffoldState,
         sheetDragHandle = null,
         sheetSwipeEnabled = sheetSwipeEnabled,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/divider/Divider.kt
@@ -42,6 +42,7 @@ import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.spacer.HorizontalSpacer
 import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import androidx.compose.material3.HorizontalDivider as MaterialHorizontalDivider
 import androidx.compose.material3.VerticalDivider as MaterialVerticalDivider
 
@@ -84,11 +85,15 @@ public fun HorizontalDivider(
     if (label == null) {
         MaterialHorizontalDivider(
             color = intent.color(),
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier
+                .sparkUsageOverlay()
+                .fillMaxWidth(),
         )
     } else {
         ConstraintLayout(
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier
+                .sparkUsageOverlay()
+                .fillMaxWidth(),
         ) {
             val (lineLeft, labelBox, lineRight) = createRefs()
 
@@ -148,11 +153,15 @@ public fun VerticalDivider(
     if (label == null) {
         MaterialVerticalDivider(
             color = intent.color(),
-            modifier = modifier.fillMaxHeight(),
+            modifier = modifier
+                .sparkUsageOverlay()
+                .fillMaxHeight(),
         )
     } else {
         ConstraintLayout(
-            modifier = modifier.fillMaxHeight(),
+            modifier = modifier
+                .sparkUsageOverlay()
+                .fillMaxHeight(),
         ) {
             val (lineTop, labelBox, lineBottom) = createRefs()
 

--- a/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/icons/Icons.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.icons.Check
@@ -43,7 +44,6 @@ import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tools.modifiers.ifNotNull
 import com.adevinta.spark.tools.modifiers.ifTrue
-import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import androidx.compose.material3.Icon as MaterialIcon
 
@@ -73,7 +73,6 @@ public fun Icon(
         painter = rememberSparkIconPainter(sparkIcon),
         contentDescription = contentDescription,
         modifier = modifier
-            .sparkUsageOverlay()
             .ifNotNull(size) {
                 size(it.size)
             },
@@ -107,7 +106,6 @@ public fun Icon(
         imageVector = imageVector,
         contentDescription = contentDescription,
         modifier = modifier
-            .sparkUsageOverlay()
             .ifNotNull(size) {
                 size(it.size)
             },
@@ -141,7 +139,6 @@ public fun Icon(
         bitmap = bitmap,
         contentDescription = contentDescription,
         modifier = modifier
-            .sparkUsageOverlay()
             .ifNotNull(size) {
                 size(it.size)
             },
@@ -175,7 +172,6 @@ public fun Icon(
         painter = painter,
         contentDescription = contentDescription,
         modifier = modifier
-            .sparkUsageOverlay()
             .ifNotNull(size) {
                 size(it.size)
             },
@@ -189,6 +185,7 @@ public fun rememberSparkIconPainter(sparkIcon: SparkIcon): Painter = when (spark
     is SparkIcon.DrawableRes -> rememberDrawablePainter(getDrawable(LocalContext.current, sparkIcon.drawableId))
 }
 
+@PreviewLightDark
 @Composable
 private fun IconPreview() {
     PreviewTheme {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/menu/DropdownMenu.kt
@@ -70,6 +70,7 @@ import com.adevinta.spark.tokens.EmphasizeDim1
 import com.adevinta.spark.tokens.SparkColors
 import com.adevinta.spark.tokens.SparkTypography
 import com.adevinta.spark.tokens.ripple
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import androidx.compose.material3.DropdownMenu as MaterialDropdownMenu
 
 /**
@@ -119,7 +120,7 @@ public fun DropdownMenu(
     MaterialDropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismissRequest,
-        modifier = modifier,
+        modifier = modifier.sparkUsageOverlay(),
         offset = offset,
         scrollState = scrollState,
         properties = properties,
@@ -184,7 +185,8 @@ public fun DropdownMenuItem(
                 maxWidth = 280.dp,
                 minHeight = 48.dp,
             )
-            .padding(contentPadding),
+            .padding(contentPadding)
+            .sparkUsageOverlay(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ProvideTextStyle(SparkTheme.typography.body1) {
@@ -266,7 +268,7 @@ public fun DropdownMenuGroupItem(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    Column(modifier = modifier) {
+    Column(modifier = modifier.sparkUsageOverlay()) {
         SectionHeadline {
             title()
         }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/popover/Popover.kt
@@ -60,6 +60,7 @@ import com.adevinta.spark.icons.Close
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tokens.ElevationTokens
 import com.adevinta.spark.tokens.highlight
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import kotlinx.coroutines.launch
 
 /**
@@ -108,7 +109,8 @@ public fun Popover(
             Surface(
                 modifier = Modifier
                     .sizeIn(minWidth = PopoverMinWidth, maxWidth = 320.dp, minHeight = PopoverMinHeight)
-                    .padding(bottom = PopoverAnchorPadding),
+                    .padding(bottom = PopoverAnchorPadding)
+                    .sparkUsageOverlay(),
                 shape = shape,
                 elevation = ElevationTokens.Level2,
                 color = colors.containerColor,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/slider/Slider.kt
@@ -67,6 +67,7 @@ import com.adevinta.spark.tokens.dim3
 import com.adevinta.spark.tokens.dim4
 import com.adevinta.spark.tokens.ripple
 import com.adevinta.spark.tokens.transparent
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import androidx.compose.material3.Slider as MaterialSlider
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -107,7 +108,7 @@ internal fun SparkSlider(
     MaterialSlider(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier,
+        modifier = modifier.sparkUsageOverlay(),
         enabled = enabled,
         valueRange = valueRange,
         steps = steps,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/text/TextLink.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/text/TextLink.kt
@@ -65,6 +65,7 @@ import com.adevinta.spark.icons.InfoOutline
 import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.res.annotatedStringResource
+import com.adevinta.spark.tools.modifiers.sparkUsageOverlay
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.launch
@@ -135,7 +136,7 @@ public fun TextLink(
         modifier = modifier.clickable(
             onClickLabel = onClickLabel,
             onClick = onClick,
-        ),
+        ).sparkUsageOverlay(),
         style = style,
         overflow = overflow,
         softWrap = softWrap,


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Adds sparkUsageOverlay modifier to component taht were missing it

Remove it from the icon Component as it makes the QA think that a Icon button is a spark component when it's not

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.
