### PR TITLE
chore(gha): replace deprecated `gradle-home-cache-cleanup`

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -6,5 +6,5 @@ runs:
     - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
       with:
         validate-wrappers: true
-        gradle-home-cache-cleanup: true
+        cache-cleanup: true
         add-job-summary-as-pr-comment: on-failure


### PR DESCRIPTION
https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-gradle-home-cache-cleanup-input-parameter-has-been-replaced-by-cache-cleanup
