### PR TITLE
feat: Add a ColorScheme to SparkColors adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Spark
+
+- 🎨 Add a new function to convert a Material Theme colors to a Spark Theme colors.
+
 ## [1.0.0]
 
 _2024-10-07_

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -45,6 +45,8 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.derivedStateOf
@@ -57,6 +59,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
@@ -70,6 +73,7 @@ import com.adevinta.spark.catalog.model.Component
 import com.adevinta.spark.catalog.tabbar.CatalogTabBar
 import com.adevinta.spark.catalog.tabbar.CatalogTabs
 import com.adevinta.spark.catalog.themes.BrandMode
+import com.adevinta.spark.catalog.themes.ColorMode
 import com.adevinta.spark.catalog.themes.FontScaleMode
 import com.adevinta.spark.catalog.themes.TextDirection
 import com.adevinta.spark.catalog.themes.Theme
@@ -87,6 +91,7 @@ import com.adevinta.spark.catalog.ui.BackdropValue
 import com.adevinta.spark.catalog.ui.rememberBackdropScaffoldState
 import com.adevinta.spark.catalog.ui.shaders.colorblindness.ColorBlindNessType
 import com.adevinta.spark.catalog.ui.shaders.colorblindness.shader
+import com.adevinta.spark.tokens.asSparkColors
 import com.google.accompanist.testharness.TestHarness
 import kotlinx.coroutines.launch
 

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/CatalogApp.kt
@@ -105,8 +105,15 @@ internal fun ComponentActivity.CatalogApp(
 
     val useDark = (theme.themeMode == ThemeMode.System && isSystemInDarkTheme()) || theme.themeMode == ThemeMode.Dark
 
-    val colors =
+    val colors = if (theme.colorMode == ColorMode.Dynamic && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (useDark) {
+            dynamicDarkColorScheme(LocalContext.current)
+        } else {
+            dynamicLightColorScheme(LocalContext.current)
+        }.asSparkColors(useDark = true)
+    } else {
         themeProvider.colors(useDarkColors = useDark, isPro = theme.userMode == UserMode.Pro)
+    }
     val shapes = themeProvider.shapes()
     val typography = themeProvider.typography()
 
@@ -291,10 +298,6 @@ private fun HomeTabBar(
         )
     }
 }
-
-private val SheetScrimColor = Color.Black.copy(alpha = 0.4f)
-
-internal const val HomeRoute = "home"
 
 public enum class CatalogHomeScreen { Examples, Configurator, Icons }
 

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -822,6 +822,18 @@ public class SparkColors(
     }
 }
 
+/**
+ * Converts a [SparkColors] instance to a Material 3 [ColorScheme].
+ *
+ * This function maps the Spark color properties to their corresponding Material 3 color roles.
+ * Note: Some Material 3 color roles might not have a direct equivalent in SparkColors and are
+ * mapped to the closest available Spark color. For example, [ColorScheme.tertiary] colors
+ * are mapped to [SparkColors.support] colors, and various surface container colors are mapped
+ * to the base surface color.
+ *
+ * @return A [ColorScheme] representing the Material 3 color scheme derived from the
+ * [SparkColors] instance.
+ */
 public fun SparkColors.asMaterial3Colors(): ColorScheme = ColorScheme(
     primary = main,
     onPrimary = onMain,
@@ -861,6 +873,22 @@ public fun SparkColors.asMaterial3Colors(): ColorScheme = ColorScheme(
     surfaceContainerLowest = surface,
 )
 
+/**
+ * Converts a Material [ColorScheme] to a [SparkColors] instance.
+ *
+ * This function adapts the color values from a Material Design ColorScheme
+ * to the structure and naming conventions used by SparkColors.
+ * The following tokens [SparkColors.mainVariant], [SparkColors.accentVariant],
+ * [SparkColors.supportVariant] and their on counterparts have no equivalent in Material so
+ * their are juste derivative of their principal token with a different tone that needs to
+ * be different for each (90/10 or 10/99).
+ * It handles both light and dark themes by adjusting the color tones accordingly.
+ *
+ * @param useDark Whether to generate colors for a dark theme as the tone used for
+ * variants is different in a dark theme
+ *
+ * @return A [SparkColors] populated with color values derived from the provided [ColorScheme].
+ */
 public fun ColorScheme.asSparkColors(useDark: Boolean): SparkColors = if (useDark) {
     darkSparkColors(
         main = primary,

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Color.kt
@@ -19,8 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-@file:Suppress("DEPRECATION")
-
 package com.adevinta.spark.tokens
 
 import android.annotation.SuppressLint
@@ -47,10 +45,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.ColorUtils
 import com.adevinta.spark.InternalSparkApi
 import com.adevinta.spark.PreviewTheme
 import com.adevinta.spark.SparkTheme
@@ -860,6 +860,95 @@ public fun SparkColors.asMaterial3Colors(): ColorScheme = ColorScheme(
     surfaceContainerLow = surface,
     surfaceContainerLowest = surface,
 )
+
+public fun ColorScheme.asSparkColors(useDark: Boolean): SparkColors = if (useDark) {
+    darkSparkColors(
+        main = primary,
+        onMain = onPrimary,
+        mainContainer = primaryContainer,
+        onMainContainer = onPrimaryContainer,
+        mainVariant = primary.adjustColorToMaterialTone(90f),
+        onMainVariant = primary.adjustColorToMaterialTone(10f),
+        accent = secondary,
+        onAccent = onSecondary,
+        accentContainer = secondaryContainer,
+        onAccentContainer = onSecondaryContainer,
+        accentVariant = secondary.adjustColorToMaterialTone(90f),
+        onAccentVariant = secondary.adjustColorToMaterialTone(10f),
+        support = tertiary,
+        onSupport = onTertiary,
+        supportContainer = tertiaryContainer,
+        onSupportContainer = onTertiaryContainer,
+        supportVariant = tertiary.adjustColorToMaterialTone(90f),
+        onSupportVariant = tertiary.adjustColorToMaterialTone(10f),
+        basic = tertiary,
+        onBasic = onTertiary,
+        basicContainer = tertiaryContainer,
+        onBasicContainer = onTertiaryContainer,
+        background = background,
+        onBackground = onBackground,
+        surface = surface,
+        onSurface = onSurface,
+        backgroundVariant = surfaceVariant,
+        onBackgroundVariant = onSurfaceVariant,
+        surfaceTint = surfaceTint,
+        surfaceInverse = inverseSurface,
+        onSurfaceInverse = inverseOnSurface,
+        error = error,
+        onError = onError,
+        errorContainer = errorContainer,
+        onErrorContainer = onErrorContainer,
+        outline = outline,
+        outlineHigh = outlineVariant,
+        scrim = scrim,
+    )
+} else {
+    lightSparkColors(
+        main = primary,
+        onMain = onPrimary,
+        mainContainer = primaryContainer,
+        onMainContainer = onPrimaryContainer,
+        mainVariant = primary.adjustColorToMaterialTone(10f),
+        onMainVariant = primary.adjustColorToMaterialTone(99f),
+        accent = secondary,
+        onAccent = onSecondary,
+        accentContainer = secondaryContainer,
+        onAccentContainer = onSecondaryContainer,
+        accentVariant = secondary.adjustColorToMaterialTone(10f),
+        onAccentVariant = secondary.adjustColorToMaterialTone(99f),
+        support = tertiary,
+        onSupport = onTertiary,
+        supportContainer = tertiaryContainer,
+        onSupportContainer = onTertiaryContainer,
+        supportVariant = tertiary.adjustColorToMaterialTone(10f),
+        onSupportVariant = tertiary.adjustColorToMaterialTone(99f),
+        basic = tertiary,
+        onBasic = onTertiary,
+        basicContainer = tertiaryContainer,
+        onBasicContainer = onTertiaryContainer,
+        background = background,
+        onBackground = onBackground,
+        surface = surface,
+        onSurface = onSurface,
+        backgroundVariant = surfaceVariant,
+        onBackgroundVariant = onSurfaceVariant,
+        surfaceInverse = inverseSurface,
+        onSurfaceInverse = inverseOnSurface,
+        error = error,
+        onError = onError,
+        errorContainer = errorContainer,
+        onErrorContainer = onErrorContainer,
+        outline = outline,
+        outlineHigh = outlineVariant,
+        scrim = scrim,
+    )
+}
+
+private fun Color.adjustColorToMaterialTone(tone: Float): Color {
+    val m3HCT = FloatArray(3)
+    ColorUtils.colorToM3HCT(this.toArgb(), m3HCT)
+    return Color(ColorUtils.M3HCTToColor(m3HCT[0], m3HCT[1], tone))
+}
 
 /**
  * The Material color system contains pairs of colors that are typically used for the background


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add best attempt to adapt a Material Theme color scheme to a Spark Theme colors

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
We have a adapter to convert a Spark Theme colors to Material colors but not the contrary. 
Adding this new one enable us to support the dynamic theming of Material You or the premade themes that support the new contrast specs fro mAndroid 15

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
