### PR TITLE
refactor(modal): edge-to-edge setup now optin instead of optout

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/examples/samples/dialog/modal/ModalSample.kt
@@ -85,6 +85,7 @@ internal fun ModalSample(
             ModalScaffold(
                 onClose = { showDialog = false },
                 contentPadding = paddingValues,
+                inEdgeToEdge = true,
                 mainButton = if (withButtons) {
                     { MainButton(it, coroutineScope, snackbarHostState) }
                 } else {


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Apply latest and simpler workaround to display a Dialog in fullscreen that support edge-to-edge.
Modal `inEdgeToEdge` is now false by default.


## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
Close [SPA-496](https://jira.ets.mpi-internal.com/browse/SPA-496) 

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->

In a screen that doesn't support Edge-to-edge:

| `inEdgeToEdge`: true | `inEdgeToEdge`: false |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/dd47de4e-0546-442a-a578-8b4648e67b77) | ![image](https://github.com/user-attachments/assets/b6beda2c-ec23-4e2c-9fdb-19b36ed91c8d) | 

