### PR TITLE
chore(dependabot): add explicit Gradle Plugins portal registry

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,4 +23,6 @@ registries:
   maven-google:
     type: "maven-repository"
     url: "https://maven.google.com"
-    replaces-base: true
+  gradle-plugins:
+    type: "maven-repository"
+    url: "https://plugins.gradle.org/m2/"


### PR DESCRIPTION
and remove `replaces-base` to restore the default maven repo.