### PR TITLE
fix: conditional modifiers not working as expected

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Conditions.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tools/modifiers/Conditions.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.Modifier
  * @param builder the modifier(s) to apply when [predicate] is true
  */
 public inline fun Modifier.ifTrue(predicate: Boolean, builder: Modifier.() -> Modifier): Modifier =
-    then(if (predicate) this.builder() else Modifier)
+    then(if (predicate) this.builder() else this)
 
 /**
  * Modifier to make it easy to conditionally add a modifier based on [predicate]
@@ -51,7 +51,7 @@ public inline fun Modifier.ifTrue(predicate: Boolean, builder: Modifier.() -> Mo
  * @param builder the modifier(s) to apply when [predicate] is false
  */
 public inline fun Modifier.ifFalse(predicate: Boolean, builder: Modifier.() -> Modifier): Modifier =
-    then(if (!predicate) this.builder() else Modifier)
+    then(if (!predicate) this.builder() else this)
 
 /**
  * Modifier to make it easy to conditionally add a modifier based on [value] nullability
@@ -66,7 +66,7 @@ public inline fun Modifier.ifFalse(predicate: Boolean, builder: Modifier.() -> M
  * @param builder the modifier(s) to apply when [value] is not null
  */
 public inline fun <T : Any> Modifier.ifNotNull(value: T?, builder: Modifier.(T) -> Modifier): Modifier =
-    then(if (value != null) this.builder(value) else Modifier)
+    then(if (value != null) this.builder(value) else this)
 
 /**
  * Modifier to make it easy to conditionally add a modifier based on [value] nullability
@@ -81,4 +81,4 @@ public inline fun <T : Any> Modifier.ifNotNull(value: T?, builder: Modifier.(T) 
  * @param builder the modifier(s) to apply when [value] is null
  */
 public inline fun <T : Any> Modifier.ifNull(value: T?, builder: Modifier.() -> Modifier): Modifier =
-    then(if (value == null) this.builder() else Modifier)
+    then(if (value == null) this.builder() else this)


### PR DESCRIPTION
## 📋 Changes

Fix the conditional modifier extensions

## 🤔 Context

The conditional modifiers seem to drop previous modifiers in case the condition is not met.
After further investigation, it appears that if the condition is not met, the extension returns `Modifier` instead of `this`, hence this issue.
