### PR TITLE
chore(gha): cleanup setup-gradle default values

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -5,6 +5,4 @@ runs:
   steps:
     - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
       with:
-        validate-wrappers: true
-        cache-cleanup: true
         add-job-summary-as-pr-comment: on-failure


### PR DESCRIPTION
Remove explicit values that are also default values.

https://github.com/gradle/actions/blob/main/docs/setup-gradle.md

(fixes `cache-cleanup` not having a proper value after incorrect update in #1424)