### PR TITLE
refactor: allow multiple configurators for a single component

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/ComponentsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/ComponentsScreen.kt
@@ -78,10 +78,10 @@ public fun ConfiguratorComponentsScreen(
 internal fun ComponentsListScreen(
     components: List<Component>,
     contentPadding: PaddingValues,
-    onConfiguratorClick: (Int) -> Unit,
+    onConfiguratorSelected: (componentId: Int, index: Int) -> Unit,
 ) {
     val configuratorsComponents by remember(components) {
-        mutableStateOf(components.filter { it.configurator != null })
+        mutableStateOf(components.filter { it.configurators.firstOrNull() != null })
     }
     val columns = Layout.columns / 2
     LazyVerticalGrid(
@@ -128,12 +128,14 @@ internal fun ComponentsListScreen(
             span = { GridItemSpan(1) },
             contentType = { ComponentsItemType.Component },
             itemContent = { component ->
+                val configuratorCount = component.configurators.size
                 ComponentItem(
                     component = component,
-                    showExampleCount = false,
-                    onClick = {
-                        val componentId = component.id
-                        onConfiguratorClick(componentId)
+                    countIndicator = configuratorCount,
+                    configuratorCount = configuratorCount,
+                    onClick = { selectedComponent, index ->
+                        val componentId = selectedComponent.id
+                        onConfiguratorSelected(componentId, index)
                     },
                 )
             },

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/Navigation.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/Navigation.kt
@@ -56,8 +56,8 @@ internal fun NavGraphBuilder.configuratorsDestination(
         val configuratorIndex = configuratorShowcase.configuratorIndex
         val component =
             components.first { component ->
-                component.configurators.firstOrNull() != null
-                        && component.id == componentId
+                component.configurators.firstOrNull() != null &&
+                    component.id == componentId
             }
         val configurator = component.configurators.get(configuratorIndex)
         ConfiguratorComponentScreen(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/Navigation.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/Navigation.kt
@@ -31,7 +31,7 @@ import com.adevinta.spark.catalog.model.Component
 import kotlinx.serialization.Serializable
 
 @Serializable
-private data class ConfiguratorShowcase(val componentId: Int)
+private data class ConfiguratorShowcase(val componentId: Int, val configuratorIndex: Int)
 
 internal fun NavGraphBuilder.configuratorsDestination(
     navController: NavHostController,
@@ -42,8 +42,10 @@ internal fun NavGraphBuilder.configuratorsDestination(
         ComponentsListScreen(
             components = components,
             contentPadding = contentPadding,
-            onConfiguratorClick = { id ->
-                navController.navigate(route = ConfiguratorShowcase(componentId = id))
+            onConfiguratorSelected = { id, index ->
+                navController.navigate(
+                    route = ConfiguratorShowcase(componentId = id, configuratorIndex = index),
+                )
             },
         )
     }
@@ -51,10 +53,16 @@ internal fun NavGraphBuilder.configuratorsDestination(
     composable<ConfiguratorShowcase> { navBackStackEntry ->
         val configuratorShowcase = navBackStackEntry.toRoute<ConfiguratorShowcase>()
         val componentId = configuratorShowcase.componentId
-        val component = components.first { component -> component.configurator != null && component.id == componentId }
+        val configuratorIndex = configuratorShowcase.configuratorIndex
+        val component =
+            components.first { component ->
+                component.configurators.firstOrNull() != null
+                        && component.id == componentId
+            }
+        val configurator = component.configurators.get(configuratorIndex)
         ConfiguratorComponentScreen(
             component = component,
-            configurator = requireNotNull(component.configurator),
+            configurator = configurator,
         )
     }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/buttons/ButtonsConfigurator.kt
@@ -65,13 +65,15 @@ import com.adevinta.spark.icons.SparkIcon
 import com.adevinta.spark.icons.SparkIcons
 import com.adevinta.spark.tokens.highlight
 
-public val ButtonsConfigurator: Configurator = Configurator(
-    name = "Button",
-    description = "Button configuration",
-    sourceUrl = "$SampleSourceUrl/ButtonSamples.kt",
-) {
-    ButtonSample()
-}
+public val ButtonsConfigurator: List<Configurator> = listOf(
+    Configurator(
+        name = "Button",
+        description = "Button configuration",
+        sourceUrl = "$SampleSourceUrl/ButtonSamples.kt",
+    ) {
+        ButtonSample()
+    },
+)
 
 @Composable
 private fun ColumnScope.ButtonSample() {

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/ComponentsScreen.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/ComponentsScreen.kt
@@ -126,8 +126,9 @@ internal fun ComponentsListScreen(
             itemContent = { component ->
                 ComponentItem(
                     component = component,
-                    onClick = {
-                        val componentId = component.id
+                    countIndicator = component.examples.size,
+                    onClick = { selectedComponent, _ ->
+                        val componentId = selectedComponent.id
                         onExampleSectionClick(componentId)
                     },
                 )

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/component/ComponentItem.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/component/ComponentItem.kt
@@ -21,45 +21,69 @@
  */
 package com.adevinta.spark.catalog.examples.component
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEachIndexed
 import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.catalog.R
 import com.adevinta.spark.catalog.model.Component
-import com.adevinta.spark.catalog.model.Configurator
 import com.adevinta.spark.catalog.util.PreviewTheme
 import com.adevinta.spark.catalog.util.drawForegroundGradientScrim
+import com.adevinta.spark.components.badge.Badge
+import com.adevinta.spark.components.badge.BadgeIntent
+import com.adevinta.spark.components.badge.BadgeStyle
+import com.adevinta.spark.components.icons.Icon
 import com.adevinta.spark.components.image.Image
+import com.adevinta.spark.components.menu.DropdownMenu
+import com.adevinta.spark.components.menu.DropdownMenuItem
 import com.adevinta.spark.components.surface.Surface
-import com.adevinta.spark.components.tags.TagTinted
+import com.adevinta.spark.icons.SparkIcons
+import com.adevinta.spark.icons.WheelOutline
 import com.adevinta.spark.tokens.applyTonalElevation
 
 @Composable
 public fun ComponentItem(
     component: Component,
-    onClick: (component: Component) -> Unit,
-    showExampleCount: Boolean = true,
+    onClick: (component: Component, index: Int) -> Unit,
+    countIndicator: Int = 0,
+    configuratorCount: Int = -1,
 ) {
+    var expanded by remember { mutableStateOf(false) }
+    val singleContent = countIndicator == 1
+
     Surface(
-        onClick = { onClick(component) },
+        onClick = {
+            if (singleContent || configuratorCount != countIndicator) {
+                return@Surface onClick(component, 0)
+            } else {
+                // Show a menu for all other options
+                expanded = true
+            }
+        },
         modifier = Modifier
             .height(ComponentItemHeight)
             .padding(ComponentItemOuterPadding),
         shape = SparkTheme.shapes.medium,
-        border = BorderStroke(1.dp, SparkTheme.colors.outline),
+        elevation = 2.dp,
     ) {
-        Box {
+        Box(
+            modifier = Modifier.wrapContentSize(Alignment.TopStart),
+        ) {
             val tint = ColorFilter.tint(LocalContentColor.current).takeIf { component.tintIcon }
             Image(
                 modifier = Modifier
@@ -78,13 +102,30 @@ public fun ComponentItem(
                     .padding(ComponentItemInnerPadding),
                 style = SparkTheme.typography.body2,
             )
-            if (showExampleCount) {
-                TagTinted(
+            if (countIndicator > 1) {
+                Badge(
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
                         .padding(ComponentItemInnerPadding),
-                    text = component.examples.count().toString(),
+                    count = countIndicator,
+                    intent = BadgeIntent.Basic,
+                    badgeStyle = BadgeStyle.Small,
                 )
+            }
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                component.configurators.fastForEachIndexed { i, configurator ->
+                    DropdownMenuItem(
+                        text = { Text(configurator.name) },
+                        onClick = {
+                            onClick(component, i)
+                            expanded = false
+                        },
+                        leadingIcon = { Icon(SparkIcons.WheelOutline, contentDescription = null) },
+                    )
+                }
             }
         }
     }
@@ -107,14 +148,10 @@ private fun ComponentItemPreview() {
                 docsUrl = "https://www.google.com/#q=dictas",
                 sourceUrl = "http://www.bing.com/search?q=inani",
                 examples = listOf(),
-                configurator = Configurator(
-                    name = "Ronny Bowman",
-                    description = "singulis",
-                    sourceUrl = "https://www.google.com/#q=tempor",
-                    content = {},
-                ),
+                configurators = emptyList(),
             ),
-            onClick = {},
+            countIndicator = 3,
+            onClick = { _, _ -> },
         )
         ComponentItem(
             component = Component(
@@ -127,14 +164,9 @@ private fun ComponentItemPreview() {
                 docsUrl = "https://www.google.com/#q=dictas",
                 sourceUrl = "http://www.bing.com/search?q=inani",
                 examples = listOf(),
-                configurator = Configurator(
-                    name = "Ronny Bowman",
-                    description = "singulis",
-                    sourceUrl = "https://www.google.com/#q=tempor",
-                    content = {},
-                ),
+                configurators = emptyList(),
             ),
-            onClick = {},
+            onClick = { _, _ -> },
         )
     }
 }

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -270,7 +270,7 @@ private val Stepper = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.stepper/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/stepper/Stepper.kt",
     examples = StepperExamples,
-    configurators = StepperConfigurators,
+    configurators = emptyList(),
 )
 
 private val Switches = Component(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -38,7 +38,6 @@ import com.adevinta.spark.catalog.configurator.samples.progresstracker.ProgressT
 import com.adevinta.spark.catalog.configurator.samples.rating.RatingsConfigurator
 import com.adevinta.spark.catalog.configurator.samples.slider.SlidersConfigurator
 import com.adevinta.spark.catalog.configurator.samples.snackbar.SnackbarConfigurator
-import com.adevinta.spark.catalog.configurator.samples.stepper.StepperConfigurator
 import com.adevinta.spark.catalog.configurator.samples.tabs.TabsConfigurator
 import com.adevinta.spark.catalog.configurator.samples.tags.TagsConfigurator
 import com.adevinta.spark.catalog.configurator.samples.text.TextLinksConfigurator

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -85,7 +85,7 @@ public data class Component(
     val docsUrl: String,
     val sourceUrl: String,
     val examples: List<Example>,
-    val configurator: Configurator? = null,
+    val configurators: List<Configurator> = emptyList(),
 )
 
 private var nextId: Int = 1
@@ -101,7 +101,7 @@ private val Buttons = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.buttons/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/buttons/Button.kt",
     examples = ButtonsExamples,
-    configurator = ButtonsConfigurator,
+    configurators = ButtonsConfigurator,
 )
 
 private val Checkboxes = Component(
@@ -114,7 +114,7 @@ private val Checkboxes = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.toggles/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/toggles/CheckBox.kt",
     examples = CheckboxExamples,
-    configurator = CheckboxConfigurator,
+    configurators = listOf(CheckboxConfigurator),
 )
 
 private val Chips = Component(
@@ -125,7 +125,7 @@ private val Chips = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.chips/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/chips/Chips.kt",
     examples = ChipsExamples,
-    configurator = ChipsConfigurator,
+    configurators = listOf(ChipsConfigurator),
 )
 
 private val Dialogs = Component(
@@ -136,7 +136,7 @@ private val Dialogs = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.dialog/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt",
     examples = DialogsExamples,
-    configurator = ModalConfigurator,
+    configurators = listOf(ModalConfigurator),
 )
 
 private val Dropdowns = Component(
@@ -147,7 +147,7 @@ private val Dropdowns = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.dropdown/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt",
     examples = DropdownsExamples,
-    configurator = DropdownsConfigurator,
+    configurators = listOf(DropdownsConfigurator),
 )
 
 private val Icons = Component(
@@ -160,7 +160,7 @@ private val Icons = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.iconbuttons/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/iconbuttons/IconButton.kt",
     examples = IconsExamples,
-    configurator = null,
+    configurators = emptyList(),
 )
 
 private val IconButtons = Component(
@@ -173,7 +173,7 @@ private val IconButtons = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.iconbuttons/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/iconbuttons/IconButton.kt",
     examples = IconButtonsExamples,
-    configurator = IconButtonsConfigurator,
+    configurators = listOf(IconButtonsConfigurator),
 )
 
 private val IconToggleButtons = Component(
@@ -186,7 +186,7 @@ private val IconToggleButtons = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.iconbuttons/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/iconTogglebuttons/IconToggleButton.kt",
     examples = IconToggleButtonsExamples,
-    configurator = IconToggleButtonsConfigurator,
+    configurators = listOf(IconToggleButtonsConfigurator),
 )
 
 private val Image = Component(
@@ -197,7 +197,7 @@ private val Image = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.image/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/image/Image.kt",
     examples = emptyList(),
-    configurator = ImageConfigurator,
+    configurators = listOf(ImageConfigurator),
 )
 
 private val Popovers = Component(
@@ -210,7 +210,7 @@ private val Popovers = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.popover/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/popover/Popover.kt",
     examples = PopoverExamples,
-    configurator = PopoverConfigurator,
+    configurators = listOf(PopoverConfigurator),
 )
 
 private val BottomSheets = Component(
@@ -223,7 +223,7 @@ private val BottomSheets = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.bottom-sheet/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/bottomsheet/modal/ModalBottomSheet.kt",
     examples = BottomSheetExamples,
-    configurator = BottomSheetConfigurator,
+    configurators = listOf(BottomSheetConfigurator),
 )
 
 private val RadioButtons = Component(
@@ -236,7 +236,7 @@ private val RadioButtons = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.toggles/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/toggles/RadioButton.kt",
     examples = RadioButtonExamples,
-    configurator = RadioButtonConfigurator,
+    configurators = listOf(RadioButtonConfigurator),
 )
 
 private val Rating = Component(
@@ -249,7 +249,7 @@ private val Rating = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.rating/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/rating/RatingDisplay.kt",
     examples = RatingExamples,
-    configurator = RatingsConfigurator,
+    configurators = listOf(RatingsConfigurator),
 )
 
 private val Snackbars = Component(
@@ -260,7 +260,7 @@ private val Snackbars = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.snackbars/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/snackbars/Snackbar.kt",
     examples = SnackbarExamples,
-    configurator = SnackbarConfigurator,
+    configurators = listOf(SnackbarConfigurator),
 )
 
 private val Stepper = Component(
@@ -271,7 +271,7 @@ private val Stepper = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.stepper/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/stepper/Stepper.kt",
     examples = StepperExamples,
-    configurator = StepperConfigurator,
+    configurators = StepperConfigurators,
 )
 
 private val Switches = Component(
@@ -284,7 +284,7 @@ private val Switches = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.toggles/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/toggles/Switch.kt",
     examples = SwitchExamples,
-    configurator = SwitchConfigurator,
+    configurators = listOf(SwitchConfigurator),
 )
 
 private val Tabs = Component(
@@ -295,7 +295,7 @@ private val Tabs = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.tab/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/tab/Tab.kt",
     examples = TabsExamples,
-    configurator = TabsConfigurator,
+    configurators = listOf(TabsConfigurator),
 )
 
 private val Tags = Component(
@@ -308,7 +308,7 @@ private val Tags = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.tags/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/tags/Tag.kt",
     examples = TagsExamples,
-    configurator = TagsConfigurator,
+    configurators = listOf(TagsConfigurator),
 )
 
 private val Progressbars = Component(
@@ -321,7 +321,7 @@ private val Progressbars = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.progressbar/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/progressbar/Progressbar.kt",
     examples = ProgressbarExamples,
-    configurator = ProgressbarConfigurator,
+    configurators = listOf(ProgressbarConfigurator),
 )
 
 private val Dividers = Component(
@@ -332,7 +332,7 @@ private val Dividers = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.divider/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/divider/Divider.kt",
     examples = DividerExamples,
-    configurator = DividerConfigurator,
+    configurators = listOf(DividerConfigurator),
 )
 
 private val ProgressTracker = Component(
@@ -345,7 +345,7 @@ private val ProgressTracker = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.progress.tracker/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/progress/tracker/ProgressbarTracker.kt",
     examples = ProgressTrackerExamples,
-    configurator = ProgressTrackerConfigurator,
+    configurators = listOf(ProgressTrackerConfigurator),
 )
 
 private val TextLinks = Component(
@@ -358,7 +358,7 @@ private val TextLinks = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.text/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/text/TextLink.kt",
     examples = TextLinksExamples,
-    configurator = TextLinksConfigurator,
+    configurators = listOf(TextLinksConfigurator),
 )
 
 private val Sliders = Component(
@@ -369,7 +369,7 @@ private val Sliders = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.slider/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/slider/Slider.kt",
     examples = SlidersExamples,
-    configurator = SlidersConfigurator,
+    configurators = listOf(SlidersConfigurator),
 )
 
 private val TextFields = Component(
@@ -380,7 +380,7 @@ private val TextFields = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.textfields/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/components/textfields/TextField.kt",
     examples = TextFieldsExamples,
-    configurator = TextFieldsConfigurator,
+    configurators = listOf(TextFieldsConfigurator),
 )
 
 private val Tokens = Component(
@@ -393,7 +393,7 @@ private val Tokens = Component(
     docsUrl = "$PackageSummaryUrl/com.adevinta.spark.tokens/index.html",
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/tokens/Color.kt",
     examples = TokensExamples,
-    configurator = null,
+    configurators = emptyList(),
 )
 
 /** Components for the catalog, ordered alphabetically by name. */


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add the ability to use multiple configurators for a component

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
The previous limit of 1 configurator per component made each configurators more complex each time a component could have mutiple visuals like a simple one and a "complex" one which like the Stepper could include additional labels, helpers

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->
