### PR TITLE
fix(bottomsheet): Add statusBar size on the content padding

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/bottomsheet/BottomSheetExamples.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/bottomsheet/BottomSheetExamples.kt
@@ -182,6 +182,7 @@ private fun ConfiguredBottomSheet(
                     BottomSheetContentExamples.List -> ListContent(onHideBottomSheetClicked)
                 }
             },
+            applyTempStatusBarPadding = true,
             dragHandle = if (isDragHandlerEnabled) {
                 { DragHandle() }
             } else {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
@@ -29,9 +29,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetDefaults.ExpandedShape
@@ -102,6 +104,7 @@ public fun BottomSheet(
     dragHandle: @Composable (() -> Unit)? = {
         DragHandle()
     },
+    applyTempStatusBarPadding: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     SparkModalBottomSheet(
@@ -109,6 +112,7 @@ public fun BottomSheet(
         modifier = modifier.sparkUsageOverlay(),
         sheetState = sheetState,
         content = content,
+        applyTempStatusBarPadding = applyTempStatusBarPadding,
         dragHandle = dragHandle,
     )
 }
@@ -152,6 +156,7 @@ internal fun SparkModalBottomSheet(
     dragHandle: (@Composable () -> Unit)? = { DragHandle() },
     contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     properties: ModalBottomSheetProperties = ModalBottomSheetDefaults.properties,
+    applyTempStatusBarPadding: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     androidx.compose.material3.ModalBottomSheet(
@@ -166,9 +171,15 @@ internal fun SparkModalBottomSheet(
         dragHandle = null,
     ) {
         Box {
+            val systemBarTopInsets = WindowInsets.systemBars.asPaddingValues().calculateTopPadding()
+            val additionalTopPadding = if (applyTempStatusBarPadding) systemBarTopInsets else 0.dp
             Column(
                 modifier = Modifier.padding(
-                    top = if (dragHandle != null) ContentTopPadding else ContentTopPaddingNoHandle,
+                    top = if (dragHandle != null) {
+                        ContentTopPadding + additionalTopPadding
+                    } else {
+                        ContentTopPaddingNoHandle + additionalTopPadding
+                    },
                 ),
             ) {
                 content()


### PR DESCRIPTION
## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
This temp parameter make it possible to interact with items on the top of the BS when a big cutout is present. Will be fixed in Material 1.4

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.


## 📸 Screenshots

<!-- Insert your screenshots here -->
<img width="341" alt="image" src="https://github.com/user-attachments/assets/5887d8aa-11f3-44ed-8d3a-7898b332c105">
