### PR TITLE
fix(Tab): tab indicator offset was not placed correctly

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastForEachIndexed
 import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.components.badge.Badge
@@ -160,14 +162,19 @@ internal fun SparkTabGroup(
                 )
             }
 
-            val tabPositions: MutableList<TabPosition> = mutableListOf()
             layout(if (scrollable) layoutWidth else tabRowWidth, layoutHeight) {
                 /* Tabs */
                 var left = 0
-                tabPlaceables.forEach {
-                    it.placeRelative(left, 0)
-                    tabPositions.add(TabPosition(left = left.toDp(), width = it.width.toDp()))
-                    left += it.width
+                val tabPositions = mutableListOf<TabPosition>()
+                tabPlaceables.fastForEachIndexed {index, placeable ->
+                    placeable.placeRelative(left, 0)
+                    tabPositions.add(
+                        TabPosition(
+                            left = left.toDp(),
+                            width = placeable.width.toDp(),
+                        ),
+                    )
+                    left += placeable.width
                 }
                 /* Divider */
                 subcompose(TabSlots.Divider, divider).forEach {
@@ -181,12 +188,11 @@ internal fun SparkTabGroup(
                     placeable.placeRelative(0, layoutHeight - placeable.height)
                 }
                 /* Indicator */
-                subcompose(TabSlots.Indicator) {
-                    indicator(tabPositions)
-                }.forEach {
-                    it.measure(Constraints.fixed(if (scrollable) layoutWidth else tabRowWidth, layoutHeight))
-                        .placeRelative(0, 0)
-                }
+                subcompose(TabSlots.Indicator) { indicator(tabPositions) }
+                    .fastForEach {
+                        it.measure(Constraints.fixed(if (scrollable) layoutWidth else tabRowWidth, layoutHeight))
+                            .placeRelative(0, 0)
+                    }
 
                 scrollableTabData.onLaidOut(
                     density = this@SubcomposeLayout,
@@ -382,7 +388,7 @@ private fun TabGroupFixedSizePreview() {
         Pair("Home", null) to 0,
         Pair("Message", SparkIcons.MessageOutline) to 1,
     )
-    var selectedIndex by remember { mutableIntStateOf(0) }
+    var selectedIndex by remember { mutableIntStateOf(1) }
     PreviewTheme {
         TabGroup(
             selectedTabIndex = selectedIndex,

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroup.kt
@@ -166,7 +166,7 @@ internal fun SparkTabGroup(
                 /* Tabs */
                 var left = 0
                 val tabPositions = mutableListOf<TabPosition>()
-                tabPlaceables.fastForEachIndexed {index, placeable ->
+                tabPlaceables.fastForEachIndexed { index, placeable ->
                     placeable.placeRelative(left, 0)
                     tabPositions.add(
                         TabPosition(

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroupDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroupDefaults.kt
@@ -24,7 +24,6 @@ package com.adevinta.spark.components.tab
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateIntOffsetAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -81,6 +80,10 @@ internal object TabGroupDefaults {
         easing = FastOutSlowInEasing,
     )
 
+    /** [AnimationSpec] used when an indicator is updating width and/or offset. */
+    internal val TabRowIndicatorSpec: AnimationSpec<Dp> =
+        tween(durationMillis = 250, easing = FastOutSlowInEasing)
+
     /**
      * [Modifier] that takes up all the available width inside the [TabRow], and then animates
      * the offset of the indicator it is applied to, depending on the [currentTabPosition].
@@ -91,25 +94,27 @@ internal object TabGroupDefaults {
     @Suppress("ComposeModifierComposed") // Fork from M3 Tab that will be removed once the api is stable
     internal fun Modifier.tabIndicatorOffset(
         currentTabPosition: TabPosition,
-    ): Modifier = composed(
-        inspectorInfo = debugInspectorInfo {
-            name = "tabIndicatorOffset"
-            value = currentTabPosition
-        },
-    ) {
-        val currentTabWidth by animateDpAsState(
-            targetValue = currentTabPosition.width,
-            animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
-            label = "currentTabWidth",
-        )
-        val indicatorOffset by animateIntOffsetAsState(
-            targetValue = IntOffset(x = currentTabPosition.left.value.toInt(), 0),
-            animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
-            label = "indicatorOffset",
-        )
-        fillMaxWidth()
-            .wrapContentSize(Alignment.BottomStart)
-            .offset { indicatorOffset }
-            .width(currentTabWidth)
-    }
+    ): Modifier =
+        composed(
+            inspectorInfo =
+            debugInspectorInfo {
+                name = "tabIndicatorOffset"
+                value = currentTabPosition
+            },
+        ) {
+            val currentTabWidth by
+            animateDpAsState(
+                targetValue = currentTabPosition.width,
+                animationSpec = TabRowIndicatorSpec,
+            )
+            val indicatorOffset by
+            animateDpAsState(
+                targetValue = currentTabPosition.left,
+                animationSpec = TabRowIndicatorSpec,
+            )
+            fillMaxWidth()
+                .wrapContentSize(Alignment.BottomStart)
+                .offset { IntOffset(x = indicatorOffset.roundToPx(), y = 0) }
+                .width(currentTabWidth)
+        }
 }

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroupDefaults.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tab/TabGroupDefaults.kt
@@ -103,15 +103,15 @@ internal object TabGroupDefaults {
             },
         ) {
             val currentTabWidth by
-            animateDpAsState(
-                targetValue = currentTabPosition.width,
-                animationSpec = TabRowIndicatorSpec,
-            )
+                animateDpAsState(
+                    targetValue = currentTabPosition.width,
+                    animationSpec = TabRowIndicatorSpec,
+                )
             val indicatorOffset by
-            animateDpAsState(
-                targetValue = currentTabPosition.left,
-                animationSpec = TabRowIndicatorSpec,
-            )
+                animateDpAsState(
+                    targetValue = currentTabPosition.left,
+                    animationSpec = TabRowIndicatorSpec,
+                )
             fillMaxWidth()
                 .wrapContentSize(Alignment.BottomStart)
                 .offset { IntOffset(x = indicatorOffset.roundToPx(), y = 0) }


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
We previously used the dp value instead of rounding it to dp which meant that the offset was not correctly positioned. 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->
![image](https://github.com/user-attachments/assets/6b9ad344-e9c9-4387-9c36-d1a884b5e822)

