### PR TITLE
refactor: increase catalog a11y

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/SegmentedButton.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/themes/SegmentedButton.kt
@@ -28,13 +28,14 @@ import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
@@ -50,6 +51,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Constraints
@@ -87,6 +91,7 @@ internal fun SegmentedButton(
             .clip(
                 shape = SparkTheme.shapes.full,
             )
+            .selectableGroup()
             .border(
                 width = 1.dp,
                 color = SparkTheme.colors.outlineHigh,
@@ -94,9 +99,10 @@ internal fun SegmentedButton(
             ),
         content = {
             options.forEachIndexed { index, option ->
+                val selected = index == selectedIndex
                 val textColor by animateColorAsState(
                     label = "Button text color",
-                    targetValue = if (index == selectedIndex) selectedColor else unSelectedColor,
+                    targetValue = if (selected) selectedColor else unSelectedColor,
                 )
 
                 val shape = RoundedCornerShape(
@@ -110,7 +116,8 @@ internal fun SegmentedButton(
                     modifier = Modifier
                         .layoutId(MultiSelectorOption.Option)
                         .clip(shape)
-                        .clickable { onOptionSelect(option) },
+                        .selectable(selected) { onOptionSelect(option) }
+                        .semantics { role = Role.RadioButton },
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/DraggableAnchors.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/ui/DraggableAnchors.kt
@@ -1,0 +1,1021 @@
+/*
+ * Copyright (c) 2025 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.ui
+
+import androidx.annotation.FloatRange
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.animate
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.gestures.DragScope
+import androidx.compose.foundation.gestures.DraggableState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Structure that represents the anchors of a [AnchoredDraggableState].
+ *
+ * See the DraggableAnchors factory method to construct drag anchors using a default implementation.
+ */
+internal interface DraggableAnchors<T> {
+
+    /**
+     * Get the anchor position for an associated [value]
+     *
+     * @return The position of the anchor, or [Float.NaN] if the anchor does not exist
+     */
+    fun positionOf(value: T): Float
+
+    /**
+     * Whether there is an anchor position associated with the [value]
+     *
+     * @param value The value to look up
+     * @return true if there is an anchor for this value, false if there is no anchor for this value
+     */
+    fun hasAnchorFor(value: T): Boolean
+
+    /**
+     * Find the closest anchor to the [position].
+     *
+     * @param position The position to start searching from
+     * @return The closest anchor or null if the anchors are empty
+     */
+    fun closestAnchor(position: Float): T?
+
+    /**
+     * Find the closest anchor to the [position], in the specified direction.
+     *
+     * @param position The position to start searching from
+     * @param searchUpwards Whether to search upwards from the current position or downwards
+     * @return The closest anchor or null if the anchors are empty
+     */
+    fun closestAnchor(position: Float, searchUpwards: Boolean): T?
+
+    /** The smallest anchor, or [Float.NEGATIVE_INFINITY] if the anchors are empty. */
+    fun minAnchor(): Float
+
+    /** The biggest anchor, or [Float.POSITIVE_INFINITY] if the anchors are empty. */
+    fun maxAnchor(): Float
+
+    /** The amount of anchors */
+    val size: Int
+}
+
+/**
+ * [DraggableAnchorsConfig] stores a mutable configuration anchors, comprised of values of [T] and
+ * corresponding [Float] positions. This [DraggableAnchorsConfig] is used to construct an immutable
+ * [DraggableAnchors] instance later on.
+ */
+internal class DraggableAnchorsConfig<T> {
+
+    internal val anchors = mutableMapOf<T, Float>()
+
+    /**
+     * Set the anchor position for [this] anchor.
+     *
+     * @param position The anchor position.
+     */
+    @Suppress("BuilderSetStyle")
+    infix fun T.at(position: Float) {
+        anchors[this] = position
+    }
+}
+
+/**
+ * Create a new [DraggableAnchors] instance using a builder function.
+ *
+ * @param builder A function with a [DraggableAnchorsConfig] that offers APIs to configure anchors
+ * @return A new [DraggableAnchors] instance with the anchor positions set by the `builder`
+ *   function.
+ */
+internal fun <T : Any> DraggableAnchors(
+    builder: DraggableAnchorsConfig<T>.() -> Unit,
+): DraggableAnchors<T> = MapDraggableAnchors(DraggableAnchorsConfig<T>().apply(builder).anchors)
+
+/**
+ * Enable drag gestures between a set of predefined values.
+ *
+ * When a drag is detected, the offset of the [AnchoredDraggableState] will be updated with the drag
+ * delta. You should use this offset to move your content accordingly (see [Modifier.offset]). When
+ * the drag ends, the offset will be animated to one of the anchors and when that anchor is reached,
+ * the value of the [AnchoredDraggableState] will also be updated to the value corresponding to the
+ * new anchor.
+ *
+ * Dragging is constrained between the minimum and maximum anchors.
+ *
+ * @param state The associated [AnchoredDraggableState].
+ * @param orientation The orientation in which the [anchoredDraggable] can be dragged.
+ * @param enabled Whether this [anchoredDraggable] is enabled and should react to the user's input.
+ * @param reverseDirection Whether to reverse the direction of the drag, so a top to bottom drag
+ *   will behave like bottom to top, and a left to right drag will behave like right to left.
+ * @param interactionSource Optional [MutableInteractionSource] that will passed on to the internal
+ *   [Modifier.draggable].
+ * @param startDragImmediately when set to false, [draggable] will start dragging only when the
+ *   gesture crosses the touchSlop. This is useful to prevent users from "catching" an animating
+ *   widget when pressing on it. See [draggable] to learn more about startDragImmediately.
+ */
+internal fun <T> Modifier.anchoredDraggable(
+    state: AnchoredDraggableState<T>,
+    orientation: Orientation,
+    enabled: Boolean = true,
+    reverseDirection: Boolean = false,
+    interactionSource: MutableInteractionSource? = null,
+    startDragImmediately: Boolean = state.isAnimationRunning,
+) =
+    draggable(
+        state = state.draggableState,
+        orientation = orientation,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        reverseDirection = reverseDirection,
+        startDragImmediately = startDragImmediately,
+        onDragStopped = { velocity -> launch { state.settle(velocity) } },
+    )
+
+/**
+ * Scope used for suspending anchored drag blocks. Allows to set [AnchoredDraggableState.offset] to
+ * a new value.
+ *
+ * @see [AnchoredDraggableState.anchoredDrag] to learn how to start the anchored drag and get the
+ *   access to this scope.
+ */
+internal interface AnchoredDragScope {
+    /**
+     * Assign a new value for an offset value for [AnchoredDraggableState].
+     *
+     * @param newOffset new value for [AnchoredDraggableState.offset].
+     * @param lastKnownVelocity last known velocity (if known)
+     */
+    fun dragTo(newOffset: Float, lastKnownVelocity: Float = 0f)
+}
+
+/**
+ * State of the [anchoredDraggable] modifier. Use the constructor overload with anchors if the
+ * anchors are defined in composition, or update the anchors using [updateAnchors].
+ *
+ * This contains necessary information about any ongoing drag or animation and provides methods to
+ * change the state either immediately or by starting an animation.
+ *
+ * @param initialValue The initial value of the state.
+ * @param positionalThreshold The positional threshold, in px, to be used when calculating the
+ *   target state while a drag is in progress and when settling after the drag ends. This is the
+ *   distance from the start of a transition. It will be, depending on the direction of the
+ *   interaction, added or subtracted from/to the origin offset. It should always be a positive
+ *   value.
+ * @param velocityThreshold The velocity threshold (in px per second) that the end velocity has to
+ *   exceed in order to animate to the next state, even if the [positionalThreshold] has not been
+ *   reached.
+ * @param animationSpec The default animation that will be used to animate to a new state.
+ * @param confirmValueChange Optional callback invoked to confirm or veto a pending state change.
+ */
+@Stable
+internal class AnchoredDraggableState<T>(
+    initialValue: T,
+    internal val positionalThreshold: (totalDistance: Float) -> Float,
+    internal val velocityThreshold: () -> Float,
+    val animationSpec: AnimationSpec<Float>,
+    internal val confirmValueChange: (newValue: T) -> Boolean = { true },
+) {
+
+    /**
+     * Construct an [AnchoredDraggableState] instance with anchors.
+     *
+     * @param initialValue The initial value of the state.
+     * @param anchors The anchors of the state. Use [updateAnchors] to update the anchors later.
+     * @param animationSpec The default animation that will be used to animate to a new state.
+     * @param confirmValueChange Optional callback invoked to confirm or veto a pending state
+     *   change.
+     * @param positionalThreshold The positional threshold, in px, to be used when calculating the
+     *   target state while a drag is in progress and when settling after the drag ends. This is the
+     *   distance from the start of a transition. It will be, depending on the direction of the
+     *   interaction, added or subtracted from/to the origin offset. It should always be a positive
+     *   value.
+     * @param velocityThreshold The velocity threshold (in px per second) that the end velocity has
+     *   to exceed in order to animate to the next state, even if the [positionalThreshold] has not
+     *   been reached.
+     */
+    constructor(
+        initialValue: T,
+        anchors: DraggableAnchors<T>,
+        positionalThreshold: (totalDistance: Float) -> Float,
+        velocityThreshold: () -> Float,
+        animationSpec: AnimationSpec<Float>,
+        confirmValueChange: (newValue: T) -> Boolean = { true },
+    ) : this(
+        initialValue,
+        positionalThreshold,
+        velocityThreshold,
+        animationSpec,
+        confirmValueChange,
+    ) {
+        this.anchors = anchors
+        trySnapTo(initialValue)
+    }
+
+    private val dragMutex = InternalMutatorMutex()
+
+    internal val draggableState =
+        object : DraggableState {
+
+            private val dragScope =
+                object : DragScope {
+                    override fun dragBy(pixels: Float) {
+                        with(anchoredDragScope) { dragTo(newOffsetForDelta(pixels)) }
+                    }
+                }
+
+            override suspend fun drag(
+                dragPriority: MutatePriority,
+                block: suspend DragScope.() -> Unit,
+            ) {
+                this@AnchoredDraggableState.anchoredDrag(dragPriority) {
+                    with(dragScope) { block() }
+                }
+            }
+
+            override fun dispatchRawDelta(delta: Float) {
+                this@AnchoredDraggableState.dispatchRawDelta(delta)
+            }
+        }
+
+    /** The current value of the [AnchoredDraggableState]. */
+    var currentValue: T by mutableStateOf(initialValue)
+        private set
+
+    /**
+     * The target value. This is the closest value to the current offset, taking into account
+     * positional thresholds. If no interactions like animations or drags are in progress, this will
+     * be the current value.
+     */
+    val targetValue: T by derivedStateOf {
+        dragTarget
+            ?: run {
+                val currentOffset = offset
+                if (!currentOffset.isNaN()) {
+                    computeTarget(currentOffset, currentValue, velocity = 0f)
+                } else {
+                    currentValue
+                }
+            }
+    }
+
+    /**
+     * The closest value in the swipe direction from the current offset, not considering thresholds.
+     * If an [anchoredDrag] is in progress, this will be the target of that anchoredDrag (if
+     * specified).
+     */
+    internal val closestValue: T by derivedStateOf {
+        dragTarget
+            ?: run {
+                val currentOffset = offset
+                if (!currentOffset.isNaN()) {
+                    computeTargetWithoutThresholds(currentOffset, currentValue)
+                } else {
+                    currentValue
+                }
+            }
+    }
+
+    /**
+     * The current offset, or [Float.NaN] if it has not been initialized yet.
+     *
+     * The offset will be initialized when the anchors are first set through [updateAnchors].
+     *
+     * Strongly consider using [requireOffset] which will throw if the offset is read before it is
+     * initialized. This helps catch issues early in your workflow.
+     */
+    var offset: Float by mutableFloatStateOf(Float.NaN)
+        private set
+
+    /**
+     * Require the current offset.
+     *
+     * @throws IllegalStateException If the offset has not been initialized yet
+     * @see offset
+     */
+    fun requireOffset(): Float {
+        check(!offset.isNaN()) {
+            "The offset was read before being initialized. Did you access the offset in a phase " +
+                "before layout, like effects or composition?"
+        }
+        return offset
+    }
+
+    /** Whether an animation is currently in progress. */
+    val isAnimationRunning: Boolean
+        get() = dragTarget != null
+
+    /**
+     * The fraction of the progress going from [currentValue] to [closestValue], within [0f..1f]
+     * bounds, or 1f if the [AnchoredDraggableState] is in a settled state.
+     */
+    @get:FloatRange(from = 0.0, to = 1.0)
+    val progress: Float by
+        derivedStateOf(structuralEqualityPolicy()) {
+            val a = anchors.positionOf(currentValue)
+            val b = anchors.positionOf(closestValue)
+            val distance = abs(b - a)
+            if (!distance.isNaN() && distance > 1e-6f) {
+                val progress = (this.requireOffset() - a) / (b - a)
+                // If we are very close to 0f or 1f, we round to the closest
+                if (progress < 1e-6f) {
+                    0f
+                } else if (progress > 1 - 1e-6f) {
+                    1f
+                } else {
+                    progress
+                }
+            } else {
+                1f
+            }
+        }
+
+    /**
+     * The velocity of the last known animation. Gets reset to 0f when an animation completes
+     * successfully, but does not get reset when an animation gets interrupted. You can use this
+     * value to provide smooth reconciliation behavior when re-targeting an animation.
+     */
+    var lastVelocity: Float by mutableFloatStateOf(0f)
+        private set
+
+    private var dragTarget: T? by mutableStateOf(null)
+
+    var anchors: DraggableAnchors<T> by mutableStateOf(emptyDraggableAnchors())
+        private set
+
+    /**
+     * Update the anchors. If there is no ongoing [anchoredDrag] operation, snap to the [newTarget],
+     * otherwise restart the ongoing [anchoredDrag] operation (e.g. an animation) with the new
+     * anchors.
+     *
+     * <b>If your anchors depend on the size of the layout, updateAnchors should be called in the
+     * layout (placement) phase, e.g. through Modifier.onSizeChanged.</b> This ensures that the
+     * state is set up within the same frame. For static anchors, or anchors with different data
+     * dependencies, [updateAnchors] is safe to be called from side effects or layout.
+     *
+     * @param newAnchors The new anchors.
+     * @param newTarget The new target, by default the closest anchor or the current target if there
+     *   are no anchors.
+     */
+    fun updateAnchors(
+        newAnchors: DraggableAnchors<T>,
+        newTarget: T =
+            if (!offset.isNaN()) {
+                newAnchors.closestAnchor(offset) ?: targetValue
+            } else {
+                targetValue
+            },
+    ) {
+        if (anchors != newAnchors) {
+            anchors = newAnchors
+            // Attempt to snap. If nobody is holding the lock, we can immediately update the offset.
+            // If anybody is holding the lock, we send a signal to restart the ongoing work with the
+            // updated anchors.
+            val snapSuccessful = trySnapTo(newTarget)
+            if (!snapSuccessful) {
+                dragTarget = newTarget
+            }
+        }
+    }
+
+    /**
+     * Find the closest anchor, taking into account the [velocityThreshold] and
+     * [positionalThreshold], and settle at it with an animation.
+     *
+     * If the [velocity] is lower than the [velocityThreshold], the closest anchor by distance and
+     * [positionalThreshold] will be the target. If the [velocity] is higher than the
+     * [velocityThreshold], the [positionalThreshold] will <b>not</b> be considered and the next
+     * anchor in the direction indicated by the sign of the [velocity] will be the target.
+     */
+    suspend fun settle(velocity: Float) {
+        val previousValue = this.currentValue
+        val targetValue =
+            computeTarget(
+                offset = requireOffset(),
+                currentValue = previousValue,
+                velocity = velocity,
+            )
+        if (confirmValueChange(targetValue)) {
+            animateTo(targetValue, velocity)
+        } else {
+            // If the user vetoed the state change, rollback to the previous state.
+            animateTo(previousValue, velocity)
+        }
+    }
+
+    private fun computeTarget(offset: Float, currentValue: T, velocity: Float): T {
+        val currentAnchors = anchors
+        val currentAnchorPosition = currentAnchors.positionOf(currentValue)
+        val velocityThresholdPx = velocityThreshold()
+        return if (currentAnchorPosition == offset || currentAnchorPosition.isNaN()) {
+            currentValue
+        } else if (currentAnchorPosition < offset) {
+            // Swiping from lower to upper (positive).
+            if (velocity >= velocityThresholdPx) {
+                currentAnchors.closestAnchor(offset, true)!!
+            } else {
+                val upper = currentAnchors.closestAnchor(offset, true)!!
+                val distance = abs(currentAnchors.positionOf(upper) - currentAnchorPosition)
+                val relativeThreshold = abs(positionalThreshold(distance))
+                val absoluteThreshold = abs(currentAnchorPosition + relativeThreshold)
+                if (offset < absoluteThreshold) currentValue else upper
+            }
+        } else {
+            // Swiping from upper to lower (negative).
+            if (velocity <= -velocityThresholdPx) {
+                currentAnchors.closestAnchor(offset, false)!!
+            } else {
+                val lower = currentAnchors.closestAnchor(offset, false)!!
+                val distance = abs(currentAnchorPosition - currentAnchors.positionOf(lower))
+                val relativeThreshold = abs(positionalThreshold(distance))
+                val absoluteThreshold = abs(currentAnchorPosition - relativeThreshold)
+                if (offset < 0) {
+                    // For negative offsets, larger absolute thresholds are closer to lower anchors
+                    // than smaller ones.
+                    if (abs(offset) < absoluteThreshold) currentValue else lower
+                } else {
+                    if (offset > absoluteThreshold) currentValue else lower
+                }
+            }
+        }
+    }
+
+    private fun computeTargetWithoutThresholds(
+        offset: Float,
+        currentValue: T,
+    ): T {
+        val currentAnchors = anchors
+        val currentAnchorPosition = currentAnchors.positionOf(currentValue)
+        return if (currentAnchorPosition == offset || currentAnchorPosition.isNaN()) {
+            currentValue
+        } else if (currentAnchorPosition < offset) {
+            currentAnchors.closestAnchor(offset, true) ?: currentValue
+        } else {
+            currentAnchors.closestAnchor(offset, false) ?: currentValue
+        }
+    }
+
+    private val anchoredDragScope: AnchoredDragScope =
+        object : AnchoredDragScope {
+            override fun dragTo(newOffset: Float, lastKnownVelocity: Float) {
+                offset = newOffset
+                lastVelocity = lastKnownVelocity
+            }
+        }
+
+    /**
+     * Call this function to take control of drag logic and perform anchored drag with the latest
+     * anchors.
+     *
+     * All actions that change the [offset] of this [AnchoredDraggableState] must be performed
+     * within an [anchoredDrag] block (even if they don't call any other methods on this object) in
+     * order to guarantee that mutual exclusion is enforced.
+     *
+     * If [anchoredDrag] is called from elsewhere with the [dragPriority] higher or equal to ongoing
+     * drag, the ongoing drag will be cancelled.
+     *
+     * <b>If the [anchors] change while the [block] is being executed, it will be cancelled and
+     * re-executed with the latest anchors and target.</b> This allows you to target the correct
+     * state.
+     *
+     * @param dragPriority of the drag operation
+     * @param block perform anchored drag given the current anchor provided
+     */
+    suspend fun anchoredDrag(
+        dragPriority: MutatePriority = MutatePriority.Default,
+        block: suspend AnchoredDragScope.(anchors: DraggableAnchors<T>) -> Unit,
+    ) {
+        try {
+            dragMutex.mutate(dragPriority) {
+                restartable(inputs = { anchors }) { latestAnchors ->
+                    anchoredDragScope.block(latestAnchors)
+                }
+            }
+        } finally {
+            val closest = anchors.closestAnchor(offset)
+            if (
+                closest != null &&
+                abs(offset - anchors.positionOf(closest)) <= 0.5f &&
+                confirmValueChange.invoke(closest)
+            ) {
+                currentValue = closest
+            }
+        }
+    }
+
+    /**
+     * Call this function to take control of drag logic and perform anchored drag with the latest
+     * anchors and target.
+     *
+     * All actions that change the [offset] of this [AnchoredDraggableState] must be performed
+     * within an [anchoredDrag] block (even if they don't call any other methods on this object) in
+     * order to guarantee that mutual exclusion is enforced.
+     *
+     * This overload allows the caller to hint the target value that this [anchoredDrag] is intended
+     * to arrive to. This will set [AnchoredDraggableState.targetValue] to provided value so
+     * consumers can reflect it in their UIs.
+     *
+     * <b>If the [anchors] or [AnchoredDraggableState.targetValue] change while the [block] is being
+     * executed, it will be cancelled and re-executed with the latest anchors and target.</b> This
+     * allows you to target the correct state.
+     *
+     * If [anchoredDrag] is called from elsewhere with the [dragPriority] higher or equal to ongoing
+     * drag, the ongoing drag will be cancelled.
+     *
+     * @param targetValue hint the target value that this [anchoredDrag] is intended to arrive to
+     * @param dragPriority of the drag operation
+     * @param block perform anchored drag given the current anchor provided
+     */
+    suspend fun anchoredDrag(
+        targetValue: T,
+        dragPriority: MutatePriority = MutatePriority.Default,
+        block: suspend AnchoredDragScope.(anchors: DraggableAnchors<T>, targetValue: T) -> Unit,
+    ) {
+        if (anchors.hasAnchorFor(targetValue)) {
+            try {
+                dragMutex.mutate(dragPriority) {
+                    dragTarget = targetValue
+                    restartable(
+                        inputs = { anchors to this@AnchoredDraggableState.targetValue },
+                    ) { (latestAnchors, latestTarget) ->
+                        anchoredDragScope.block(latestAnchors, latestTarget)
+                    }
+                }
+            } finally {
+                dragTarget = null
+                val closest = anchors.closestAnchor(offset)
+                if (
+                    closest != null &&
+                    abs(offset - anchors.positionOf(closest)) <= 0.5f &&
+                    confirmValueChange.invoke(closest)
+                ) {
+                    currentValue = closest
+                }
+            }
+        } else {
+            // Todo: b/283467401, revisit this behavior
+            currentValue = targetValue
+        }
+    }
+
+    internal fun newOffsetForDelta(delta: Float) =
+        ((if (offset.isNaN()) 0f else offset) + delta).coerceIn(
+            anchors.minAnchor(),
+            anchors.maxAnchor(),
+        )
+
+    /**
+     * Drag by the [delta], coerce it in the bounds and dispatch it to the [AnchoredDraggableState].
+     *
+     * @return The delta the consumed by the [AnchoredDraggableState]
+     */
+    fun dispatchRawDelta(delta: Float): Float {
+        val newOffset = newOffsetForDelta(delta)
+        val oldOffset = if (offset.isNaN()) 0f else offset
+        offset = newOffset
+        return newOffset - oldOffset
+    }
+
+    /**
+     * Attempt to snap synchronously. Snapping can happen synchronously when there is no other drag
+     * transaction like a drag or an animation is progress. If there is another interaction in
+     * progress, the suspending [snapTo] overload needs to be used.
+     *
+     * @return true if the synchronous snap was successful, or false if we couldn't snap synchronous
+     */
+    private fun trySnapTo(targetValue: T): Boolean =
+        dragMutex.tryMutate {
+            with(anchoredDragScope) {
+                val targetOffset = anchors.positionOf(targetValue)
+                if (!targetOffset.isNaN()) {
+                    dragTo(targetOffset)
+                    dragTarget = null
+                }
+                currentValue = targetValue
+            }
+        }
+
+    companion object {
+        /** The default [Saver] implementation for [AnchoredDraggableState]. */
+        fun <T : Any> Saver(
+            animationSpec: AnimationSpec<Float>,
+            confirmValueChange: (T) -> Boolean,
+            positionalThreshold: (distance: Float) -> Float,
+            velocityThreshold: () -> Float,
+        ) =
+            Saver<AnchoredDraggableState<T>, T>(
+                save = { it.currentValue },
+                restore = {
+                    AnchoredDraggableState(
+                        initialValue = it,
+                        animationSpec = animationSpec,
+                        confirmValueChange = confirmValueChange,
+                        positionalThreshold = positionalThreshold,
+                        velocityThreshold = velocityThreshold,
+                    )
+                },
+            )
+    }
+}
+
+/**
+ * Snap to a [targetValue] without any animation. If the [targetValue] is not in the set of anchors,
+ * the [AnchoredDraggableState.currentValue] will be updated to the [targetValue] without updating
+ * the offset.
+ *
+ * @param targetValue The target value of the animation
+ * @throws CancellationException if the interaction interrupted by another interaction like a
+ *   gesture interaction or another programmatic interaction like a [animateTo] or [snapTo] call.
+ */
+internal suspend fun <T> AnchoredDraggableState<T>.snapTo(targetValue: T) {
+    anchoredDrag(targetValue = targetValue) { anchors, latestTarget ->
+        val targetOffset = anchors.positionOf(latestTarget)
+        if (!targetOffset.isNaN()) dragTo(targetOffset)
+    }
+}
+
+/**
+ * Animate to a [targetValue]. If the [targetValue] is not in the set of anchors, the
+ * [AnchoredDraggableState.currentValue] will be updated to the [targetValue] without updating the
+ * offset.
+ *
+ * @param targetValue The target value of the animation
+ * @param velocity The velocity the animation should start with
+ * @throws CancellationException if the interaction interrupted by another interaction like a
+ *   gesture interaction or another programmatic interaction like a [animateTo] or [snapTo] call.
+ */
+internal suspend fun <T> AnchoredDraggableState<T>.animateTo(
+    targetValue: T,
+    velocity: Float = this.lastVelocity,
+) {
+    anchoredDrag(targetValue = targetValue) { anchors, latestTarget ->
+        val targetOffset = anchors.positionOf(latestTarget)
+        if (!targetOffset.isNaN()) {
+            var prev = if (offset.isNaN()) 0f else offset
+            animate(prev, targetOffset, velocity, animationSpec) { value, velocity ->
+                // Our onDrag coerces the value within the bounds, but an animation may
+                // overshoot, for example a spring animation or an overshooting interpolator
+                // We respect the user's intention and allow the overshoot, but still use
+                // DraggableState's drag for its mutex.
+                dragTo(value, velocity)
+                prev = value
+            }
+        }
+    }
+}
+
+/** Contains useful defaults for [anchoredDraggable] and [AnchoredDraggableState]. */
+@Stable
+internal object AnchoredDraggableDefaults {
+    /** The default animation used by [AnchoredDraggableState]. */
+//    @Suppress("OPT_IN_MARKER_ON_WRONG_TARGET")
+    val AnimationSpec = SpringSpec<Float>()
+}
+
+internal class AnchoredDragFinishedSignal : CancellationException("Anchored drag finished")
+
+private suspend fun <I> restartable(inputs: () -> I, block: suspend (I) -> Unit) {
+    try {
+        coroutineScope {
+            var previousDrag: Job? = null
+            snapshotFlow(inputs).collect { latestInputs ->
+                previousDrag?.apply {
+                    cancel(AnchoredDragFinishedSignal())
+                    join()
+                }
+                previousDrag =
+                    launch(start = CoroutineStart.UNDISPATCHED) {
+                        block(latestInputs)
+                        this@coroutineScope.cancel(AnchoredDragFinishedSignal())
+                    }
+            }
+        }
+    } catch (anchoredDragFinished: AnchoredDragFinishedSignal) {
+        // Ignored
+    }
+}
+
+private fun <T> emptyDraggableAnchors() = MapDraggableAnchors<T>(emptyMap())
+
+private class MapDraggableAnchors<T>(private val anchors: Map<T, Float>) : DraggableAnchors<T> {
+
+    override fun positionOf(value: T): Float = anchors[value] ?: Float.NaN
+
+    override fun hasAnchorFor(value: T) = anchors.containsKey(value)
+
+    override fun closestAnchor(position: Float): T? =
+        anchors.minByOrNull { abs(position - it.value) }?.key
+
+    override fun closestAnchor(position: Float, searchUpwards: Boolean): T? = anchors
+        .minByOrNull { (_, anchor) ->
+            val delta = if (searchUpwards) anchor - position else position - anchor
+            if (delta < 0) Float.POSITIVE_INFINITY else delta
+        }
+        ?.key
+
+    override fun minAnchor() = anchors.values.minOrNull() ?: Float.NaN
+
+    override fun maxAnchor() = anchors.values.maxOrNull() ?: Float.NaN
+
+    override val size: Int
+        get() = anchors.size
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MapDraggableAnchors<*>) return false
+
+        return anchors == other.anchors
+    }
+
+    override fun hashCode() = 31 * anchors.hashCode()
+
+    override fun toString() = "MapDraggableAnchors($anchors)"
+}
+
+/**
+ * This Modifier allows configuring an [AnchoredDraggableState]'s anchors based on this layout
+ * node's size and offsetting it. It considers lookahead and reports the appropriate size and
+ * measurement for the appropriate phase.
+ *
+ * @param state The state the anchors should be attached to
+ * @param orientation The orientation the component should be offset in
+ * @param anchors Lambda to calculate the anchors based on this layout's size and the incoming
+ *   constraints. These can be useful to avoid subcomposition.
+ */
+internal fun <T> Modifier.draggableAnchors(
+    state: AnchoredDraggableState<T>,
+    orientation: Orientation,
+    anchors: (size: IntSize, constraints: Constraints) -> Pair<DraggableAnchors<T>, T>,
+) = this then DraggableAnchorsElement(state, anchors, orientation)
+
+private class DraggableAnchorsElement<T>(
+    private val state: AnchoredDraggableState<T>,
+    private val anchors: (size: IntSize, constraints: Constraints) -> Pair<DraggableAnchors<T>, T>,
+    private val orientation: Orientation,
+) : ModifierNodeElement<DraggableAnchorsNode<T>>() {
+
+    override fun create() = DraggableAnchorsNode(state, anchors, orientation)
+
+    override fun update(node: DraggableAnchorsNode<T>) {
+        node.state = state
+        node.anchors = anchors
+        node.orientation = orientation
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+
+        if (other !is DraggableAnchorsElement<*>) return false
+
+        if (state != other.state) return false
+        if (anchors !== other.anchors) return false
+        if (orientation != other.orientation) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + anchors.hashCode()
+        result = 31 * result + orientation.hashCode()
+        return result
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        debugInspectorInfo {
+            properties["state"] = state
+            properties["anchors"] = anchors
+            properties["orientation"] = orientation
+        }
+    }
+}
+
+private class DraggableAnchorsNode<T>(
+    var state: AnchoredDraggableState<T>,
+    var anchors: (size: IntSize, constraints: Constraints) -> Pair<DraggableAnchors<T>, T>,
+    var orientation: Orientation,
+) : Modifier.Node(),
+    LayoutModifierNode {
+    private var didLookahead: Boolean = false
+
+    override fun onDetach() {
+        didLookahead = false
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        // If we are in a lookahead pass, we only want to update the anchors here and not in
+        // post-lookahead. If there is no lookahead happening (!isLookingAhead && !didLookahead),
+        // update the anchors in the main pass.
+        if (!isLookingAhead || !didLookahead) {
+            val size = IntSize(placeable.width, placeable.height)
+            val newAnchorResult = anchors(size, constraints)
+            state.updateAnchors(newAnchorResult.first, newAnchorResult.second)
+        }
+        didLookahead = isLookingAhead || didLookahead
+        return layout(placeable.width, placeable.height) {
+            // In a lookahead pass, we use the position of the current target as this is where any
+            // ongoing animations would move. If the component is in a settled state, lookahead
+            // and post-lookahead will converge.
+            val offset =
+                if (isLookingAhead) {
+                    state.anchors.positionOf(state.targetValue)
+                } else {
+                    state.requireOffset()
+                }
+            val xOffset = if (orientation == Orientation.Horizontal) offset else 0f
+            val yOffset = if (orientation == Orientation.Vertical) offset else 0f
+            placeable.place(xOffset.roundToInt(), yOffset.roundToInt())
+        }
+    }
+}
+
+/**
+ * Mutual exclusion for UI state mutation over time.
+ *
+ * [mutate] permits interruptible state mutation over time using a standard [MutatePriority]. A
+ * [InternalMutatorMutex] enforces that only a single writer can be active at a time for a
+ * particular state resource. Instead of queueing callers that would acquire the lock like a
+ * traditional [Mutex], new attempts to [mutate] the guarded state will either cancel the current
+ * mutator or if the current mutator has a higher priority, the new caller will throw
+ * [CancellationException].
+ *
+ * [InternalMutatorMutex] should be used for implementing hoisted state objects that many mutators
+ * may want to manipulate over time such that those mutators can coordinate with one another. The
+ * [InternalMutatorMutex] instance should be hidden as an implementation detail. For example:
+ */
+@Stable
+internal class InternalMutatorMutex {
+    private class Mutator(val priority: MutatePriority, val job: Job) {
+        fun canInterrupt(other: Mutator) = priority >= other.priority
+
+        fun cancel() = job.cancel()
+    }
+
+    private val currentMutator = AtomicReference<Mutator?>(null)
+    private val mutex = Mutex()
+
+    private fun tryMutateOrCancel(mutator: Mutator) {
+        while (true) {
+            val oldMutator = currentMutator.get()
+            if (oldMutator == null || mutator.canInterrupt(oldMutator)) {
+                if (currentMutator.compareAndSet(oldMutator, mutator)) {
+                    oldMutator?.cancel()
+                    break
+                }
+            } else {
+                throw CancellationException("Current mutation had a higher priority")
+            }
+        }
+    }
+
+    /**
+     * Enforce that only a single caller may be active at a time.
+     *
+     * If [mutate] is called while another call to [mutate] or [mutateWith] is in progress, their
+     * [priority] values are compared. If the new caller has a [priority] equal to or higher than
+     * the call in progress, the call in progress will be cancelled, throwing
+     * [CancellationException] and the new caller's [block] will be invoked. If the call in progress
+     * had a higher [priority] than the new caller, the new caller will throw
+     * [CancellationException] without invoking [block].
+     *
+     * @param priority the priority of this mutation; [MutatePriority.Default] by default. Higher
+     *   priority mutations will interrupt lower priority mutations.
+     * @param block mutation code to run mutually exclusive with any other call to [mutate],
+     *   [mutateWith] or [tryMutate].
+     */
+    suspend fun <R> mutate(
+        priority: MutatePriority = MutatePriority.Default,
+        block: suspend () -> R,
+    ) = coroutineScope {
+        val mutator = Mutator(priority, coroutineContext[Job]!!)
+
+        tryMutateOrCancel(mutator)
+
+        mutex.withLock {
+            try {
+                block()
+            } finally {
+                currentMutator.compareAndSet(mutator, null)
+            }
+        }
+    }
+
+    /**
+     * Enforce that only a single caller may be active at a time.
+     *
+     * If [mutateWith] is called while another call to [mutate] or [mutateWith] is in progress,
+     * their [priority] values are compared. If the new caller has a [priority] equal to or higher
+     * than the call in progress, the call in progress will be cancelled, throwing
+     * [CancellationException] and the new caller's [block] will be invoked. If the call in progress
+     * had a higher [priority] than the new caller, the new caller will throw
+     * [CancellationException] without invoking [block].
+     *
+     * This variant of [mutate] calls its [block] with a [receiver], removing the need to create an
+     * additional capturing lambda to invoke it with a receiver object. This can be used to expose a
+     * mutable scope to the provided [block] while leaving the rest of the state object read-only.
+     * For example:
+     *
+     * @param receiver the receiver `this` that [block] will be called with
+     * @param priority the priority of this mutation; [MutatePriority.Default] by default. Higher
+     *   priority mutations will interrupt lower priority mutations.
+     * @param block mutation code to run mutually exclusive with any other call to [mutate],
+     *   [mutateWith] or [tryMutate].
+     */
+    suspend fun <T, R> mutateWith(
+        receiver: T,
+        priority: MutatePriority = MutatePriority.Default,
+        block: suspend T.() -> R,
+    ) = coroutineScope {
+        val mutator = Mutator(priority, coroutineContext[Job]!!)
+
+        tryMutateOrCancel(mutator)
+
+        mutex.withLock {
+            try {
+                receiver.block()
+            } finally {
+                currentMutator.compareAndSet(mutator, null)
+            }
+        }
+    }
+
+    /**
+     * Attempt to mutate synchronously if there is no other active caller. If there is no other
+     * active caller, the [block] will be executed in a lock. If there is another active caller,
+     * this method will return false, indicating that the active caller needs to be cancelled
+     * through a [mutate] or [mutateWith] call with an equal or higher mutation priority.
+     *
+     * Calls to [mutate] and [mutateWith] will suspend until execution of the [block] has finished.
+     *
+     * @param block mutation code to run mutually exclusive with any other call to [mutate],
+     *   [mutateWith] or [tryMutate].
+     * @return true if the [block] was executed, false if there was another active caller and the
+     *   [block] was not executed.
+     */
+    fun tryMutate(block: () -> Unit): Boolean {
+        val didLock = mutex.tryLock()
+        if (didLock) {
+            try {
+                block()
+            } finally {
+                mutex.unlock()
+            }
+        }
+        return didLock
+    }
+}

--- a/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingDisplay.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/rating/RatingDisplay.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -52,9 +51,7 @@ public fun RatingDisplay(
 ) {
     if (value !in .5f..5f) return
     Row(
-        modifier = modifier
-            .semantics(mergeDescendants = true) {}
-            .sparkUsageOverlay(),
+        modifier = modifier.sparkUsageOverlay(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {

--- a/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/tags/Tag.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
@@ -76,9 +77,7 @@ internal fun BaseSparkTag(
     content: @Composable RowScope.() -> Unit,
 ) {
     Surface(
-        modifier = modifier
-            .semantics(mergeDescendants = true) {}
-            .sparkUsageOverlay(),
+        modifier = modifier.sparkUsageOverlay(),
         shape = SparkTheme.shapes.full,
         color = colors.backgroundColor,
         contentColor = colors.contentColor.copy(1.0f),
@@ -95,6 +94,9 @@ internal fun BaseSparkTag(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 AnimatedVisibility(
+                    modifier = Modifier.semantics {
+                        hideFromAccessibility()
+                    },
                     visible = leadingIcon != null,
                 ) {
                     if (leadingIcon != null) {


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->
Improve a11y by fixing the backdrop priority order
The Tag and the rating no longer get selectable in a semantic group
Add correct semantic (selectable) to SegmentedButton 

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->
This aim to make the Catlog app simpler to use with screen reader and with keyboard navigation but it still needs more work to be completly usabe
