### PR TITLE
feat: Add Catalog component that accept a Enum

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/DropdownEnum.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/DropdownEnum.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import com.adevinta.spark.components.icons.Icon
+import com.adevinta.spark.components.menu.DropdownMenuItem
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.Dropdown
+import com.adevinta.spark.icons.Check
+import com.adevinta.spark.icons.SparkIcons
+import kotlin.enums.enumEntries
+
+@Composable
+internal inline fun <reified T : Enum<T>> DropdownEnum(
+    title: String,
+    selectedOption: T,
+    crossinline onOptionSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Dropdown(
+        modifier = modifier.fillMaxWidth(),
+        value = selectedOption.name,
+        label = title,
+        expanded = expanded,
+        onExpandedChange = {
+            expanded = !expanded
+        },
+        onDismissRequest = {
+            expanded = false
+        },
+        dropdownContent = {
+            enumEntries<T>().forEach { enum ->
+                DropdownEnumItem<T>(
+                    enum = enum,
+                    selectedOption = selectedOption,
+                    onOptionSelect = {
+                        onOptionSelect(it)
+                        expanded = false
+                    },
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private inline fun <reified T : Enum<T>> DropdownEnumItem(
+    enum: T,
+    selectedOption: T,
+    crossinline onOptionSelect: (T) -> Unit,
+) {
+    val selected = enum == selectedOption
+    DropdownMenuItem(
+        modifier = Modifier.semantics {
+            this.selected = selected
+        },
+        text = { Text(enum.name) },
+        onClick = {
+            onOptionSelect(enum)
+        },
+        leadingIcon = if (selected) {
+            {
+                Icon(
+                    SparkIcons.Check,
+                    contentDescription = null,
+                )
+            }
+        } else {
+            null
+        },
+    )
+}


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Add `DropdownEnum` that will allow to select an enum entry out of all entries available with a uniform design 

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
This enum version of the dropdown make it easy for the configurations of component as we use enums to test various states

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->