### PR TITLE
fix: Remove unecessary includeFontPadding

### DIFF
--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight

--- a/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/tokens/Type.kt
@@ -40,9 +40,6 @@ internal val display1Type = TextStyle(
     fontSize = 40.sp,
     fontWeight = FontWeight.Bold,
     lineHeight = 56.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
 
 )
 
@@ -51,9 +48,6 @@ internal val display2Type = TextStyle(
     fontSize = 32.sp,
     fontWeight = FontWeight.Bold,
     lineHeight = 44.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
 
 )
 
@@ -62,10 +56,6 @@ internal val display3Type = TextStyle(
     fontSize = 24.sp,
     fontWeight = FontWeight.Bold,
     lineHeight = 32.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val headline1Type = TextStyle(
@@ -73,10 +63,6 @@ internal val headline1Type = TextStyle(
     fontSize = 20.sp,
     fontWeight = FontWeight.Bold,
     lineHeight = 28.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val headline2Type = TextStyle(
@@ -84,10 +70,6 @@ internal val headline2Type = TextStyle(
     fontSize = 18.sp,
     fontWeight = FontWeight.Bold,
     lineHeight = 24.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val subheadType = TextStyle(
@@ -95,10 +77,6 @@ internal val subheadType = TextStyle(
     fontSize = 16.sp,
     fontWeight = FontWeight.Bold,
     lineHeight = 24.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val body1Type = TextStyle(
@@ -106,10 +84,6 @@ internal val body1Type = TextStyle(
     fontSize = 16.sp,
     fontWeight = FontWeight.Normal,
     lineHeight = 24.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val body2Type = TextStyle(
@@ -117,10 +91,6 @@ internal val body2Type = TextStyle(
     fontSize = 14.sp,
     fontWeight = FontWeight.Normal,
     lineHeight = 20.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val captionType = TextStyle(
@@ -128,10 +98,6 @@ internal val captionType = TextStyle(
     fontSize = 12.sp,
     fontWeight = FontWeight.Normal,
     lineHeight = 16.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val smallType = TextStyle(
@@ -139,10 +105,6 @@ internal val smallType = TextStyle(
     fontSize = 10.sp,
     fontWeight = FontWeight.Normal,
     lineHeight = 14.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 internal val calloutType = TextStyle(
@@ -150,10 +112,6 @@ internal val calloutType = TextStyle(
     fontSize = 16.sp,
     fontWeight = FontWeight.Bold,
     lineHeight = 24.sp,
-    platformStyle = PlatformTextStyle(
-        includeFontPadding = false,
-    ),
-
 )
 
 public fun sparkTypography(


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Remove override of `includeFontPadding` on all spark typografy

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
`includeFontPadding` override is no longer needed since Compose 1.6

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
