### PR TITLE
fix: Imageborder in configurator was not properly representing the component size

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/image/ImageConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/image/ImageConfigurator.kt
@@ -35,7 +35,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -126,7 +126,10 @@ private fun ColumnScope.ImageSample() {
         model = state.ordinal,
         contentDescription = stringResource(selectedImage.contentDescription),
         modifier = Modifier
-            .widthIn(max = imageMaxWidth)
+            .width(imageMaxWidth)
+            .ifTrue(showBorder) {
+                border(1.dp, SparkTheme.colors.outlineHigh)
+            }
             .aspectRatio(
                 ratio = if (aspectRatio == ImageAspectRatio.Custom) {
                     (width?.toFloat() ?: 1f) / (height?.toFloat() ?: 1f)
@@ -135,9 +138,6 @@ private fun ColumnScope.ImageSample() {
                 },
                 matchHeightConstraintsFirst = true,
             )
-            .ifTrue(showBorder) {
-                border(1.dp, SparkTheme.colors.outlineHigh)
-            }
             .align(Alignment.CenterHorizontally)
             .clip(imageShape.shape)
             .animateContentSize(),


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
